### PR TITLE
로딩 시 뒷 화면 클릭 블록

### DIFF
--- a/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/LoadingScreen.kt
+++ b/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/LoadingScreen.kt
@@ -18,13 +18,14 @@ import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
+import com.nexters.bandalart.android.core.ui.extension.noRippleClickable
 import com.nexters.bandalart.android.core.ui.theme.Black
 import com.nexters.bandalart.android.core.ui.theme.White
 
 @Composable
 fun LoadingScreen(modifier: Modifier = Modifier) {
   Box(
-    modifier = modifier,
+    modifier = modifier.noRippleClickable { },
     contentAlignment = Alignment.Center,
   ) {
     val composition by rememberLottieComposition(


### PR DESCRIPTION
빈 noRippleClickable으로 막음