### PR TITLE
bottomsheet fix

### DIFF
--- a/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/extension/WindowInsets.kt
+++ b/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/extension/WindowInsets.kt
@@ -1,8 +1,11 @@
 package com.nexters.bandalart.android.core.ui.extension
 
+import android.app.Activity
+import android.graphics.Rect
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 
 // https://sungbin.land/jetpack-compose-windowinsets-fa8f286f092b
@@ -12,8 +15,21 @@ val NavigationBarHeightDp
     WindowInsets.systemBars.getBottom(this).toDp()
   }
 
-val StatusBarHeightDp
+val StatusBarAndActionBarHeightDp
   @Composable
   get() = with(LocalDensity.current) {
     WindowInsets.systemBars.getTop(this).toDp()
+  }
+
+val StatusBarHeightDp
+  @Composable
+  get() = with(LocalContext.current) {
+    val activity = this as Activity
+
+    val rectangle = Rect()
+    activity.window.decorView.getWindowVisibleDisplayFrame(rectangle)
+
+    with(LocalDensity.current) {
+      rectangle.top.toDp()
+    }
   }

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
@@ -495,7 +496,7 @@ fun Cell(
     }
     if (openBottomSheet) {
       ModalBottomSheet(
-        modifier = Modifier.wrapContentSize(),
+        modifier = Modifier.wrapContentSize().statusBarsPadding(),
         onDismissRequest = { openBottomSheet = false },
         sheetState = bottomSheetState,
         content = BottomSheetContent(

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BottomSheetContent.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BottomSheetContent.kt
@@ -4,8 +4,6 @@ package com.nexters.bandalart.android.feature.home.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -49,6 +47,7 @@ import com.nexters.bandalart.android.core.ui.component.bottomsheet.BottomSheetSu
 import com.nexters.bandalart.android.core.ui.component.bottomsheet.BottomSheetTextStyle
 import com.nexters.bandalart.android.core.ui.component.bottomsheet.BottomSheetTopBar
 import com.nexters.bandalart.android.core.ui.extension.NavigationBarHeightDp
+import com.nexters.bandalart.android.core.ui.extension.StatusBarHeightDp
 import com.nexters.bandalart.android.core.ui.theme.Gray300
 import com.nexters.bandalart.android.core.ui.theme.Gray400
 import com.nexters.bandalart.android.core.ui.theme.Gray700
@@ -64,7 +63,6 @@ fun BottomSheetContent(
   isSubCell: Boolean,
 ): @Composable (ColumnScope.() -> Unit) {
   return {
-    val scrollState = rememberScrollState()
     var openDatePickerBottomSheet by rememberSaveable { mutableStateOf(false) }
     val datePickerSkipPartiallyExpanded by remember { mutableStateOf(true) }
     val datePickerScope = rememberCoroutineScope()
@@ -75,10 +73,11 @@ fun BottomSheetContent(
     var memo by rememberSaveable { mutableStateOf("") }
     var scrollable = rememberScrollState()
 
-    Column(modifier = Modifier
+    Column(
+      modifier = Modifier
         .background(White)
         .navigationBarsPadding()
-        .verticalScroll(scrollable)
+        .verticalScroll(scrollable),
     ) {
       Spacer(modifier = Modifier.height(20.dp))
       BottomSheetTopBar(
@@ -214,8 +213,7 @@ fun BottomSheetContent(
           Spacer(modifier = Modifier.width(9.dp))
           BottomSheetCompleteButton(modifier = Modifier.weight(1f))
         }
-        Spacer(modifier = Modifier.height(NavigationBarHeightDp)) // 하단 바 스타일에 따른 높이
-        Spacer(modifier = Modifier.height(StatusBarHeightDp)) // 상태바 제한으로 인해 밀린 만큼의 높
+        Spacer(modifier = Modifier.height(StatusBarHeightDp + NavigationBarHeightDp)) // 상태바 제한으로 인해 밀린 만큼의 높
       }
     }
   }

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BottomSheetContent.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BottomSheetContent.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowForwardIos
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -45,6 +47,7 @@ import com.nexters.bandalart.android.core.ui.component.bottomsheet.BottomSheetDi
 import com.nexters.bandalart.android.core.ui.component.bottomsheet.BottomSheetSubTitleText
 import com.nexters.bandalart.android.core.ui.component.bottomsheet.BottomSheetTopBar
 import com.nexters.bandalart.android.core.ui.extension.NavigationBarHeightDp
+import com.nexters.bandalart.android.core.ui.extension.StatusBarHeightDp
 import com.nexters.bandalart.android.core.ui.extension.nonScaleSp
 import com.nexters.bandalart.android.core.ui.theme.Gray300
 import com.nexters.bandalart.android.core.ui.theme.Gray400
@@ -70,8 +73,9 @@ fun BottomSheetContent(
     )
     var goal by rememberSaveable { mutableStateOf("") }
     var memo by rememberSaveable { mutableStateOf("") }
+    var scrollable = rememberScrollState()
 
-    Column(modifier = Modifier.background(White)) {
+    Column(modifier = Modifier.background(White).verticalScroll(scrollable)) {
       Spacer(modifier = Modifier.height(20.dp))
       BottomSheetTopBar(
         isMainCell = false,
@@ -218,7 +222,8 @@ fun BottomSheetContent(
           Spacer(modifier = Modifier.width(9.dp))
           BottomSheetCompleteButton(modifier = Modifier.weight(1f))
         }
-        Spacer(modifier = Modifier.height(NavigationBarHeightDp))
+        Spacer(modifier = Modifier.height(NavigationBarHeightDp)) // 하단 바 스타일에 따른 높이
+        Spacer(modifier = Modifier.height(StatusBarHeightDp)) // 상태바 제한으로 인해 밀린 만큼의 높
       }
     }
   }


### PR DESCRIPTION
문제 - 바텀 시트가 상태 표시바를 침범하고, 그것을 해결하려하니 바텀 시트의 하단이 잘리는 현상 발생

- 바텀 시트가 상태 표시바를 침범하는 것 제한
- 그로 인해 바텀 시트가 밀리는데, 밀린 만큼의 Spacer를 추가