### PR TITLE
HomeScreen의 이벤트 분리 (다음은 컴포져블 분산, 로딩 위치 고민)

### DIFF
--- a/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/model/bandalart/UpdateBandalartRequest.kt
+++ b/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/model/bandalart/UpdateBandalartRequest.kt
@@ -22,7 +22,7 @@ data class UpdateBandalartMainCellRequest(
 @Serializable
 data class UpdateBandalartSubCellRequest(
   @SerialName("title")
-  val title: String,
+  val title: String?,
   @SerialName("description")
   val description: String?,
   @SerialName("dueDate")
@@ -32,7 +32,7 @@ data class UpdateBandalartSubCellRequest(
 @Serializable
 data class UpdateBandalartTaskCellRequest(
   @SerialName("title")
-  val title: String,
+  val title: String?,
   @SerialName("description")
   val description: String?,
   @SerialName("dueDate")

--- a/core/domain/src/main/kotlin/com/nexters/bandalart/android/core/domain/entity/UpdateBandalartEntity.kt
+++ b/core/domain/src/main/kotlin/com/nexters/bandalart/android/core/domain/entity/UpdateBandalartEntity.kt
@@ -27,7 +27,7 @@ data class UpdateBandalartMainCellEntity(
  * @param dueDate 셀 마감일, 미설정인 경우 null
  */
 data class UpdateBandalartSubCellEntity(
-  val title: String,
+  val title: String?,
   val description: String?,
   val dueDate: String?,
 )
@@ -41,7 +41,7 @@ data class UpdateBandalartSubCellEntity(
  * @param isCompleted 셀 완료 여부
  */
 data class UpdateBandalartTaskCellEntity(
-  val title: String,
+  val title: String?,
   val description: String?,
   val dueDate: String?,
   val isCompleted: Boolean? = null,

--- a/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/bottomsheet/BottomSheetTopBar.kt
+++ b/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/bottomsheet/BottomSheetTopBar.kt
@@ -28,7 +28,7 @@ fun BottomSheetTopBar(
   isBlankCell: Boolean,
   scope: CoroutineScope,
   bottomSheetState: SheetState,
-  onResult: (Boolean) -> Unit,
+  onResult: (Boolean, Boolean) -> Unit,
 ) {
   Box(
     modifier = Modifier
@@ -43,7 +43,7 @@ fun BottomSheetTopBar(
         .aspectRatio(1f),
       onClick = {
         scope.launch { bottomSheetState.hide() }.invokeOnCompletion {
-          if (!bottomSheetState.isVisible) onResult(false)
+          if (!bottomSheetState.isVisible) onResult(false, false)
         }
       },
     ) {

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/BottomSheetViewModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/BottomSheetViewModel.kt
@@ -108,7 +108,6 @@ class BottomSheetViewModel @Inject constructor(
         result.isFailure -> {
           val exception = result.exceptionOrNull()!!
           _bottomSheetState.value = _bottomSheetState.value.copy(error = exception)
-
           _eventFlow.emit(BottomSheetUiEvent.ShowSnackbar("${exception.message}"))
           Timber.e(exception)
         }

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/BottomSheetViewModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/BottomSheetViewModel.kt
@@ -1,0 +1,243 @@
+package com.nexters.bandalart.android.feature.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.nexters.bandalart.android.core.domain.usecase.bandalart.DeleteBandalartCellUseCase
+import com.nexters.bandalart.android.core.domain.usecase.bandalart.UpdateBandalartMainCellUseCase
+import com.nexters.bandalart.android.core.domain.usecase.bandalart.UpdateBandalartSubCellUseCase
+import com.nexters.bandalart.android.core.domain.usecase.bandalart.UpdateBandalartTaskCellUseCase
+import com.nexters.bandalart.android.feature.home.mapper.toEntity
+import com.nexters.bandalart.android.feature.home.model.BandalartCellUiModel
+import com.nexters.bandalart.android.feature.home.model.UpdateBandalartTaskCellModel
+import com.nexters.bandalart.android.feature.home.model.UpdateBandalartMainCellModel
+import com.nexters.bandalart.android.feature.home.model.UpdateBandalartSubCellModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * BottomSheetUiState
+ *
+ * @param cellData 반다라트 표의 데이터, 서버와의 통신을 성공하면 not null
+ * @param isCellUpdated 반다라트 표의 특정 셀이 수정됨
+ * @param isCellDeleted 반다라트의 표의 특정 셀의 삭제됨(비어있는 셀로 전환)
+ * @param isDatePickerOpened 데이트 피커가 열림
+ * @param isEmojiPickerOpened 이모지 피커가 열림
+ * @param isDeleteCellDialogOpened 셀 삭제 시, 경고 창이 열림
+ * @param error 서버와의 통신을 실패
+ */
+
+// TODO Token 확인 로직의 위치 결정
+data class BottomSheetUiState(
+  val cellData: BandalartCellUiModel = BandalartCellUiModel(),
+  val isCellUpdated: Boolean = false,
+  val isCellDeleted: Boolean = false,
+  val isDatePickerOpened: Boolean = false,
+  val isEmojiPickerOpened: Boolean = false,
+  val isDeleteCellDialogOpened: Boolean = false,
+  val error: Throwable? = null,
+)
+
+sealed class BottomSheetUiEvent {
+  data class ShowSnackbar(val message: String) : BottomSheetUiEvent()
+}
+
+@Suppress("unused")
+@HiltViewModel
+class BottomSheetViewModel @Inject constructor(
+  private val updateBandalartMainCellUseCase: UpdateBandalartMainCellUseCase,
+  private val updateBandalartSubCellUseCase: UpdateBandalartSubCellUseCase,
+  private val updateBandalartTaskCellUseCase: UpdateBandalartTaskCellUseCase,
+  private val deleteBandalartCellUseCase: DeleteBandalartCellUseCase,
+) : ViewModel() {
+
+  private val _bottomSheetState = MutableStateFlow(BottomSheetUiState())
+  val bottomSheetState: StateFlow<BottomSheetUiState> = this._bottomSheetState.asStateFlow()
+
+  private val _eventFlow = MutableSharedFlow<BottomSheetUiEvent>()
+  val eventFlow: SharedFlow<BottomSheetUiEvent> = _eventFlow.asSharedFlow()
+
+  fun copyCellData(cellData: BandalartCellUiModel) {
+    _bottomSheetState.update {
+      it.copy(cellData = cellData)
+    }
+  }
+
+  fun updateBandalartMainCell(
+    bandalartKey: String,
+    cellKey: String,
+    updateBandalartMainCellModel: UpdateBandalartMainCellModel,
+  ) {
+    viewModelScope.launch {
+      val result = updateBandalartMainCellUseCase(bandalartKey, cellKey, updateBandalartMainCellModel.toEntity())
+      when {
+        result.isSuccess && result.getOrNull() != null -> { }
+        result.isSuccess && result.getOrNull() == null -> {
+          Timber.e("Request succeeded but data validation failed")
+        }
+        result.isFailure -> {
+          val exception = result.exceptionOrNull()!!
+          _bottomSheetState.value = _bottomSheetState.value.copy(error = exception)
+          _eventFlow.emit(BottomSheetUiEvent.ShowSnackbar("${exception.message}"))
+          Timber.e(exception)
+        }
+      }
+    }
+  }
+
+  fun updateBandalartSubCell(
+    bandalartKey: String,
+    cellKey: String,
+    updateBandalartSubCellModel: UpdateBandalartSubCellModel,
+  ) {
+    viewModelScope.launch {
+      val result = updateBandalartSubCellUseCase(bandalartKey, cellKey, updateBandalartSubCellModel.toEntity())
+      when {
+        result.isSuccess && result.getOrNull() != null -> { }
+        result.isSuccess && result.getOrNull() == null -> {
+          Timber.e("Request succeeded but data validation failed")
+        }
+        result.isFailure -> {
+          val exception = result.exceptionOrNull()!!
+          _bottomSheetState.value = _bottomSheetState.value.copy(error = exception)
+
+          _eventFlow.emit(BottomSheetUiEvent.ShowSnackbar("${exception.message}"))
+          Timber.e(exception)
+        }
+      }
+    }
+  }
+
+  fun updateBandalartTaskCell(
+    bandalartKey: String,
+    cellKey: String,
+    updateBandalartTaskCellModel: UpdateBandalartTaskCellModel,
+  ) {
+    viewModelScope.launch {
+      val result = updateBandalartTaskCellUseCase(bandalartKey, cellKey, updateBandalartTaskCellModel.toEntity())
+      when {
+        result.isSuccess && result.getOrNull() != null -> { }
+        result.isSuccess && result.getOrNull() == null -> {
+          Timber.e("Request succeeded but data validation failed")
+        }
+        result.isFailure -> {
+          val exception = result.exceptionOrNull()!!
+          _bottomSheetState.value = _bottomSheetState.value.copy(error = exception)
+          _eventFlow.emit(BottomSheetUiEvent.ShowSnackbar("${exception.message}"))
+          Timber.e(exception)
+        }
+      }
+    }
+  }
+
+  fun deleteBandalartCell(bandalartKey: String, cellKey: String) {
+    viewModelScope.launch {
+      val result = deleteBandalartCellUseCase(bandalartKey, cellKey)
+      when {
+        result.isSuccess && result.getOrNull() != null -> { }
+        result.isSuccess && result.getOrNull() == null -> {
+          Timber.e("Request succeeded but data validation failed")
+        }
+        result.isFailure -> {
+          val exception = result.exceptionOrNull()!!
+          _bottomSheetState.value = _bottomSheetState.value.copy(
+            isCellDeleted = false,
+            error = exception,
+          )
+          openDeleteCellDialog(false)
+          _eventFlow.emit(BottomSheetUiEvent.ShowSnackbar("${exception.message}"))
+          Timber.e(exception)
+        }
+      }
+    }
+  }
+
+  fun openDeleteCellDialog(deleteCellDialogState: Boolean) {
+    viewModelScope.launch {
+      _bottomSheetState.update {
+        it.copy(isDeleteCellDialogOpened = deleteCellDialogState)
+      }
+    }
+  }
+
+  fun openDatePicker(datePickerState: Boolean) {
+    _bottomSheetState.update {
+      it.copy(isDatePickerOpened = datePickerState)
+    }
+  }
+
+  fun openEmojiPicker(emojiPickerState: Boolean) {
+    _bottomSheetState.update {
+      it.copy(isEmojiPickerOpened = emojiPickerState)
+    }
+  }
+
+  fun emojiSelected(profileEmoji: String?) {
+    _bottomSheetState.update {
+      it.copy(
+        cellData = it.cellData.copy(
+          profileEmoji = profileEmoji,
+        ),
+      )
+    }
+  }
+
+  fun titleChanged(title: String) {
+    _bottomSheetState.update {
+      it.copy(
+        cellData = it.cellData.copy(
+          title = title,
+        ),
+      )
+    }
+  }
+
+  fun colorChanged(mainColor: String, subColor: String) {
+    _bottomSheetState.update {
+      it.copy(
+        cellData = it.cellData.copy(
+          mainColor = mainColor,
+          subColor = subColor,
+        ),
+      )
+    }
+  }
+
+  fun dueDateChanged(dueDate: String?) {
+    _bottomSheetState.update {
+      it.copy(
+        cellData = it.cellData.copy(
+          dueDate = dueDate,
+        ),
+      )
+    }
+  }
+
+  fun descriptionChanged(description: String?) {
+    _bottomSheetState.update {
+      it.copy(
+        cellData = it.cellData.copy(
+          description = description,
+        ),
+      )
+    }
+  }
+
+  fun isCompletedChanged(isCompleted: Boolean) {
+    _bottomSheetState.update {
+      it.copy(
+        cellData = it.cellData.copy(
+          isCompleted = isCompleted,
+        ),
+      )
+    }
+  }
+}

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
@@ -741,9 +741,9 @@ fun Cell(
         isMainCell = isMainCell,
         isBlankCell = cellData.title.isNullOrEmpty(),
         cellData = cellData,
-        onResult = { openBottomSheetClosed, valueChanged ->
-          openBottomSheet = openBottomSheetClosed
-          bottomSheetDataChanged(valueChanged)
+        onResult = { bottomSheetState, bottomSheetDataChangedState ->
+          openBottomSheet = bottomSheetState
+          bottomSheetDataChanged(bottomSheetDataChangedState)
         },
       )
     }

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeViewModel.kt
@@ -60,6 +60,7 @@ data class HomeUiState(
   val isBandalartCellDeleted: Boolean = false,
   val isDropDownMenuOpened: Boolean = false,
   val isBandalartDeleteAlertDialogOpened: Boolean = false,
+  val bottomSheetDataChanged: Boolean = false,
   val isLoading: Boolean = true,
   val error: Throwable? = null,
 )
@@ -162,6 +163,7 @@ class HomeViewModel @Inject constructor(
             bandalartCellData = result.getOrNull()!!.toUiModel(),
             error = null,
           )
+          bottomSheetDataChanged(false)
         }
         result.isSuccess && result.getOrNull() == null -> {
           Timber.e("Request succeeded but data validation failed")
@@ -360,6 +362,14 @@ class HomeViewModel @Inject constructor(
     viewModelScope.launch {
       _uiState.value = _uiState.value.copy(
         isBandalartDeleteAlertDialogOpened = state,
+      )
+    }
+  }
+
+  fun bottomSheetDataChanged(state: Boolean) {
+    viewModelScope.launch {
+      _uiState.value = _uiState.value.copy(
+        bottomSheetDataChanged = state,
       )
     }
   }

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/model/BandalartCellUiModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/model/BandalartCellUiModel.kt
@@ -2,9 +2,9 @@ package com.nexters.bandalart.android.feature.home.model
 
 data class BandalartCellUiModel(
   val key: String = "",
-  val title: String? = "",
-  val description: String? = "",
-  val dueDate: String? = "",
+  val title: String? = null,
+  val description: String? = null,
+  val dueDate: String? = null,
   val isCompleted: Boolean = false,
   val completionRatio: Int = 0,
   val profileEmoji: String? = "",

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/model/UpdateBandalartMainCellModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/model/UpdateBandalartMainCellModel.kt
@@ -1,7 +1,7 @@
 package com.nexters.bandalart.android.feature.home.model
 
 data class UpdateBandalartMainCellModel(
-  val title: String? = "",
+  val title: String = "",
   val description: String? = null,
   val dueDate: String? = null,
   val profileEmoji: String? = "",

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/model/UpdateBandalartSubCellModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/model/UpdateBandalartSubCellModel.kt
@@ -1,7 +1,7 @@
 package com.nexters.bandalart.android.feature.home.model
 
 data class UpdateBandalartSubCellModel(
-  val title: String = "",
+  val title: String? = "",
   val description: String? = null,
   val dueDate: String? = null,
 )

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BandalartColorPicker.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BandalartColorPicker.kt
@@ -36,6 +36,14 @@ fun BandalartColorPicker(
     horizontalArrangement = Arrangement.SpaceEvenly,
   ) {
     var initSelected by remember { mutableStateOf(initColor) }
+    val allColor = listOf(
+      ThemeColor("#3FFFBA", "#3FFFBA"),
+      ThemeColor("#4E3FFF", "#B5AEFF"),
+      ThemeColor("#3FF3FF", "#3FF3FF"),
+      ThemeColor("#93FF3F", "#93FF3F"),
+      ThemeColor("#FBFF3F", "#FBFF3F"),
+      ThemeColor("#FFB423", "#FFB423"),
+    )
     allColor.forEach {
       Box(
         contentAlignment = Alignment.Center,

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BandalartDatePicker.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BandalartDatePicker.kt
@@ -43,21 +43,21 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun BandalartDatePicker(
-  onResult: (String, Boolean) -> Unit,
+  onResult: (String?, Boolean) -> Unit,
   datePickerScope: CoroutineScope,
   datePickerState: SheetState,
-  currentDueDate: String? = "",
+  currentDueDate: String? = null,
 ) {
   Column(
     horizontalAlignment = Alignment.CenterHorizontally,
     modifier = Modifier.fillMaxWidth(),
   ) {
     val chosenYear =
-      remember { mutableStateOf(if (currentDueDate!!.isNotEmpty()) currentDueDate.split("-")[0] else currentYear.toString()) }
+      remember { mutableStateOf(if (!currentDueDate.isNullOrEmpty()) currentDueDate.split("-")[0] else currentYear.toString()) }
     val chosenMonth =
-      remember { mutableStateOf(if (currentDueDate!!.isNotEmpty()) currentDueDate.split("-")[1] else currentMonth.toString()) }
+      remember { mutableStateOf(if (!currentDueDate.isNullOrEmpty()) currentDueDate.split("-")[1] else currentMonth.toString()) }
     val chosenDay =
-      remember { mutableStateOf(if (currentDueDate!!.isNotEmpty()) currentDueDate.split("-")[2].split("T")[0] else currentDay.toString()) }
+      remember { mutableStateOf(if (!currentDueDate.isNullOrEmpty()) currentDueDate.split("-")[2].split("T")[0] else currentDay.toString()) }
 
     Row(
       modifier = Modifier
@@ -75,7 +75,7 @@ fun BandalartDatePicker(
               .invokeOnCompletion {
                 if (!datePickerState.isVisible) {
                   onResult(
-                    "",
+                    null,
                     false,
                   )
                 }

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BottomSheet.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BottomSheet.kt
@@ -84,7 +84,10 @@ fun BottomSheet(
   isMainCell: Boolean,
   isBlankCell: Boolean,
   cellData: BandalartCellUiModel,
-  onResult: (Boolean, Boolean) -> Unit,
+  onResult: (
+    bottomSheetState: Boolean,
+    bottomSheetDataChangedState: Boolean,
+  ) -> Unit,
   viewModel: BottomSheetViewModel = hiltViewModel(),
 ) {
   val uiState by viewModel.bottomSheetState.collectAsStateWithLifecycle()

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BottomSheet.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BottomSheet.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
@@ -21,6 +20,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
@@ -35,23 +35,22 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.SheetState
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nexters.bandalart.android.core.designsystem.R
 import com.nexters.bandalart.android.core.ui.component.BandalartDeleteAlertDialog
 import com.nexters.bandalart.android.core.ui.component.EmojiText
@@ -71,52 +70,39 @@ import com.nexters.bandalart.android.core.ui.theme.Gray400
 import com.nexters.bandalart.android.core.ui.theme.Gray700
 import com.nexters.bandalart.android.core.ui.theme.Gray900
 import com.nexters.bandalart.android.core.ui.theme.White
+import com.nexters.bandalart.android.feature.home.BottomSheetViewModel
 import com.nexters.bandalart.android.feature.home.model.BandalartCellUiModel
 import com.nexters.bandalart.android.feature.home.model.UpdateBandalartMainCellModel
 import com.nexters.bandalart.android.feature.home.model.UpdateBandalartSubCellModel
 import com.nexters.bandalart.android.feature.home.model.UpdateBandalartTaskCellModel
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 @Composable
-fun bottomSheetContent(
-  onResult: (Boolean) -> Unit,
-  scope: CoroutineScope,
-  bottomSheetState: SheetState,
+fun BottomSheet(
+  bandalartKey: String,
   isSubCell: Boolean,
   isMainCell: Boolean,
   isBlankCell: Boolean,
   cellData: BandalartCellUiModel,
-  bandalartKey: String,
-  updateBandalartMainCell: (String, String, UpdateBandalartMainCellModel) -> Unit,
-  updateBandalartSubCell: (String, String, UpdateBandalartSubCellModel) -> Unit,
-  updateBandalartTaskCell: (String, String, UpdateBandalartTaskCellModel) -> Unit,
-  deleteBandalartCell: (String, String) -> Unit,
-): @Composable (ColumnScope.() -> Unit) {
-  return {
-    var openDatePickerPush by rememberSaveable { mutableStateOf(false) }
-    val datePickerSkipPartiallyExpanded by remember { mutableStateOf(true) }
-    val datePickerScope = rememberCoroutineScope()
-    val datePickerState = rememberModalBottomSheetState(
-      skipPartiallyExpanded = datePickerSkipPartiallyExpanded,
-    )
-    var openEmojiPickerPush by rememberSaveable { mutableStateOf(false) }
-    val emojiSkipPartiallyExpanded by remember { mutableStateOf(true) }
-    val emojiPickerScope = rememberCoroutineScope()
-    val emojiPickerState = rememberModalBottomSheetState(
-      skipPartiallyExpanded = emojiSkipPartiallyExpanded,
-    )
-    var openDeleteAlertDialog by rememberSaveable { mutableStateOf(false) }
-    var currentEmoji by remember { mutableStateOf(cellData.profileEmoji) }
-    var title by rememberSaveable { mutableStateOf(cellData.title ?: "") }
-    var mainColor by rememberSaveable { mutableStateOf(cellData.mainColor ?: "#3FFFBA") }
-    var subColor by rememberSaveable { mutableStateOf(cellData.subColor ?: "#111827") }
-    var dueDate by rememberSaveable { mutableStateOf(cellData.dueDate ?: "") }
-    var description by rememberSaveable { mutableStateOf(cellData.description ?: "") }
-    var isCompleted by remember { mutableStateOf(cellData.isCompleted) }
-    val scrollable = rememberScrollState()
+  onResult: (Boolean, Boolean) -> Unit,
+  viewModel: BottomSheetViewModel = hiltViewModel(),
+) {
+  val uiState by viewModel.bottomSheetState.collectAsStateWithLifecycle()
+  LaunchedEffect(key1 = Unit) {
+    viewModel.copyCellData(cellData = cellData)
+  }
+  val scope = rememberCoroutineScope()
+  val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
 
-    if (openDeleteAlertDialog) {
+  ModalBottomSheet(
+    modifier = Modifier
+      .wrapContentSize()
+      .statusBarsPadding(),
+    onDismissRequest = { onResult(false, false) },
+    sheetState = bottomSheetState,
+    dragHandle = null,
+  ) {
+    if (uiState.isDeleteCellDialogOpened) {
       BandalartDeleteAlertDialog(
         title = "해당 셀을 삭제하시겠어요?",
         message = if (isMainCell) {
@@ -127,11 +113,18 @@ fun bottomSheetContent(
           "삭제된 내용은 다시 복구할 수 없어요."
         },
         onDeleteClicked = {
-          deleteBandalartCell(bandalartKey, cellData.key)
-          openDeleteAlertDialog = false
-          onResult(false)
+          scope.launch {
+            viewModel.deleteBandalartCell(
+              bandalartKey = bandalartKey,
+              cellKey = uiState.cellData.key,
+            )
+            viewModel.openDeleteCellDialog(deleteCellDialogState = false)
+            bottomSheetState.hide()
+          }.invokeOnCompletion {
+            if (!bottomSheetState.isVisible) { onResult(false, true) }
+          }
         },
-        onCancelClicked = { openDeleteAlertDialog = false },
+        onCancelClicked = { viewModel.openDeleteCellDialog(deleteCellDialogState = false) },
       )
     }
 
@@ -139,7 +132,7 @@ fun bottomSheetContent(
       modifier = Modifier
         .background(White)
         .navigationBarsPadding()
-        .verticalScroll(scrollable),
+        .verticalScroll(rememberScrollState()),
     ) {
       Spacer(modifier = Modifier.height(20.dp))
       BottomSheetTopBar(
@@ -179,12 +172,12 @@ fun bottomSheetContent(
                     .aspectRatio(1f)
                     .background(Gray100)
                     .clickable {
-                      openEmojiPickerPush = !openEmojiPickerPush
-                      if (openDatePickerPush) openDatePickerPush = false
+                      viewModel.openEmojiPicker(emojiPickerState = !uiState.isEmojiPickerOpened)
+                      if (uiState.isDatePickerOpened) viewModel.openDatePicker(datePickerState = false)
                     },
                   contentAlignment = Alignment.Center,
                 ) {
-                  if (currentEmoji.isNullOrEmpty()) {
+                  if (uiState.cellData.profileEmoji.isNullOrEmpty()) {
                     val image = painterResource(id = R.drawable.ic_empty_emoji)
                     Image(
                       painter = image,
@@ -192,23 +185,20 @@ fun bottomSheetContent(
                     )
                   } else {
                     EmojiText(
-                      emojiText = currentEmoji,
+                      emojiText = uiState.cellData.profileEmoji,
                       fontSize = 22.sp.nonScaleSp,
                     )
                   }
                 }
               }
-              if (currentEmoji.isNullOrEmpty()) {
+              if (uiState.cellData.profileEmoji.isNullOrEmpty()) {
                 val image = painterResource(id = R.drawable.ic_edit)
                 Image(
                   painter = image,
                   contentDescription = "Edit Icon",
                   modifier = Modifier
                     .align(Alignment.BottomEnd)
-                    .offset(
-                      x = 4.dp,
-                      y = 4.dp,
-                    ),
+                    .offset(x = 4.dp, y = 4.dp),
                 )
               }
             }
@@ -218,13 +208,15 @@ fun bottomSheetContent(
               modifier = Modifier
                 .fillMaxWidth()
                 .height(18.dp),
-              value = title,
-              onValueChange = { title = if (it.length > 15) title else it },
+              value = uiState.cellData.title ?: "",
+              onValueChange = {
+                viewModel.titleChanged(title = if (it.length > 15) uiState.cellData.title ?: "" else it)
+              },
               keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
               maxLines = 1,
               textStyle = BottomSheetTextStyle(),
               decorationBox = { innerTextField ->
-                if (title.isEmpty()) BottomSheetContentText(text = "15자 이내로 입력해주세요.")
+                if (uiState.cellData.title.isNullOrEmpty()) BottomSheetContentText(text = "15자 이내로 입력해주세요.")
                 innerTextField()
               },
             )
@@ -232,7 +224,7 @@ fun bottomSheetContent(
             BottomSheetDivider()
           }
         }
-        AnimatedVisibility(visible = openEmojiPickerPush) {
+        AnimatedVisibility(visible = uiState.isEmojiPickerOpened) {
           Column(
             content = BandalartEmojiPicker(
               modifier = Modifier
@@ -244,14 +236,14 @@ fun bottomSheetContent(
                     easing = LinearOutSlowInEasing,
                   ),
                 ),
-              currentEmoji = currentEmoji,
+              currentEmoji = uiState.cellData.profileEmoji,
               isBottomSheet = false,
               onResult = { currentEmojiResult, openEmojiPushResult ->
-                currentEmoji = currentEmojiResult
-                openEmojiPickerPush = openEmojiPushResult
+                viewModel.emojiSelected(profileEmoji = currentEmojiResult)
+                viewModel.openEmojiPicker(emojiPickerState = openEmojiPushResult)
               },
-              emojiPickerScope = emojiPickerScope,
-              emojiPickerState = emojiPickerState,
+              emojiPickerScope = rememberCoroutineScope(),
+              emojiPickerState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
             ),
           )
         }
@@ -259,10 +251,15 @@ fun bottomSheetContent(
           Spacer(modifier = Modifier.height(22.dp))
           BottomSheetSubTitleText(text = "색상 테마")
           BandalartColorPicker(
-            initColor = ThemeColor(mainColor, subColor),
+            initColor = ThemeColor(
+              mainColor = uiState.cellData.mainColor ?: "#3FFFBA",
+              subColor = uiState.cellData.subColor ?: "#3FFFBA",
+            ),
             onResult = {
-              mainColor = it.mainColor
-              subColor = it.subColor
+              viewModel.colorChanged(
+                mainColor = it.mainColor,
+                subColor = it.subColor,
+              )
             },
           )
           Spacer(modifier = Modifier.height(3.dp))
@@ -276,15 +273,15 @@ fun bottomSheetContent(
               .fillMaxWidth()
               .height(18.dp)
               .clickable {
-                openDatePickerPush = !openDatePickerPush
-                if (openEmojiPickerPush) openEmojiPickerPush = false
+                viewModel.openDatePicker(datePickerState = !uiState.isDatePickerOpened)
+                if (uiState.isEmojiPickerOpened) viewModel.openEmojiPicker(emojiPickerState = false)
               },
           ) {
-            val dueDateText = dueDate.split("-")
+            val dueDateText = uiState.cellData.dueDate?.split("-")
             BottomSheetContentText(
-              color = if (dueDate.isEmpty()) Gray400 else Gray900,
+              color = if (uiState.cellData.dueDate.isNullOrEmpty()) Gray400 else Gray900,
               text =
-              if (dueDate.isEmpty()) "마감일을 선택해주세요."
+              if (dueDateText.isNullOrEmpty()) "마감일을 선택해주세요."
               else {
                 dueDateText[0] + "년 " + dueDateText[1] + "월 " + dueDateText[2].split("T")[0].toInt() + "일"
               },
@@ -302,15 +299,17 @@ fun bottomSheetContent(
           Spacer(modifier = Modifier.height(10.dp))
           BottomSheetDivider()
         }
-        AnimatedVisibility(visible = openDatePickerPush) {
+        AnimatedVisibility(visible = uiState.isDatePickerOpened) {
           BandalartDatePicker(
             onResult = { dueDateResult, openDatePickerPushResult ->
-              dueDate = dueDateResult.ifEmpty { "" }
-              openDatePickerPush = openDatePickerPushResult
+              viewModel.dueDateChanged(
+                dueDate = if (dueDateResult.isNullOrEmpty()) null else dueDateResult,
+              )
+              viewModel.openDatePicker(datePickerState = openDatePickerPushResult)
             },
-            datePickerScope = datePickerScope,
-            datePickerState = datePickerState,
-            currentDueDate = dueDate,
+            datePickerScope = rememberCoroutineScope(),
+            datePickerState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            currentDueDate = uiState.cellData.dueDate,
           )
         }
         Spacer(modifier = Modifier.height(28.dp))
@@ -322,13 +321,17 @@ fun bottomSheetContent(
               modifier = Modifier
                 .fillMaxWidth()
                 .height(18.dp),
-              value = description,
-              onValueChange = { description = if (it.length > 15) description else it },
+              value = uiState.cellData.description ?: "",
+              onValueChange = {
+                viewModel.descriptionChanged(
+                  description = if (it.length > 15) uiState.cellData.description else it,
+                )
+              },
               keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
               maxLines = 1,
               textStyle = BottomSheetTextStyle(),
               decorationBox = { innerTextField ->
-                if (description.isEmpty()) BottomSheetContentText(text = "메모를 입력해주세요.")
+                if (uiState.cellData.description.isNullOrEmpty()) BottomSheetContentText(text = "메모를 입력해주세요.")
                 innerTextField()
               },
             )
@@ -343,12 +346,12 @@ fun bottomSheetContent(
           Box(modifier = Modifier.fillMaxWidth()) {
             BottomSheetContentText(
               modifier = Modifier.align(Alignment.CenterStart),
-              text = if (isCompleted) "달성" else "미달성",
+              text = if (uiState.cellData.isCompleted) "달성" else "미달성",
               color = Gray900,
             )
             Switch(
-              checked = isCompleted,
-              onCheckedChange = { _switchOn -> isCompleted = _switchOn },
+              checked = uiState.cellData.isCompleted,
+              onCheckedChange = { switchOn -> viewModel.isCompletedChanged(isCompleted = switchOn) },
               colors = SwitchDefaults.colors(
                 uncheckedThumbColor = White,
                 uncheckedTrackColor = Gray300,
@@ -375,61 +378,54 @@ fun bottomSheetContent(
           if (!isBlankCell) {
             BottomSheetDeleteButton(
               modifier = Modifier.weight(1f),
-              onClick = {
-                scope.launch {
-                  openDeleteAlertDialog = !openDeleteAlertDialog
-                }.invokeOnCompletion {
-                  if (!bottomSheetState.isVisible) { onResult(false) }
-                }
-              },
+              onClick = { viewModel.openDeleteCellDialog(deleteCellDialogState = !uiState.isDeleteCellDialogOpened) },
             )
             Spacer(modifier = Modifier.width(9.dp))
           }
           BottomSheetCompleteButton(
             modifier = Modifier.weight(1f),
-            isBlankCell = title.isEmpty(),
+            isBlankCell = uiState.cellData.title.isNullOrEmpty(),
             onClick = {
               scope.launch {
                 if (isMainCell) {
-                  updateBandalartMainCell(
-                    bandalartKey,
-                    cellData.key,
-                    UpdateBandalartMainCellModel(
-                      title = title,
-                      description = description,
-                      dueDate = dueDate.ifEmpty { null },
-                      profileEmoji = currentEmoji,
-                      mainColor = mainColor,
-                      subColor = subColor,
+                  viewModel.updateBandalartMainCell(
+                    bandalartKey = bandalartKey,
+                    cellKey = cellData.key,
+                    updateBandalartMainCellModel = UpdateBandalartMainCellModel(
+                      title = uiState.cellData.title ?: "",
+                      description = uiState.cellData.description,
+                      dueDate = uiState.cellData.dueDate?.ifEmpty { null },
+                      profileEmoji = uiState.cellData.profileEmoji,
+                      mainColor = uiState.cellData.mainColor ?: "#3FFFBA",
+                      subColor = uiState.cellData.subColor ?: "#111827",
                     ),
                   )
                 } else if (isSubCell) {
-                  updateBandalartSubCell(
-                    bandalartKey,
-                    cellData.key,
-                    UpdateBandalartSubCellModel(
-                      title = title,
-                      description = description,
-                      dueDate = dueDate.ifEmpty { null },
+                  viewModel.updateBandalartSubCell(
+                    bandalartKey = bandalartKey,
+                    cellKey = cellData.key,
+                    updateBandalartSubCellModel = UpdateBandalartSubCellModel(
+                      title = uiState.cellData.title,
+                      description = uiState.cellData.description,
+                      dueDate = uiState.cellData.dueDate?.ifEmpty { null },
                     ),
                   )
                 } else {
-                  updateBandalartTaskCell(
-                    bandalartKey,
-                    cellData.key,
-                    UpdateBandalartTaskCellModel(
-                      title = title,
-                      description = description,
-                      dueDate = dueDate.ifEmpty { null },
-                      isCompleted = isCompleted,
+                  viewModel.updateBandalartTaskCell(
+                    bandalartKey = bandalartKey,
+                    cellKey = cellData.key,
+                    updateBandalartTaskCellModel = UpdateBandalartTaskCellModel(
+                      title = uiState.cellData.title.toString(),
+                      description = uiState.cellData.description,
+                      dueDate = uiState.cellData.dueDate?.ifEmpty { null },
+                      isCompleted = uiState.cellData.isCompleted,
                     ),
                   )
                 }
-
                 // Todo 실패 처리해줘야함
                 bottomSheetState.hide()
               }.invokeOnCompletion {
-                if (!bottomSheetState.isVisible) { onResult(false) }
+                if (!bottomSheetState.isVisible) { onResult(false, true) }
               }
             },
           )
@@ -443,13 +439,4 @@ fun bottomSheetContent(
 data class ThemeColor(
   val mainColor: String,
   val subColor: String,
-)
-
-val allColor = listOf(
-  ThemeColor("#3FFFBA", "#3FFFBA"),
-  ThemeColor("#4E3FFF", "#B5AEFF"),
-  ThemeColor("#3FF3FF", "#3FF3FF"),
-  ThemeColor("#93FF3F", "#93FF3F"),
-  ThemeColor("#FBFF3F", "#FBFF3F"),
-  ThemeColor("#FFB423", "#FFB423"),
 )


### PR DESCRIPTION
이벤트 분리에 이어서 컴포져블 분산, 로딩 위치 고민을 이번 PR이후 진행할 계획임

- [x] 이벤트 분리
- [ ] 컴포져블 분산
- [ ] 로딩 위치 고민 + 실패 시 예외처리

근데 어제 나온 [해당 이슈](https://cdn.discordapp.com/attachments/1125426707227234395/1137803348091879645/Screen_Recording_20230807_024401.mp4)의 원인은 바텀 시트는 25개인데, 뷰모델 하나로 퉁치려는 건방진 생각의 결과물임 
(자세히 보면, 열기 이벤트 하나에 바텀시트 25개가 전원 집합하는 꼴을 볼 수 있음)

이 떄문에 25개의 바텀 시트의 상태를 전부 각자 관리하는 것은 비효율적이라고 생각함(미리 만들기에도, 매번 찾기도)

그래서 BottomSheetViewModel을 만들어서 HomeScreen에 있던 ModalBottomSheet을 아예 BottomSheet.kt쪽으로 옮기고 바텀 시트에서 이뤄지는 로직들을 함께 옮겨줬음.
(현재 성과 - 이벤트가 뎊스에 뎊스에 뎊스에 뎊스를 거듭하지 않고 BottomSheetViewModel에서 바로 접근하기 때문에 HomeViewModel과 HomeScreen의 경량화..)

가장 뚜렷한 메인 화면과 바텀 시트를 분리했으니,  바텀 시트 내부의 컴포져블의 분산과 로딩 위치(+실패 시 예외처리)를 고민할 것인데, 네이밍이 많이 바뀐부분이 있어서 미리 머지하기를 희망함