### PR TITLE
홈 화면 첫 진입시 초기화 로직 구현

### DIFF
--- a/app/src/main/kotlin/com/nexters/bandalart/android/MainViewModel.kt
+++ b/app/src/main/kotlin/com/nexters/bandalart/android/MainViewModel.kt
@@ -2,6 +2,7 @@ package com.nexters.bandalart.android
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.nexters.bandalart.android.core.domain.usecase.bandalart.CreateBandalartUseCase
 import com.nexters.bandalart.android.core.domain.usecase.login.CreateGuestLoginTokenUseCase
 import com.nexters.bandalart.android.core.domain.usecase.login.GetGuestLoginTokenUseCase
 import com.nexters.bandalart.android.core.domain.usecase.login.SetGuestLoginTokenUseCase
@@ -32,6 +33,7 @@ class MainViewModel @Inject constructor(
   private val getGuestLoginTokenUseCase: GetGuestLoginTokenUseCase,
   private val createGuestLoginTokenUseCase: CreateGuestLoginTokenUseCase,
   private val setGuestLoginTokenUseCase: SetGuestLoginTokenUseCase,
+  private val createBandalartUseCase: CreateBandalartUseCase,
 ) : ViewModel() {
 
   private val _uiState = MutableStateFlow(MainUiState())
@@ -58,6 +60,7 @@ class MainViewModel @Inject constructor(
               isLoggedIn = false,
               isLoading = false,
             )
+            createBandalartUseCase()
           }
           result.isSuccess && result.getOrNull() == null -> {
             Timber.e("Request succeeded but data validation failed")

--- a/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/di/NetworkModule.kt
+++ b/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/di/NetworkModule.kt
@@ -31,11 +31,10 @@ internal object NetworkModule {
   @Provides
   fun provideKtorHttpClient(dataStoreProvider: DataStoreProvider): HttpClient {
     return HttpClient(CIO) {
-      val guestLoginToken = runBlocking {
-        dataStoreProvider.getGuestLoginToken()
-      }
-      Timber.d(guestLoginToken)
       defaultRequest {
+        val guestLoginToken = runBlocking {
+          dataStoreProvider.getGuestLoginToken()
+        }
         url(BuildConfig.SERVER_BASE_URL)
         contentType(ContentType.Application.Json)
         header("X-GUEST-KEY", guestLoginToken)

--- a/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/LoadingWheel.kt
+++ b/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/LoadingWheel.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
-// TODO 다른 로띠로 변경
+// TODO 다른 로띠로 변경, 배경을 투명하게 변경
 @Composable
 fun LoadingWheel(
   progressColor: Color,

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
@@ -156,16 +156,16 @@ internal fun HomeScreen(
   )
   // TODO 데이터 연동(BandalartDetail 에 emoji 데이터가 추가된 이후에)
   var currentEmoji by remember { mutableStateOf(bandalartDetailData.profileEmoji) }
-  // val testBandalartKey = "JWjMl"
-  val testBandalartKey = "b_EFS"
+  // TODO 제거
+  val testBandalartKey = "JWjMl"
 
   LaunchedEffect(key1 = Unit) {
-    getBandalartDetail(testBandalartKey)
-    // getBandalartDetail("K3mLJ")
+    getBandalartList()
   }
 
   LaunchedEffect(key1 = uiState.bottomSheetDataChanged) {
     if (uiState.bottomSheetDataChanged) {
+      // TODO 뷰모델 내부에서 bandalartList[0].key 로 접근하는 방법으로 함수 변경 필요
       getBandalartDetail(testBandalartKey)
     }
   }

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeViewModel.kt
@@ -84,11 +84,13 @@ class HomeViewModel @Inject constructor(
       val result = getBandalartListUseCase()
       when {
         result.isSuccess && result.getOrNull() != null -> {
+          val bandalartList = result.getOrNull()!!.map { it.toUiModel() }
           _uiState.value = _uiState.value.copy(
             isLoading = false,
-            bandalartList = result.getOrNull()!!.map { it.toUiModel() },
+            bandalartList = bandalartList,
             error = null,
           )
+          getBandalartDetail(bandalartList[0].key)
         }
         // TODO 해당 케이스의 대한 처리 유무 결정
         result.isSuccess && result.getOrNull() == null -> {
@@ -110,7 +112,7 @@ class HomeViewModel @Inject constructor(
 
   fun getBandalartDetail(bandalartKey: String) {
     viewModelScope.launch {
-//      _uiState.value = _uiState.value.copy(isLoading = true)
+      _uiState.value = _uiState.value.copy(isLoading = true)
       val result = getBandalartDetailUseCase(bandalartKey)
       when {
         result.isSuccess && result.getOrNull() != null -> {

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeViewModel.kt
@@ -112,7 +112,7 @@ class HomeViewModel @Inject constructor(
 
   fun getBandalartDetail(bandalartKey: String) {
     viewModelScope.launch {
-      _uiState.value = _uiState.value.copy(isLoading = true)
+      // _uiState.value = _uiState.value.copy(isLoading = true)
       val result = getBandalartDetailUseCase(bandalartKey)
       when {
         result.isSuccess && result.getOrNull() != null -> {


### PR DESCRIPTION
임의의 반다라트 키를 통해 화면을 구성하는 것이 아닌, 목록 조회를 통해 가지고 있는 반다라트 표 목록을 조회

목록 중에 첫번째 인덱스의 표를 통해 화면을 구성하도록

첫 로그인의 경우 이와 다르게 표를 서버에서 발급받은 키로 표를 하나 생성하는 방식으로(이후는 위의 플로우와 같음)

// TODO 홈화면 내에서 testBandalartKey를 사용하는 부분을 전부 제거해야할듯해 

// TODO 로딩바 배경만 투명하게

// 동기적으로 호출되어 딜레이가 늘어나는 현재 api 호출 방식 병렬적으로 변경할 수 있는 부분들을 찾아 딜레이를 줄이기
