### PR TITLE
다국어 지원 적용

### DIFF
--- a/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/BandalartDeleteAlertDialog.kt
+++ b/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/BandalartDeleteAlertDialog.kt
@@ -103,7 +103,7 @@ fun BandalartDeleteAlertDialog(
             ),
           ) {
             Text(
-              text = context.getString(R.string.delete_bandalart_cancle),
+              text = context.getString(R.string.delete_bandalart_cancel),
               fontSize = 16.sp.nonScaleSp,
               fontWeight = FontWeight.W600,
               color = Gray900,

--- a/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/bottomsheet/BottomSheetButton.kt
+++ b/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/bottomsheet/BottomSheetButton.kt
@@ -5,11 +5,13 @@ import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.IconButtonColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.nexters.bandalart.android.core.designsystem.theme.Gray200
 import com.nexters.bandalart.android.core.designsystem.theme.Gray400
 import com.nexters.bandalart.android.core.designsystem.theme.Gray900
 import com.nexters.bandalart.android.core.designsystem.theme.White
+import com.nexters.bandalart.android.core.ui.R
 
 @Composable
 fun BottomSheetDeleteButton(
@@ -22,7 +24,7 @@ fun BottomSheetDeleteButton(
     modifier = modifier.height(56.dp),
   ) {
     BottomSheetButtonText(
-      text = "삭제",
+      text = stringResource(R.string.bottomsheet_delete),
       color = Gray900,
     )
   }
@@ -41,7 +43,7 @@ fun BottomSheetCompleteButton(
     enabled = !isBlankCell,
   ) {
     BottomSheetButtonText(
-      text = "완료",
+      text = stringResource(R.string.bottomsheet_done),
       color = if (isBlankCell) Gray400 else White,
     )
   }

--- a/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/bottomsheet/BottomSheetText.kt
+++ b/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/bottomsheet/BottomSheetText.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
@@ -11,6 +12,7 @@ import com.nexters.bandalart.android.core.ui.component.FixedSizeText
 import com.nexters.bandalart.android.core.designsystem.theme.Gray400
 import com.nexters.bandalart.android.core.designsystem.theme.Gray600
 import com.nexters.bandalart.android.core.designsystem.theme.Gray900
+import com.nexters.bandalart.android.core.ui.R
 
 @Composable
 fun BottomSheetTitleText(
@@ -22,12 +24,12 @@ fun BottomSheetTitleText(
   FixedSizeText(
     text =
     if (isBlankCell)
-      if (isMainCell) "메인목표 입력"
-      else if (isSubCell) "서브목표 입력"
-      else "태스크 입력"
-    else if (isMainCell) "메인목표 수정"
-    else if (isSubCell) "서브목표 수정"
-    else "태스크 수정",
+      if (isMainCell) stringResource(id = R.string.bottomsheet_header_maincell_enter_title)
+      else if (isSubCell) stringResource(id = R.string.bottomsheet_header_subcell_enter_title)
+      else stringResource(id = R.string.bottomsheet_header_taskcell_enter_title)
+    else if (isMainCell) stringResource(id = R.string.bottomsheet_header_maincell_edit_title)
+    else if (isSubCell) stringResource(id = R.string.bottomsheet_header_subcell_edit_title)
+    else stringResource(id = R.string.bottomsheet_header_taskcell_edit_title),
     modifier = modifier.fillMaxWidth(),
     textAlign = TextAlign.Center,
     color = Gray900,

--- a/core/ui/src/main/res/values-en/strings.xml
+++ b/core/ui/src/main/res/values-en/strings.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!-- OnBoardingScreen.kt -->
+  <string name="onboarding_first_title">Say goodbye to complex and overwhelming Mandalart!</string>
+  <string name="onboarding_second_title">Now, plan effortlessly with Bandalart!</string>
+  <string name="onboarding_start">Get Started</string>
+
+  <!-- CompleteScreen.kt -->
+  <string name="complete_title">You\'ve achieved all the goals in Bandalart. Truly amazing!</string>
+  <string name="complete_share">Share Link</string>
+  <string name="complete_chart">Completed Bandalart</string>
+  <string name="save_image">Save Image</string>
+
+  <!--  HomeScreen.kt -->
+  <string name="home_default_emoji">default emoji</string>
+  <string name="home_share_url">제가 만든 반다라트를 구경하러오세요!\n%1$s</string>
+  <string name="home_share_type">text/plain</string>
+  <string name="home_empty_title">Please enter your main goal</string>
+  <string name="home_complete_ratio">Completion Rate %1$d%%</string>
+  <string name="home_complete">All Goals Completed!</string>
+  <string name="home_share">Share</string>
+
+  <!-- BandalartChart.kt -->
+  <string name="home_layout_id">Sub %1$d</string>
+  <string name="home_sub1_id">Sub 1</string>
+  <string name="home_sub2_id">Sub 2</string>
+  <string name="home_sub3_id">Sub 3</string>
+  <string name="home_sub4_id">Sub 4</string>
+  <string name="home_main_id">Main</string>
+
+  <!-- BandalartCell.kt -->
+  <string name="home_main_cell">Main Goal</string>
+  <string name="home_sub_cell">Sub Goal</string>
+
+  <!-- HomeTopbar.kt -->
+  <string name="home_list">List</string>
+  <string name="home_add">Add</string>
+
+  <!--  BandalartListBottomSheet.kt -->
+  <string name="bandalart_list_empty_title">New Bandalart %1$d</string>
+  <string name="bandalart_list_title">Bandalart List</string>
+  <string name="bandalart_list_add">Add a Bandalart</string>
+
+  <!-- BandalartDropDownMenu.kt -->
+  <string name="dropdown_delete">Delete</string>
+
+  <!--  BandalartBottomSheet.kt -->
+  <string name="bottomsheet_title">Goal Name (Required)</string>
+  <string name="bottomsheet_title_placeholder">Enter within 15 characters</string>
+  <string name="bottomsheet_color">Color Theme</string>
+  <string name="bottomsheet_duedate">Due Date (Optional)</string>
+  <string name="bottomsheet_duedate_placeholder">Please select a due date</string>
+  <string name="bottomsheet_description">Notes (Optional)</string>
+  <string name="bottomsheet_description_placeholder">Please enter notes</string>
+  <string name="bottomsheet_is_completed">Achievement Status</string>
+  <string name="bottomsheet_completed">Achieved</string>
+  <string name="bottomsheet_in_completed">Not Achieved</string>
+
+  <!-- BandalartDatePicker.kt -->
+  <string name="datepicker_year">%1$s year</string>
+  <string name="datepicker_month">%1$s month</string>
+  <string name="datepicker_day">%1$s day</string>
+
+  <!-- BandalartDeleteAlertDialog -->
+  <string name="delete_bandalart_dialog_empty_title">Do you want to delete the Bandalart?</string>
+  <string name="delete_bandalart_dialog_title">Do you want to delete the &quot;%1$s&quot; Bandalart?</string>
+  <string name="delete_bandalart_dialog_message">Deleted Bandalart cannot be restored</string>
+
+  <string name="delete_bandalart_maincelll_dialog_empty_title">Do you want to delete the main goal?</string>
+  <string name="delete_bandalart_maincell_dialog_title">Do you want to delete the main goal &quot;%1$s&quot;?</string>
+  <string name="delete_bandalart_maincell_dialog_message">Sub goals and tasks will all be deleted</string>
+
+  <string name="delete_bandalart_subcell_dialog_empty_title">Do you want to delete the sub goal?</string>
+  <string name="delete_bandalart_subcell_dialog_title">Do you want to delete the sub goal &quot;%1$s&quot;?</string>
+  <string name="delete_bandalart_subcell_dialog_message">All associated tasks will be deleted.</string>
+
+  <string name="delete_bandalart_taskcell_dialog_title">Do you want to delete the task &quot;%1$s&quot;?</string>
+  <string name="delete_bandalart_taskcell_dialog_message">Deleted content cannot be restored.</string>
+
+  <string name="delete_bandalart_delete">Delete</string>
+  <string name="delete_bandalart_cancel">Cancel</string>
+
+  <!-- NetworkErrorAlertDialog -->
+  <string name="network_error_dialog_title">Failed to load Bandalart due to network issues.</string>
+  <string name="network_error_dialog_message">Please try again.</string>
+  <string name="network_error_retry_message">Retry</string>
+
+  <!-- BandalartSkeletonScreen.kt-->
+  <string name="skeleton_title">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</string>
+  <string name="skeleton_complete_ratio">Completion Rate (-%)</string>
+
+
+  <!-- HomeScreenViewModel.kt, BandalartBottomSheetViewModel.kt -->
+  <string name="data_validation">Request succeeded but data validation failed</string>
+  <string name="create_bandalart">Created a new bandalart.</string>
+  <string name="limit_create_bandalart">You can create up to 5 bandalarts.</string>
+  <string name="delete_bandalart">Bandalart deleted.</string>
+
+  <!-- image descrption -->
+  <string name="empty_emoji_descrption">Empty Emoji Icon</string>
+  <string name="edit_descrption">Edit Icon</string>
+  <string name="arrow_forward_descrption">Arrow Forward Icon</string>
+  <string name="option_descrption">Option Icon</string>
+  <string name="check_descrption">Check Icon</string>
+  <string name="share_descrption">Share Icon</string>
+  <string name="add_descrption">Add Icon</string>
+  <string name="complete_descrption">Complete Icon</string>
+  <string name="app_descrption">App Title</string>
+  <string name="hamburger_descrption">Hamburger Icon</string>
+  <string name="clear_descrption">Clear Icon</string>
+  <string name="delete_descrption">Delete Icon</string>
+  <string name="splash_description">Splash Icon</string>
+
+  <!--  label -->
+  <string name="skeleton_trans_animate_label">Hamburger Icon</string>
+
+</resources>

--- a/core/ui/src/main/res/values-en/strings.xml
+++ b/core/ui/src/main/res/values-en/strings.xml
@@ -45,6 +45,12 @@
   <string name="dropdown_delete">Delete</string>
 
   <!--  BandalartBottomSheet.kt -->
+  <string name="bottomsheet_header_maincell_enter_title">Enter Main Goal</string>
+  <string name="bottomsheet_header_maincell_edit_title">Edit Main Goal</string>
+  <string name="bottomsheet_header_subcell_enter_title">Enter Sub Goal</string>
+  <string name="bottomsheet_header_subcell_edit_title">Edit Sub Goal</string>
+  <string name="bottomsheet_header_taskcell_enter_title">Enter Task</string>
+  <string name="bottomsheet_header_taskcell_edit_title">Edit Task</string>
   <string name="bottomsheet_title">Goal Name (Required)</string>
   <string name="bottomsheet_title_placeholder">Enter within 15 characters</string>
   <string name="bottomsheet_color">Color Theme</string>
@@ -55,6 +61,8 @@
   <string name="bottomsheet_is_completed">Achievement Status</string>
   <string name="bottomsheet_completed">Achieved</string>
   <string name="bottomsheet_in_completed">Not Achieved</string>
+  <string name="bottomsheet_delete">Delete</string>
+  <string name="bottomsheet_done">Done</string>
 
   <!-- BandalartDatePicker.kt -->
   <string name="datepicker_year">%1$s year</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -62,15 +62,23 @@
   <string name="datepicker_day">%1$s일</string>
 
 <!-- BandalartDeleteAlertDialog -->
-  <string name="delete_bandalart_dialog_empty_title">지금 작성중인\n반다라트를 삭제하시겠어요?</string>
-  <string name="delete_bandalart_dialog_title">%1$s\n반다라트를 삭제하시겠어요?</string>
-  <string name="delete_bandalart_dialog_message">삭제된 반다라트는 다시 복구할 수 없어요.</string>
-  <string name="delete_bandalart_cell_dialog_title">해당 셀을 삭제하시겠어요?</string>
-  <string name="delete_bandalart_maincell_dialog_message">메인 목표 삭제는 반다라트 전체가 삭제되고\n다시 복구할 수 없어요.</string>
-  <string name="delete_bandalart_subcell_dialog_message">서브 목표 삭제는 하위 태스크와 함께 삭제되고\n다시 복구할 수 없어요.</string>
+  <string name="delete_bandalart_dialog_empty_title">반다라트를 삭제하시겠어요?</string>
+  <string name="delete_bandalart_dialog_title">\&apos;%1$s\&apos;\n반다라트를 삭제하시겠어요?</string>
+  <string name="delete_bandalart_dialog_message">삭제 반다라트는 다시 복구할 수 없어요.</string>
+
+  <string name="delete_bandalart_maincelll_dialog_empty_title">메인목표를 삭제하시겠어요?</string>
+  <string name="delete_bandalart_maincell_dialog_title">\&apos;%1$s\&apos;\n메인목표를 삭제하시겠어요?</string>
+  <string name="delete_bandalart_maincell_dialog_message">서브목표와 태스크들이 모두 삭제돼요</string>
+
+  <string name="delete_bandalart_subcell_dialog_empty_title">서브목표를 삭제하시겠어요?</string>
+  <string name="delete_bandalart_subcell_dialog_title">\&apos;%1$s\&apos;\n서브목표를 삭제하시겠어요?</string>
+  <string name="delete_bandalart_subcell_dialog_message">속해있는 하위 태스크들이 모두 삭제돼요</string>
+
+  <string name="delete_bandalart_taskcell_dialog_title">\&apos;%1$s\&apos;\n태스크를 삭제하시겠어요?</string>
   <string name="delete_bandalart_taskcell_dialog_message">삭제된 내용은 다시 복구할 수 없어요.</string>
+
   <string name="delete_bandalart_delete">삭제하기</string>
-  <string name="delete_bandalart_cancle">취소</string>
+  <string name="delete_bandalart_cancel">취소</string>
 
 <!-- NetworkErrorAlertDialog -->
   <string name="network_error_dialog_title">네트워크 문제로 표를\n불러오지 못했어요</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -55,6 +55,8 @@
   <string name="bottomsheet_is_completed">달성 여부</string>
   <string name="bottomsheet_completed">달성</string>
   <string name="bottomsheet_in_completed">미달성</string>
+  <string name="bottomsheet_delete">삭제</string>
+  <string name="bottomsheet_done">완료</string>
 
 <!-- BandalartDatePicker.kt -->
   <string name="datepicker_year">%1$s년</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -45,6 +45,12 @@
   <string name="dropdown_delete">삭제하기</string>
 
 <!--  BandalartBottomSheet.kt -->
+  <string name="bottomsheet_header_maincell_enter_title">메인목표 입력</string>
+  <string name="bottomsheet_header_maincell_edit_title">메인목표 수정</string>
+  <string name="bottomsheet_header_subcell_enter_title">서브목표 입력</string>
+  <string name="bottomsheet_header_subcell_edit_title">서브목표 수정</string>
+  <string name="bottomsheet_header_taskcell_enter_title">태스크 입력</string>
+  <string name="bottomsheet_header_taskcell_edit_title">태스크 수정</string>
   <string name="bottomsheet_title">목표 이름 (필수)</string>
   <string name="bottomsheet_title_placeholder">15자 이내로 입력해주세요</string>
   <string name="bottomsheet_color">색상 테마</string>
@@ -76,7 +82,8 @@
   <string name="delete_bandalart_subcell_dialog_title">\&apos;%1$s\&apos;\n서브목표를 삭제하시겠어요?</string>
   <string name="delete_bandalart_subcell_dialog_message">속해있는 하위 태스크들이 모두 삭제돼요</string>
 
-  <string name="delete_bandalart_taskcell_dialog_title">\&apos;%1$s\&apos;\n태스크를 삭제하시겠어요?</string>
+  <string name="delete_bandalart_taskcell_dialog_title">태스크를 삭제하시겠어요?</string>
+<!--  <string name="delete_bandalart_taskcell_dialog_title">\&apos;%1$s\&apos;\n태스크를 삭제하시겠어요?</string>-->
   <string name="delete_bandalart_taskcell_dialog_message">삭제된 내용은 다시 복구할 수 없어요.</string>
 
   <string name="delete_bandalart_delete">삭제하기</string>

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/BandalartBottomSheet.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/BandalartBottomSheet.kt
@@ -127,11 +127,13 @@ fun BandalartBottomSheet(
     LaunchedEffect(key1 = Unit) {
       viewModel.copyCellData(cellData = cellData)
     }
+
     LaunchedEffect(key1 = uiState.isCellDataCopied) {
       if (uiState.isCellDataCopied && uiState.cellData.title.isNullOrEmpty()) {
         focusRequester.requestFocus()
       }
     }
+
     LaunchedEffect(key1 = uiState.isCellUpdated) {
       if (uiState.isCellUpdated) {
         scope.launch {
@@ -141,6 +143,7 @@ fun BandalartBottomSheet(
         }
       }
     }
+
     LaunchedEffect(viewModel) {
       viewModel.eventFlow.collect { event ->
         when (event) {
@@ -150,9 +153,16 @@ fun BandalartBottomSheet(
         }
       }
     }
+
     if (uiState.isDeleteCellDialogOpened) {
       BandalartDeleteAlertDialog(
-        title = stringResource(R.string.delete_bandalart_cell_dialog_title),
+        title = if (isMainCell) {
+          stringResource(R.string.delete_bandalart_maincelll_dialog_empty_title)
+        } else if (isSubCell) {
+          stringResource(R.string.delete_bandalart_subcell_dialog_empty_title)
+        } else {
+          stringResource(R.string.delete_bandalart_taskcell_dialog_title)
+        },
         message = if (isMainCell) {
           stringResource(R.string.delete_bandalart_maincell_dialog_message)
         } else if (isSubCell) {

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BandalartDatePicker.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/ui/BandalartDatePicker.kt
@@ -102,7 +102,7 @@ fun BandalartDatePicker(
                 }
               }
           },
-        text = "완료",
+        text = stringResource(id = R.string.bottomsheet_done),
         color = Gray900,
         fontFamily = pretendard,
         fontWeight = FontWeight.W700,


### PR DESCRIPTION
하드코딩 된 텍스트 string 추가 및 참조 형태로 변환

TODO 메인목표, 서브목표, 태스크 삭제시 해당 셀의 title을 삭제 다이얼로그에 전달해서 ' ' 안에 담아야 함

TODO 토스트 메세지도 다국어 지원 적용 해야함 -> 스프레드 시트에 추가요청 완료

TODO 삭제 다이얼로그의 메세지 앞에 (!) 아이콘 추가되어서 해당 아이콘을 추가해줘야함  