### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <br/>
 
 ## 개발환경
-[![Kotlin](https://img.shields.io/badge/Kotlin-1.8.22-blue.svg)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-1.9-blue.svg)](https://kotlinlang.org)
 [![Gradle](https://img.shields.io/badge/gradle-8.0-green.svg)](https://gradle.org/)
 [![Android Studio](https://img.shields.io/badge/Android%20Studio-2022.3.1%20%28Giraff%29-green)](https://developer.android.com/studio)
 [![minSdkVersion](https://img.shields.io/badge/minSdkVersion-24-red)](https://developer.android.com/distribute/best-practices/develop/target-sdk)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <br/>
 
 ## 개발환경
-[![Kotlin](https://img.shields.io/badge/Kotlin-1.9-blue.svg)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-1.8.22-blue.svg)](https://kotlinlang.org)
 [![Gradle](https://img.shields.io/badge/gradle-8.0-green.svg)](https://gradle.org/)
 [![Android Studio](https://img.shields.io/badge/Android%20Studio-2022.3.1%20%28Giraff%29-green)](https://developer.android.com/studio)
 [![minSdkVersion](https://img.shields.io/badge/minSdkVersion-24-red)](https://developer.android.com/distribute/best-practices/develop/target-sdk)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 android {
-  namespace = "com.nexters.bandalart.data"
+  namespace = "com.nexters.bandalart.android.data"
 
   buildFeatures {
     buildConfig = true

--- a/data/src/main/kotlin/com/nexters/bandalart/android/data/datasource/GuestLoginTokenDataSource.kt
+++ b/data/src/main/kotlin/com/nexters/bandalart/android/data/datasource/GuestLoginTokenDataSource.kt
@@ -1,4 +1,4 @@
-package com.nexters.bandalart.data.datasource
+package com.nexters.bandalart.android.data.datasource
 
 import kotlinx.coroutines.flow.Flow
 

--- a/data/src/main/kotlin/com/nexters/bandalart/android/data/local/datasource/GuestLoginTokenDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/nexters/bandalart/android/data/local/datasource/GuestLoginTokenDataSourceImpl.kt
@@ -1,11 +1,11 @@
-package com.nexters.bandalart.data.local.datasource
+package com.nexters.bandalart.android.data.local.datasource
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
-import com.nexters.bandalart.data.datasource.GuestLoginTokenDataSource
+import com.nexters.bandalart.android.data.datasource.GuestLoginTokenDataSource
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map

--- a/data/src/main/kotlin/com/nexters/bandalart/android/data/repository/GuestLoginTokenRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/nexters/bandalart/android/data/repository/GuestLoginTokenRepositoryImpl.kt
@@ -1,7 +1,7 @@
-package com.nexters.bandalart.data.repository
+package com.nexters.bandalart.android.data.repository
 
-import com.nexters.bandalart.data.datasource.GuestLoginTokenDataSource
-import com.nexters.bandalart.domain.repository.GuestLoginTokenRepository
+import com.nexters.bandalart.android.data.datasource.GuestLoginTokenDataSource
+import com.nexters.bandalart.android.domain.repository.GuestLoginTokenRepository
 import kotlinx.coroutines.flow.Flow
 
 class GuestLoginTokenRepositoryImpl(private val dataSource: GuestLoginTokenDataSource) : GuestLoginTokenRepository {

--- a/domain/src/main/kotlin/com/nexters/bandalart/android/domain/repository/GuestLoginTokenRepository.kt
+++ b/domain/src/main/kotlin/com/nexters/bandalart/android/domain/repository/GuestLoginTokenRepository.kt
@@ -1,4 +1,4 @@
-package com.nexters.bandalart.domain.repository
+package com.nexters.bandalart.android.domain.repository
 
 import kotlinx.coroutines.flow.Flow
 

--- a/domain/src/main/kotlin/com/nexters/bandalart/android/domain/usecase/GetGuestLoginTokenUseCase.kt
+++ b/domain/src/main/kotlin/com/nexters/bandalart/android/domain/usecase/GetGuestLoginTokenUseCase.kt
@@ -1,4 +1,4 @@
-package com.nexters.bandalart.domain.usecase
+package com.nexters.bandalart.android.domain.usecase
 
 import kotlinx.coroutines.flow.Flow
 

--- a/domain/src/main/kotlin/com/nexters/bandalart/android/domain/usecase/GetGuestLoginTokenUseCaseImpl.kt
+++ b/domain/src/main/kotlin/com/nexters/bandalart/android/domain/usecase/GetGuestLoginTokenUseCaseImpl.kt
@@ -1,6 +1,6 @@
-package com.nexters.bandalart.domain.usecase
+package com.nexters.bandalart.android.domain.usecase
 
-import com.nexters.bandalart.domain.repository.GuestLoginTokenRepository
+import com.nexters.bandalart.android.domain.repository.GuestLoginTokenRepository
 import kotlinx.coroutines.flow.Flow
 
 class GetGuestLoginTokenUseCaseImpl(private val repository: GuestLoginTokenRepository) : GetGuestLoginTokenUseCase {

--- a/domain/src/main/kotlin/com/nexters/bandalart/android/domain/usecase/SetGuestLoginTokenUseCase.kt
+++ b/domain/src/main/kotlin/com/nexters/bandalart/android/domain/usecase/SetGuestLoginTokenUseCase.kt
@@ -1,4 +1,4 @@
-package com.nexters.bandalart.domain.usecase
+package com.nexters.bandalart.android.domain.usecase
 
 interface SetGuestLoginTokenUseCase {
   suspend operator fun invoke(guestLoginToken: String)

--- a/domain/src/main/kotlin/com/nexters/bandalart/android/domain/usecase/SetGuestLoginTokenUseCaseImpl.kt
+++ b/domain/src/main/kotlin/com/nexters/bandalart/android/domain/usecase/SetGuestLoginTokenUseCaseImpl.kt
@@ -1,6 +1,6 @@
-package com.nexters.bandalart.domain.usecase
+package com.nexters.bandalart.android.domain.usecase
 
-import com.nexters.bandalart.domain.repository.GuestLoginTokenRepository
+import com.nexters.bandalart.android.domain.repository.GuestLoginTokenRepository
 
 class SetGuestLoginTokenUseCaseImpl(private val repository: GuestLoginTokenRepository) : SetGuestLoginTokenUseCase {
   override suspend fun invoke(guestLoginToken: String) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 android-gradle-plugin = "8.0.2"
 gradle-dependency-handler-extensions = "1.1.0"
 
-kotlin-core = "1.9.0"
+kotlin-core = "1.8.22"
 kotlin-detekt = "1.23.0"
 kotlin-ktlint-gradle = "11.5.0"
 kotlin-ktlint-source = "0.48.2"

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-  namespace = "com.nexters.bandalart.presentation"
+  namespace = "com.nexters.bandalart.android.presentation"
 
   buildFeatures {
     compose = true

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.nexters.bandalart.presentation">
+  package="com.nexters.bandalart.android.presentation">
 
   <application android:theme="@style/Theme.Bandalart">
     <activity
-      android:name=".MainActivity"
+      android:name="com.nexters.bandalart.android.presentation.MainActivity"
       android:exported="true">
 
       <intent-filter>

--- a/presentation/src/main/kotlin/com/nexters/bandalart/android/presentation/MainActivity.kt
+++ b/presentation/src/main/kotlin/com/nexters/bandalart/android/presentation/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.nexters.bandalart.presentation
+package com.nexters.bandalart.android.presentation
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -10,7 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.nexters.bandalart.presentation.ui.theme.BandalartTheme
+import com.nexters.bandalart.android.presentation.ui.theme.BandalartTheme
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/presentation/src/main/kotlin/com/nexters/bandalart/android/presentation/ui/theme/Color.kt
+++ b/presentation/src/main/kotlin/com/nexters/bandalart/android/presentation/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.nexters.bandalart.presentation.ui.theme
+package com.nexters.bandalart.android.presentation.ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/presentation/src/main/kotlin/com/nexters/bandalart/android/presentation/ui/theme/Theme.kt
+++ b/presentation/src/main/kotlin/com/nexters/bandalart/android/presentation/ui/theme/Theme.kt
@@ -1,4 +1,4 @@
-package com.nexters.bandalart.presentation.ui.theme
+package com.nexters.bandalart.android.presentation.ui.theme
 
 import android.app.Activity
 import android.os.Build

--- a/presentation/src/main/kotlin/com/nexters/bandalart/android/presentation/ui/theme/Type.kt
+++ b/presentation/src/main/kotlin/com/nexters/bandalart/android/presentation/ui/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.nexters.bandalart.presentation.ui.theme
+package com.nexters.bandalart.android.presentation.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle


### PR DESCRIPTION
정상 빌드가 가능하도록 코틀린 버전 downgrade 1.9 -> 1.8.22 (아직 1.9 버전에 호환되는 compose compiler version 이 존재하지 않는듯)

namespace com.nexters.Bandalart.android 로 통일 -> 패키지 구조도 이에 맞춰서 android 패키지 추가 