### PR TITLE
버그 및 필요 없는 코드 수정

### DIFF
--- a/app/src/main/kotlin/com/nexters/bandalart/android/MainViewModel.kt
+++ b/app/src/main/kotlin/com/nexters/bandalart/android/MainViewModel.kt
@@ -47,9 +47,6 @@ class MainViewModel @Inject constructor(
 
   private fun getGuestLoginToken() {
     viewModelScope.launch {
-      _uiState.value = _uiState.value.copy(
-        isLoading = true,
-      )
       val guestLoginToken = getGuestLoginTokenUseCase()
       Timber.d(guestLoginToken)
       if (guestLoginToken.isEmpty()) {

--- a/app/src/main/res/values/splash.xml
+++ b/app/src/main/res/values/splash.xml
@@ -3,7 +3,6 @@
 
   <style name="Theme.Bandalart.Splash" parent="Theme.SplashScreen">
     <item name="windowSplashScreenBackground">#FFFFFF</item>
-    <!--    스플래시 아이콘은 여기에 추가 해주면 됨-->
     <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_round</item>
     <item name="postSplashScreenTheme">@style/Theme.Bandalart</item>
   </style>

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
@@ -6,8 +6,6 @@ import android.content.Intent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -25,6 +23,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
@@ -248,13 +247,12 @@ internal fun HomeScreen(
     color = Gray50,
   ) {
     Box(
-      modifier = Modifier
-        .fillMaxSize()
-        .scrollable(scrollState, Orientation.Vertical),
+      modifier = Modifier.fillMaxSize()
     ) {
       Column(
         modifier = Modifier
           .fillMaxSize()
+          .verticalScroll(scrollState)
           .padding(bottom = 32.dp),
       ) {
         HomeTopBar(
@@ -488,6 +486,7 @@ internal fun HomeScreen(
             )
           }
         }
+        Spacer(modifier = Modifier.height(64.dp))
         Spacer(modifier = Modifier.weight(1f))
         Box(
           modifier = Modifier

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeScreen.kt
@@ -246,9 +246,7 @@ internal fun HomeScreen(
     modifier = modifier.fillMaxSize(),
     color = Gray50,
   ) {
-    Box(
-      modifier = Modifier.fillMaxSize()
-    ) {
+    Box(modifier = Modifier.fillMaxSize()) {
       Column(
         modifier = Modifier
           .fillMaxSize()

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeViewModel.kt
@@ -71,7 +71,6 @@ sealed class HomeUiEvent {
   data class ShowSnackbar(val message: String) : HomeUiEvent()
 }
 
-@Suppress("unused")
 @HiltViewModel
 class HomeViewModel @Inject constructor(
   private val getBandalartListUseCase: GetBandalartListUseCase,

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/HomeViewModel.kt
@@ -91,13 +91,6 @@ class HomeViewModel @Inject constructor(
   private val _eventFlow = MutableSharedFlow<HomeUiEvent>()
   val eventFlow: SharedFlow<HomeUiEvent> = _eventFlow.asSharedFlow()
 
-  init {
-    _uiState.value = _uiState.value.copy(
-      isTopLoading = true,
-      isBottomLoading = true,
-    )
-  }
-
   fun getBandalartList(bandalartKey: String? = null) {
     viewModelScope.launch {
       _uiState.value = _uiState.value.copy(


### PR DESCRIPTION
스플래시에 로띠를 적용할 브랜치 였지만 실패하여

버그를 잡는데 기여하는 브랜치로 변경 

필요 없는 코드를 삭제하고, 홈화면에 스크롤을 활성화하여 공유하기 버튼이 화면이 작은 핸드폰에 대해서도 짤리지 않도록 대응, 또한 표와 버튼이 적절히 떨어져있도록 최소 간격 지정



