### PR TITLE
debug 앱과 release 앱을 분리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,13 @@ android {
   }
 
   buildTypes {
+    getByName("debug") {
+      applicationIdSuffix = ".dev"
+      manifestPlaceholders += mapOf(
+        "appName" to "@string/app_name_dev"
+      )
+    }
+
     getByName("release") {
       isDebuggable = false
       isMinifyEnabled = true
@@ -33,6 +40,9 @@ android {
         "proguard-rules.pro"
       )
       signingConfig = signingConfigs.getByName("release")
+      manifestPlaceholders += mapOf(
+        "appName" to "@string/app_name"
+      )
     }
   }
 

--- a/app/src/debug/google-services.json
+++ b/app/src/debug/google-services.json
@@ -1,0 +1,47 @@
+{
+  "project_info": {
+    "project_number": "197590766195",
+    "project_id": "bandalart-e0288",
+    "storage_bucket": "bandalart-e0288.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:197590766195:android:6e7a024f76678038179006",
+        "android_client_info": {
+          "package_name": "com.nexters.bandalart.android.dev"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "197590766195-gu7oadddf14doo77tnbecgji41c43sil.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "com.nexters.bandalart.android.dev",
+            "certificate_hash": "f815bf3587470a6d12ccc191569e579132a87a68"
+          }
+        },
+        {
+          "client_id": "197590766195-qikbkeakavvvd0qvucr4j78siktfv647.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "AIzaSyAzAhCCMGscA_wEWQNEi_d-NxiuJSmJg_E"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "197590766195-qikbkeakavvvd0qvucr4j78siktfv647.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
     android:name=".BandalartApplication"
     android:allowBackup="true"
     android:icon="@mipmap/ic_launcher"
-    android:label="@string/app_name"
+    android:label="${appName}"
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"
     android:theme="@style/Theme.Bandalart"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
   <string name="app_name">반다라트</string>
+  <string name="app_name_dev">반다라트.dev</string>
   <string name="app_name_english">Bandalart</string>
 </resources>


### PR DESCRIPTION
debug 로 빌드시 앱의 package명 맨 뒤에 .dev가 붙어  다른 앱이라고 판단-> 기존의 앱을 삭제하지 않고 별도의 디버그용 앱이 설치되도록 변경 


![릴리즈 디버그](https://github.com/Nexters/BandalArt-Android/assets/51016231/31412ec2-3c79-444e-93bf-82468e4775e5)
