### PR TITLE
hilt ksp migration

### DIFF
--- a/build-logic/src/main/kotlin/build-logics.kt
+++ b/build-logic/src/main/kotlin/build-logics.kt
@@ -53,9 +53,9 @@ internal class AndroidLibraryPlugin : BuildLogicPlugin({
 internal class AndroidHiltPlugin : BuildLogicPlugin({
   applyPlugins(
     libs.findPlugin("android-hilt").get().get().pluginId,
-    Plugins.KotlinKapt,
+    Plugins.Ksp,
   )
-  dependencies.add("kapt", libs.findLibrary("android-hilt-compile").get())
+  dependencies.add("ksp", libs.findLibrary("android-hilt-compile").get())
   dependencies.add("implementation", libs.findLibrary("android-hilt-runtime").get())
 })
 

--- a/build-logic/src/main/kotlin/plugins.kt
+++ b/build-logic/src/main/kotlin/plugins.kt
@@ -3,8 +3,9 @@ internal object Plugins {
 
   const val KotlinJvm = "org.jetbrains.kotlin.jvm"
   const val KotlinAndroid = "org.jetbrains.kotlin.android"
-  const val KotlinKapt = "org.jetbrains.kotlin.kapt"
 
   const val AndroidApplication = "com.android.application"
   const val AndroidLibrary = "com.android.library"
+
+  const val Ksp = "com.google.devtools.ksp"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ plugins {
   alias(libs.plugins.kotlin.android) apply false
   alias(libs.plugins.google.service) apply false
   alias(libs.plugins.firebase.crashlytics) apply false
+  alias(libs.plugins.ksp) apply false
 }
 
 buildscript {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -117,7 +117,6 @@ google-service = { id = "com.google.gms.google-services", version.ref = "google-
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin-core" }
 kotlin-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "kotlin-detekt" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin-core" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin-core" }
 kotlin-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "kotlin-ktlint-gradle" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin-core" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ timber = "5.0.1"
 facebook-shimmer = "0.5.0"
 firebase-bom = "32.2.2"
 firebase-crashlytics = "2.9.2"
+ksp = "1.8.22-1.0.11"
 
 [libraries]
 
@@ -55,7 +56,7 @@ kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
-kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable"}
+kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
 
 android-hilt-compile = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "android-hilt" }
 android-hilt-runtime = { group = "com.google.dagger", name = "hilt-android", version.ref = "android-hilt" }
@@ -127,6 +128,7 @@ android-library = { id = "com.android.library", version.ref = "android-gradle-pl
 android-hilt = { id = "com.google.dagger.hilt.android", version.ref = "android-hilt" }
 
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebase-crashlytics" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 
 [bundles]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ okhttp = "5.0.0-alpha.11"
 lottie-compose = "5.2.0"
 timber = "5.0.1"
 facebook-shimmer = "0.5.0"
-firebase-bom = "32.2.2"
+firebase-bom = "32.2.3"
 firebase-crashlytics = "2.9.2"
 ksp = "1.8.22-1.0.11"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kotlinx-serialization = "1.5.1"
 kotlinx-serialization-converter = "1.0.0"
 kotlinx-collections-immutable = "0.3.5"
 
-android-hilt = "2.47"
+android-hilt = "2.48"
 
 androidx-core = "1.10.1"
 androidx-datastore = "1.0.0"


### PR DESCRIPTION
hilt version 2.48 버전에서 ksp 를 지원하게 되어
https://github.com/google/dagger/releases/tag/dagger-2.48

기존의 kapt 를 ksp 로 migration

chore: library version upgrade

