### PR TITLE
SplashScreen API 적용

### DIFF
--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -19,9 +19,10 @@ android {
 
 dependencies {
   implementations(
-    libs.androidx.core,
     libs.androidx.appcompat,
+    libs.androidx.core,
     libs.androidx.hilt.compose.navigation,
+    libs.androidx.splash,
     libs.bundles.androidx.compose,
     libs.bundles.androidx.lifecycle,
     projects.domain,

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -5,7 +5,8 @@
   <application android:theme="@style/Theme.Bandalart">
     <activity
       android:name="com.nexters.bandalart.android.presentation.MainActivity"
-      android:exported="true">
+      android:exported="true"
+      android:theme="@style/Theme.Bandalart.Splash">
 
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />

--- a/presentation/src/main/kotlin/com/nexters/bandalart/android/presentation/MainActivity.kt
+++ b/presentation/src/main/kotlin/com/nexters/bandalart/android/presentation/MainActivity.kt
@@ -10,11 +10,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.nexters.bandalart.android.presentation.ui.theme.BandalartTheme
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    installSplashScreen()
     setContent {
       BandalartTheme {
         // A surface container using the 'background' color from the theme

--- a/presentation/src/main/res/values/splash.xml
+++ b/presentation/src/main/res/values/splash.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+  <style name="Theme.Bandalart.Splash" parent="Theme.SplashScreen">
+    <item name="windowSplashScreenBackground">#FFFFFF</item>
+    <!--    스플래시 아이콘은 여기에 추가 해주면 됨-->
+    <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_round</item>
+    <item name="postSplashScreenTheme">@style/Theme.Bandalart</item>
+  </style>
+</resources>


### PR DESCRIPTION
SplashScreen API 를 미리 적용하여 스플래시 화면이 두번 뜨는 문제를 방지
스플래시 아이콘이 추가되면 splash.xml 파일에 
windowSplashScreenAnimatedIcon 속성에 drawable 파일을 넣어주면 됩니다 
