### PR TITLE
메인 셀의 바텀 시트를 혼용하기 위한 코드 수정

### DIFF
--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
@@ -357,18 +357,20 @@ private fun BandalartChart(
           .clip(RoundedCornerShape(10.dp))
           .background(color = Primary),
         content = {
-          Box(
-            modifier = Modifier
-              .matchParentSize()
-              .padding(1.dp),
-            contentAlignment = Alignment.Center,
-          ) {
-            CellText(
-              cellText = bandalart.title,
-              cellColor = Secondary,
-              fontWeight = FontWeight.W700,
-            )
-          }
+          Cell(
+            cellText = bandalart.title,
+            isSubCell = false,
+            isMainCell = true,
+            colIndex = 2,
+            rowIndex = 2,
+            colCnt = 1,
+            rowCnt = 1,
+          )
+//            CellText(
+//              cellText = bandalart.title,
+//              cellColor = Secondary,
+//              fontWeight = FontWeight.W700,
+//            )
         },
       )
     },
@@ -436,6 +438,7 @@ fun CellGrid(
           Cell(
             cellText = cellText,
             isSubCell = isSubCell,
+            isMainCell = false,
             colIndex = colIndex,
             rowIndex = rowIndex,
             colCnt = cols,
@@ -453,12 +456,14 @@ fun Cell(
   modifier: Modifier = Modifier,
   cellText: String,
   isSubCell: Boolean,
+  isMainCell: Boolean,
   colIndex: Int,
   rowIndex: Int,
   colCnt: Int,
   rowCnt: Int,
   outerPadding: Dp = 3.dp,
   innerPadding: Dp = 2.dp,
+  mainCellPadding: Dp = 1.dp,
 ) {
   var openBottomSheet by rememberSaveable { mutableStateOf(false) }
   val skipPartiallyExpanded by remember { mutableStateOf(true) }
@@ -469,19 +474,24 @@ fun Cell(
   Box(
     modifier = modifier
       .padding(
-        start = if (colIndex == 0) outerPadding else innerPadding,
-        end = if (colIndex == colCnt - 1) outerPadding else innerPadding,
-        top = if (rowIndex == 0) outerPadding else innerPadding,
-        bottom = if (rowIndex == rowCnt - 1) outerPadding else innerPadding,
+        start = if (isMainCell) mainCellPadding else if (colIndex == 0) outerPadding else innerPadding,
+        end = if (isMainCell) mainCellPadding else if (colIndex == colCnt - 1) outerPadding else innerPadding,
+        top = if (isMainCell) mainCellPadding else if (rowIndex == 0) outerPadding else innerPadding,
+        bottom = if (isMainCell) mainCellPadding else if (rowIndex == rowCnt - 1) outerPadding else innerPadding,
       )
       .aspectRatio(1f)
-      .background(Gray100)
       .clip(RoundedCornerShape(10.dp))
-      .background(if (isSubCell) Secondary else White)
+      .background(if (isMainCell) Primary else if (isSubCell) Secondary else White)
       .clickable { openBottomSheet = !openBottomSheet },
     contentAlignment = Alignment.Center,
   ) {
-    if (isSubCell) {
+    if (isMainCell) {
+      CellText(
+        cellText = cellText,
+        cellColor = Secondary,
+        fontWeight = FontWeight.W700,
+      )
+    } else if (isSubCell) {
       CellText(
         cellText = cellText,
         cellColor = Primary,
@@ -504,6 +514,7 @@ fun Cell(
           scope = scope,
           bottomSheetState = bottomSheetState,
           isSubCell = isSubCell,
+          isMainCell = isMainCell,
         ),
         dragHandle = null,
       )

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
@@ -494,7 +494,8 @@ fun Cell(
     skipPartiallyExpanded = skipPartiallyExpanded,
   )
   val backgroundColor = when {
-    isSubCell -> Secondary
+    isMainCell -> Primary
+    cellInfo.isSubCell -> Secondary
     cell.isCompleted -> Gray200
     else -> White
   }
@@ -508,7 +509,7 @@ fun Cell(
       )
       .aspectRatio(1f)
       .clip(RoundedCornerShape(10.dp))
-      .background(if (isMainCell) Primary else if (cellInfo.isSubCell) Secondary else White)
+      .background(backgroundColor)
       .clickable { openBottomSheet = !openBottomSheet },
     contentAlignment = Alignment.Center,
   ) {
@@ -522,8 +523,8 @@ fun Cell(
         )
       }
       CellText(
-        cellText = cell.title,
-        cellColor = Secondary,
+        cellText = cell.title ?: "",
+        cellTextColor = Secondary,
         fontWeight = FontWeight.W700,
       )
     } else if (cellInfo.isSubCell) {

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
@@ -359,18 +359,8 @@ private fun BandalartChart(
         content = {
           Cell(
             cellText = bandalart.title,
-            isSubCell = false,
             isMainCell = true,
-            colIndex = 2,
-            rowIndex = 2,
-            colCnt = 1,
-            rowCnt = 1,
           )
-//            CellText(
-//              cellText = bandalart.title,
-//              cellColor = Secondary,
-//              fontWeight = FontWeight.W700,
-//            )
         },
       )
     },
@@ -437,12 +427,14 @@ fun CellGrid(
             else subCell.bandalartData.children[taskIndex++].title
           Cell(
             cellText = cellText,
-            isSubCell = isSubCell,
             isMainCell = false,
-            colIndex = colIndex,
-            rowIndex = rowIndex,
-            colCnt = cols,
-            rowCnt = rows,
+            cellInfo = CellInfo(
+              isSubCell = isSubCell,
+              colIndex = colIndex,
+              rowIndex = rowIndex,
+              colCnt = cols,
+              rowCnt = rows,
+            ),
             modifier = Modifier.weight(1f),
           )
         }
@@ -451,16 +443,20 @@ fun CellGrid(
   }
 }
 
+data class CellInfo(
+  val isSubCell: Boolean = false,
+  val colIndex: Int = 2,
+  val rowIndex: Int = 2,
+  val colCnt: Int = 1,
+  val rowCnt: Int = 1,
+)
+
 @Composable
 fun Cell(
   modifier: Modifier = Modifier,
   cellText: String,
-  isSubCell: Boolean,
   isMainCell: Boolean,
-  colIndex: Int,
-  rowIndex: Int,
-  colCnt: Int,
-  rowCnt: Int,
+  cellInfo: CellInfo = CellInfo(),
   outerPadding: Dp = 3.dp,
   innerPadding: Dp = 2.dp,
   mainCellPadding: Dp = 1.dp,
@@ -474,14 +470,14 @@ fun Cell(
   Box(
     modifier = modifier
       .padding(
-        start = if (isMainCell) mainCellPadding else if (colIndex == 0) outerPadding else innerPadding,
-        end = if (isMainCell) mainCellPadding else if (colIndex == colCnt - 1) outerPadding else innerPadding,
-        top = if (isMainCell) mainCellPadding else if (rowIndex == 0) outerPadding else innerPadding,
-        bottom = if (isMainCell) mainCellPadding else if (rowIndex == rowCnt - 1) outerPadding else innerPadding,
+        start = if (isMainCell) mainCellPadding else if (cellInfo.colIndex == 0) outerPadding else innerPadding,
+        end = if (isMainCell) mainCellPadding else if (cellInfo.colIndex == cellInfo.colCnt - 1) outerPadding else innerPadding,
+        top = if (isMainCell) mainCellPadding else if (cellInfo.rowIndex == 0) outerPadding else innerPadding,
+        bottom = if (isMainCell) mainCellPadding else if (cellInfo.rowIndex == cellInfo.rowCnt - 1) outerPadding else innerPadding,
       )
       .aspectRatio(1f)
       .clip(RoundedCornerShape(10.dp))
-      .background(if (isMainCell) Primary else if (isSubCell) Secondary else White)
+      .background(if (isMainCell) Primary else if (cellInfo.isSubCell) Secondary else White)
       .clickable { openBottomSheet = !openBottomSheet },
     contentAlignment = Alignment.Center,
   ) {
@@ -491,7 +487,7 @@ fun Cell(
         cellColor = Secondary,
         fontWeight = FontWeight.W700,
       )
-    } else if (isSubCell) {
+    } else if (cellInfo.isSubCell) {
       CellText(
         cellText = cellText,
         cellColor = Primary,
@@ -513,7 +509,7 @@ fun Cell(
           onResult = { openBottomSheet = it },
           scope = scope,
           bottomSheetState = bottomSheetState,
-          isSubCell = isSubCell,
+          isSubCell = cellInfo.isSubCell,
           isMainCell = isMainCell,
         ),
         dragHandle = null,

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BottomSheetContent.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BottomSheetContent.kt
@@ -61,6 +61,7 @@ fun BottomSheetContent(
   scope: CoroutineScope,
   bottomSheetState: SheetState,
   isSubCell: Boolean,
+  isMainCell: Boolean,
 ): @Composable (ColumnScope.() -> Unit) {
   return {
     var openDatePickerBottomSheet by rememberSaveable { mutableStateOf(false) }
@@ -81,7 +82,7 @@ fun BottomSheetContent(
     ) {
       Spacer(modifier = Modifier.height(20.dp))
       BottomSheetTopBar(
-        isMainCell = false,
+        isMainCell = isMainCell,
         isSubCell = isSubCell,
         scope = scope,
         bottomSheetState = bottomSheetState,
@@ -173,7 +174,7 @@ fun BottomSheetContent(
           }
         }
         Spacer(modifier = Modifier.height(28.dp))
-        if (!isSubCell) {
+        if (!isSubCell && !isMainCell) {
           var switchOn by remember { mutableStateOf(false) }
           BottomSheetSubTitleText(text = "달성 여부")
           Spacer(modifier = Modifier.height(12.dp))
@@ -213,7 +214,7 @@ fun BottomSheetContent(
           Spacer(modifier = Modifier.width(9.dp))
           BottomSheetCompleteButton(modifier = Modifier.weight(1f))
         }
-        Spacer(modifier = Modifier.height(StatusBarHeightDp + NavigationBarHeightDp)) // 상태바 제한으로 인해 밀린 만큼의 높
+        Spacer(modifier = Modifier.height(StatusBarHeightDp + NavigationBarHeightDp + 20.dp))
       }
     }
   }


### PR DESCRIPTION
메인 셀에서 바텀 시트를 공용으로 사용하기 위해 조치한 사항 중에 조금 껄끄러운 부분이 있어서 

1. 박스의 패딩을 줄 때, 
    앞에는 메인인지 아닌지로, 만약 메인이 아니라면 colIndex, rowIndex, colCnt, rowCnt로 패딩 값을 찾는데 분기의 조건이 좀 어색하달까..?
<img width="946" alt="image" src="https://github.com/Nexters/BandalArt-Android/assets/54509842/228b2e41-6506-429d-b336-b4ec97ed78b6">

2. 메인 셀에서 cell로 넘겨주는 값이 쓸모 없는 값을 넣어줘야하는 점
    사실 상 메인 셀은 메인 셀이기만 하면 이라는 boolean 값이 프리패스라서 colIndex, rowIndex, colCnt, rowCnt 값들이 무의미해. 해당하는 값을 넘겨줄 순 있더라도 말이야
<img width="462" alt="image" src="https://github.com/Nexters/BandalArt-Android/assets/54509842/e6a3c19d-ebec-47e5-b5bd-e82a70e1599e">


이 두 가지만 아니라면 하위 바텀 시트에서도 메인 셀까지도 포함한다는 전제로 개발한거라 걱정이 없지.