### PR TITLE
사용하지 않는 의존성 제거

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     projects.feature.onboarding,
     libs.androidx.splash,
     libs.androidx.startup,
-    libs.androidx.appcompat,
     libs.androidx.core,
     libs.androidx.hilt.compose.navigation,
     libs.androidx.splash,

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -19,7 +19,6 @@ android {
 dependencies {
   implementations(
     libs.androidx.core,
-    libs.androidx.appcompat,
     libs.bundles.androidx.compose
   )
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
     projects.core.designsystem,
     libs.kotlinx.datetime,
     libs.androidx.core,
-    libs.androidx.appcompat,
     libs.lottie.compose,
     libs.bundles.androidx.compose,
   )

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,9 +17,7 @@ kotlinx-serialization = "1.5.1"
 
 android-hilt = "2.47"
 
-androidx-appcompat = "1.6.1"
 androidx-core = "1.10.1"
-androidx-constraintlayout = "2.1.4"
 androidx-datastore = "1.0.0"
 androidx-lifecycle-runtime = "2.6.1"
 androidx-splash = "1.0.1"
@@ -33,15 +31,11 @@ androidx-compose-constraintlayout = "1.0.1"
 androidx-compose-navigation = "2.7.0"
 androidx-hilt-navigation-compose = "1.0.0"
 
-coil = "2.4.0"
 desugar-jdk = "2.0.3"
 javax-inject = "1"
 ktor-client = "2.3.3"
 lottie-compose = "5.2.0"
 timber = "5.0.1"
-junit = "4.13.2"
-androidx-test-ext-junit = "1.1.5"
-espresso-core = "3.5.1"
 facebook-shimmer = "0.5.0"
 firebase-bom = "32.2.2"
 firebase-crashlytics = "2.9.2"
@@ -61,7 +55,6 @@ kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime",
 android-hilt-compile = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "android-hilt" }
 android-hilt-runtime = { group = "com.google.dagger", name = "hilt-android", version.ref = "android-hilt" }
 
-androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }
 androidx-core = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidx.datastore" }
 androidx-hilt-compose-navigation = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "androidx-hilt-navigation-compose" }
@@ -73,7 +66,6 @@ androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lif
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle-runtime" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-compose-bom" }
 androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }
-androidx-compose-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout-compose", version.ref = "androidx-compose-constraintlayout" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout" }
 androidx-compose-material-iconsExtended = { group = "androidx.compose.material", name = "material-icons-extended" }
@@ -93,18 +85,11 @@ ktor-client-json = { group = "io.ktor", name = "ktor-client-json", version.ref =
 ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor-client" }
 ktor-serialization = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor-client" }
 
-coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
-coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
-coil-svg = { group = "io.coil-kt", name = "coil-svg", version.ref = "coil" }
-
 desugar-jdk = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugar-jdk" }
 detekt-plugin-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "kotlin-detekt" }
 javax-inject = { group = "javax.inject", name = "javax.inject", version.ref = "javax-inject" }
 lottie-compose = { group = "com.airbnb.android", name = "lottie-compose", version.ref = "lottie-compose" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
-androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 facebook-shimmer = { group = "com.facebook.shimmer", name = "shimmer", version.ref = "facebook-shimmer" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics-ktx" }
@@ -142,7 +127,6 @@ androidx-compose = [
     "androidx-compose-material3",
     "androidx-compose-runtime",
     "androidx-compose-runtime-tracing",
-    "androidx-compose-constraintlayout",
     "androidx-compose-navigation",
     "androidx-compose-ui-tooling-preview",
     "androidx-compose-ui-util",
@@ -161,10 +145,4 @@ ktor-client = [
     "ktor-client-json",
     "ktor-client-logging",
     "ktor-serialization",
-]
-
-coil = [
-    "coil",
-    "coil-compose",
-    "coil-svg",
 ]


### PR DESCRIPTION
appcompat - 현재 Android 기존의 뷰 시스템을 사용하지 않으므로 제거
constraintLayout - Compose ConstraintLayout 사용할 것으로 예상하고 추가해놓았으나, 결과적으로 사용하지 않음
coil - 서버에서 동적으로 image url 을 받아서 이를 렌더링 하지 않으므로 제거
junit, espresso - 기본적으로 모듈을 만들때 만들어지는 테스트 관련 의존성 제거 

이들을 제거하고 빌드했을 경우 정상적으로 빌드되는 것을 확인