### PR TITLE
온보딩 에러 처리 보완 및 화면 테블릿 대응

### DIFF
--- a/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/datasource/OnboardingDataSource.kt
+++ b/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/datasource/OnboardingDataSource.kt
@@ -1,0 +1,6 @@
+package com.nexters.bandalart.android.core.data.datasource
+
+interface OnboardingDataSource {
+  suspend fun setOnboardingCompletedStatus(flag: Boolean)
+  suspend fun getOnboardingCompletedStatus(): Boolean
+}

--- a/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/di/DataSourceModule.kt
+++ b/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/di/DataSourceModule.kt
@@ -4,9 +4,11 @@ import com.nexters.bandalart.android.core.data.datasource.BandalartRemoteDataSou
 import com.nexters.bandalart.android.core.data.datasource.CompletedBandalartKeyDataSource
 import com.nexters.bandalart.android.core.data.datasource.GuestLoginLocalDataSource
 import com.nexters.bandalart.android.core.data.datasource.GuestLoginRemoteDataSource
+import com.nexters.bandalart.android.core.data.datasource.OnboardingDataSource
 import com.nexters.bandalart.android.core.data.datasource.RecentBandalartKeyDataSource
 import com.nexters.bandalart.android.core.data.local.datasource.CompletedBandalartKeyDataStoreImpl
 import com.nexters.bandalart.android.core.data.local.datasource.GuestLoginLocalDataSourceImpl
+import com.nexters.bandalart.android.core.data.local.datasource.OnboardingDataSourceImpl
 import com.nexters.bandalart.android.core.data.local.datasource.RecentBandalartKeyDataSourceImpl
 import com.nexters.bandalart.android.core.data.remote.datasource.BandalartRemoteDataSourceImpl
 import com.nexters.bandalart.android.core.data.remote.datasource.GuestLoginRemoteDataSourceImpl
@@ -49,4 +51,10 @@ internal abstract class DataSourceModule {
   abstract fun bindCompletedBandalartKeyDataSource(
     completedBandalartKeyDataStoreImpl: CompletedBandalartKeyDataStoreImpl,
   ): CompletedBandalartKeyDataSource
+
+  @Binds
+  @Singleton
+  abstract fun bindOnboardingDataSource(
+    onboardingDataSourceImpl: OnboardingDataSourceImpl,
+  ): OnboardingDataSource
 }

--- a/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/di/RepositoryModule.kt
@@ -2,8 +2,10 @@ package com.nexters.bandalart.android.core.data.di
 
 import com.nexters.bandalart.android.core.data.repository.BandalartRepositoryImpl
 import com.nexters.bandalart.android.core.data.repository.GuestLoginTokenRepositoryImpl
+import com.nexters.bandalart.android.core.data.repository.OnboardingRepositoryImpl
 import com.nexters.bandalart.android.core.domain.repository.BandalartRepository
 import com.nexters.bandalart.android.core.domain.repository.GuestLoginTokenRepository
+import com.nexters.bandalart.android.core.domain.repository.OnboardingRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -25,4 +27,10 @@ internal abstract class RepositoryModule {
   abstract fun bindBandalartRepository(
     bandalartRepositoryImpl: BandalartRepositoryImpl,
   ): BandalartRepository
+
+  @Binds
+  @Singleton
+  abstract fun bindOnboardingRepository(
+    onboardingRepositoryImpl: OnboardingRepositoryImpl,
+  ): OnboardingRepository
 }

--- a/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/local/datasource/OnboardingDataSourceImpl.kt
+++ b/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/local/datasource/OnboardingDataSourceImpl.kt
@@ -1,0 +1,17 @@
+package com.nexters.bandalart.android.core.data.local.datasource
+
+import com.nexters.bandalart.android.core.data.datasource.OnboardingDataSource
+import com.nexters.bandalart.android.core.datastore.DataStoreProvider
+import javax.inject.Inject
+
+internal class OnboardingDataSourceImpl @Inject constructor(
+  private val datastoreProvider: DataStoreProvider,
+) : OnboardingDataSource {
+  override suspend fun setOnboardingCompletedStatus(flag: Boolean) {
+    datastoreProvider.setOnboardingCompletedStatus(flag)
+  }
+
+  override suspend fun getOnboardingCompletedStatus(): Boolean {
+    return datastoreProvider.getOnboardingCompletedStatus()
+  }
+}

--- a/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/repository/OnboardingRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/nexters/bandalart/android/core/data/repository/OnboardingRepositoryImpl.kt
@@ -1,0 +1,17 @@
+package com.nexters.bandalart.android.core.data.repository
+
+import com.nexters.bandalart.android.core.data.datasource.OnboardingDataSource
+import com.nexters.bandalart.android.core.domain.repository.OnboardingRepository
+import javax.inject.Inject
+
+internal class OnboardingRepositoryImpl @Inject constructor(
+  private val dataSource: OnboardingDataSource,
+) : OnboardingRepository {
+  override suspend fun setOnboardingCompletedStatus(flag: Boolean) {
+    dataSource.setOnboardingCompletedStatus(flag)
+  }
+
+  override suspend fun getOnboardingCompletedStatus(): Boolean {
+    return dataSource.getOnboardingCompletedStatus()
+  }
+}

--- a/core/datastore/src/main/kotlin/com/nexters/bandalart/android/core/datastore/DataStoreProvider.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/bandalart/android/core/datastore/DataStoreProvider.kt
@@ -2,6 +2,7 @@ package com.nexters.bandalart.android.core.datastore
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
@@ -16,15 +17,17 @@ class DataStoreProvider @Inject constructor(
   private val dataStore: DataStore<Preferences>,
 ) {
 
-  companion object {
+  private companion object {
     private const val GUEST_LOGIN_TOKEN = "guest_login_token"
     private const val RECENT_BANDALART_KEY = "recent_bandalart_key"
     private const val COMPLETED_BANDALART_LIST_KEY = "completed_bandalart_list_key"
+    private const val ONBOARDING_COMPLETED_KEY = "completed_onboarding_key"
   }
 
   private val prefKeyGuestLoginToken = stringPreferencesKey(GUEST_LOGIN_TOKEN)
   private val prefKeyRecentBandalartKey = stringPreferencesKey(RECENT_BANDALART_KEY)
   private val prefKeyCompletedBandalartList = stringPreferencesKey(COMPLETED_BANDALART_LIST_KEY)
+  private val prefKeyOnboardingCompletedKey = booleanPreferencesKey(ONBOARDING_COMPLETED_KEY)
 
   suspend fun setGuestLoginToken(guestLoginToken: String) {
     dataStore.edit { preferences ->
@@ -105,4 +108,16 @@ class DataStoreProvider @Inject constructor(
     if (data.isEmpty()) return emptyList()
     return Json.decodeFromString(data)
   }
+
+  suspend fun setOnboardingCompletedStatus(flag: Boolean) {
+    dataStore.edit { preferences ->
+      preferences[prefKeyOnboardingCompletedKey] = flag
+    }
+  }
+
+  suspend fun getOnboardingCompletedStatus() = dataStore.data
+    .catch { exception ->
+      if (exception is IOException) emit(emptyPreferences())
+      else throw exception
+    }.first()[prefKeyOnboardingCompletedKey] ?: false
 }

--- a/core/domain/src/main/kotlin/com/nexters/bandalart/android/core/domain/repository/OnboardingRepository.kt
+++ b/core/domain/src/main/kotlin/com/nexters/bandalart/android/core/domain/repository/OnboardingRepository.kt
@@ -1,0 +1,15 @@
+package com.nexters.bandalart.android.core.domain.repository
+
+interface OnboardingRepository {
+    /**
+     * 온보딩 완료 여부 저장
+     *
+     * @param flag true(완료), false(진행중)
+     */
+    suspend fun setOnboardingCompletedStatus(flag: Boolean)
+
+    /**
+     * 온보딩 완료 여부 조회
+     */
+    suspend fun getOnboardingCompletedStatus(): Boolean
+}

--- a/core/domain/src/main/kotlin/com/nexters/bandalart/android/core/domain/repository/OnboardingRepository.kt
+++ b/core/domain/src/main/kotlin/com/nexters/bandalart/android/core/domain/repository/OnboardingRepository.kt
@@ -1,15 +1,15 @@
 package com.nexters.bandalart.android.core.domain.repository
 
 interface OnboardingRepository {
-    /**
-     * 온보딩 완료 여부 저장
-     *
-     * @param flag true(완료), false(진행중)
-     */
-    suspend fun setOnboardingCompletedStatus(flag: Boolean)
+  /**
+   * 온보딩 완료 여부 저장
+   *
+   * @param flag true(완료), false(진행중)
+   */
+  suspend fun setOnboardingCompletedStatus(flag: Boolean)
 
-    /**
-     * 온보딩 완료 여부 조회
-     */
-    suspend fun getOnboardingCompletedStatus(): Boolean
+  /**
+   * 온보딩 완료 여부 조회
+   */
+  suspend fun getOnboardingCompletedStatus(): Boolean
 }

--- a/core/domain/src/main/kotlin/com/nexters/bandalart/android/core/domain/usecase/bandalart/GetOnboardingCompletedStatusUseCase.kt
+++ b/core/domain/src/main/kotlin/com/nexters/bandalart/android/core/domain/usecase/bandalart/GetOnboardingCompletedStatusUseCase.kt
@@ -12,4 +12,3 @@ class GetOnboardingCompletedStatusUseCase @Inject constructor(
     return repository.getOnboardingCompletedStatus()
   }
 }
-

--- a/core/domain/src/main/kotlin/com/nexters/bandalart/android/core/domain/usecase/bandalart/GetOnboardingCompletedStatusUseCase.kt
+++ b/core/domain/src/main/kotlin/com/nexters/bandalart/android/core/domain/usecase/bandalart/GetOnboardingCompletedStatusUseCase.kt
@@ -1,0 +1,15 @@
+package com.nexters.bandalart.android.core.domain.usecase.bandalart
+
+import com.nexters.bandalart.android.core.domain.repository.OnboardingRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class GetOnboardingCompletedStatusUseCase @Inject constructor(
+  private val repository: OnboardingRepository,
+) {
+  suspend operator fun invoke(): Boolean {
+    return repository.getOnboardingCompletedStatus()
+  }
+}
+

--- a/core/domain/src/main/kotlin/com/nexters/bandalart/android/core/domain/usecase/bandalart/SetOnboardingCompletedStatusUseCase.kt
+++ b/core/domain/src/main/kotlin/com/nexters/bandalart/android/core/domain/usecase/bandalart/SetOnboardingCompletedStatusUseCase.kt
@@ -1,0 +1,14 @@
+package com.nexters.bandalart.android.core.domain.usecase.bandalart
+
+import com.nexters.bandalart.android.core.domain.repository.OnboardingRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SetOnboardingCompletedStatusUseCase @Inject constructor(
+  private val repository: OnboardingRepository,
+) {
+  suspend operator fun invoke(flag: Boolean) {
+    repository.setOnboardingCompletedStatus(flag)
+  }
+}

--- a/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/BandalartButton.kt
+++ b/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/BandalartButton.kt
@@ -2,7 +2,6 @@ package com.nexters.bandalart.android.core.ui.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -26,19 +25,18 @@ fun BandalartButton(
 ) {
   Box(
     modifier = modifier
-      .fillMaxWidth()
-      .padding(horizontal = 24.dp)
+      .padding(horizontal = 24.dp, vertical = 16.dp)
       .height(56.dp)
       .clip(shape = RoundedCornerShape(50.dp))
       .clickableSingle(onClick = onClick)
-      .background(color = Gray900)
-      .padding(16.dp),
+      .background(color = Gray900),
     contentAlignment = Alignment.Center,
   ) {
     FixedSizeText(
       text = text,
       fontFamily = pretendard,
       fontWeight = FontWeight.W700,
+      modifier = Modifier.padding(horizontal = 32.dp),
       fontSize = 16.sp,
       color = White,
       letterSpacing = (-0.32).sp,

--- a/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/TitleText.kt
+++ b/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/component/TitleText.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
+import com.nexters.bandalart.android.core.designsystem.theme.Gray900
 import com.nexters.bandalart.android.core.ui.nonScaleSp
 import com.nexters.bandalart.android.core.designsystem.theme.pretendard
 
@@ -17,6 +18,7 @@ fun TitleText(
   Text(
     text = text,
     modifier = modifier,
+    color = Gray900,
     fontFamily = pretendard,
     fontWeight = FontWeight.W700,
     fontSize = 22.sp.nonScaleSp,

--- a/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/extension/Modifier.kt
+++ b/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/extension/Modifier.kt
@@ -53,30 +53,31 @@ fun Modifier.clickableSingle(
 }
 
 fun Modifier.aspectRatioBasedOnOrientation(aspectRatio: Float): Modifier {
-  return this.then(object : LayoutModifier {
-    override fun MeasureScope.measure(measurable: Measurable, constraints: Constraints): MeasureResult {
-      val width = constraints.maxWidth
-      val height = constraints.maxHeight
+  return this.then(
+    object : LayoutModifier {
+      override fun MeasureScope.measure(measurable: Measurable, constraints: Constraints): MeasureResult {
+        val width = constraints.maxWidth
+        val height = constraints.maxHeight
 
-      val targetWidth: Int
-      val targetHeight: Int
+        val targetWidth: Int
+        val targetHeight: Int
 
-      if (width <= height) {
-        targetWidth = width
-        targetHeight = (width / aspectRatio).toInt()
-      } else {
-        targetHeight = height
-        targetWidth = (height * aspectRatio).toInt()
+        if (width <= height) {
+          targetWidth = width
+          targetHeight = (width / aspectRatio).toInt()
+        } else {
+          targetHeight = height
+          targetWidth = (height * aspectRatio).toInt()
+        }
+
+        val placeable = measurable.measure(
+          Constraints.fixed(targetWidth, targetHeight),
+        )
+
+        return layout(placeable.width, placeable.height) {
+          placeable.placeRelative(0, 0)
+        }
       }
-
-      val placeable = measurable.measure(
-        Constraints.fixed(targetWidth, targetHeight)
-      )
-
-      return layout(placeable.width, placeable.height) {
-        placeable.placeRelative(0, 0)
-      }
-    }
-  })
+    },
+  )
 }
-

--- a/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/extension/Modifier.kt
+++ b/core/ui/src/main/kotlin/com/nexters/bandalart/android/core/ui/extension/Modifier.kt
@@ -7,8 +7,13 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
+import androidx.compose.ui.layout.LayoutModifier
+import androidx.compose.ui.layout.Measurable
+import androidx.compose.ui.layout.MeasureResult
+import androidx.compose.ui.layout.MeasureScope
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.Constraints
 import com.nexters.bandalart.android.core.ui.MultipleEventsCutter
 import com.nexters.bandalart.android.core.ui.get
 
@@ -46,3 +51,32 @@ fun Modifier.clickableSingle(
     interactionSource = remember { MutableInteractionSource() },
   )
 }
+
+fun Modifier.aspectRatioBasedOnOrientation(aspectRatio: Float): Modifier {
+  return this.then(object : LayoutModifier {
+    override fun MeasureScope.measure(measurable: Measurable, constraints: Constraints): MeasureResult {
+      val width = constraints.maxWidth
+      val height = constraints.maxHeight
+
+      val targetWidth: Int
+      val targetHeight: Int
+
+      if (width <= height) {
+        targetWidth = width
+        targetHeight = (width / aspectRatio).toInt()
+      } else {
+        targetHeight = height
+        targetWidth = (height * aspectRatio).toInt()
+      }
+
+      val placeable = measurable.measure(
+        Constraints.fixed(targetWidth, targetHeight)
+      )
+
+      return layout(placeable.width, placeable.height) {
+        placeable.placeRelative(0, 0)
+      }
+    }
+  })
+}
+

--- a/feature/complete/src/main/kotlin/com/nexters/bandalart/android/feature/complete/CompleteScreen.kt
+++ b/feature/complete/src/main/kotlin/com/nexters/bandalart/android/feature/complete/CompleteScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Surface
@@ -125,6 +126,7 @@ internal fun CompleteScreen(
             onClick = shareBandalart,
             text = context.getString(R.string.complete_share),
             modifier = Modifier
+              .fillMaxWidth()
               .align(Alignment.BottomCenter)
               .padding(bottom = 32.dp),
           )

--- a/feature/onboarding/build.gradle.kts
+++ b/feature/onboarding/build.gradle.kts
@@ -3,6 +3,7 @@
 plugins {
   bandalart("android-library")
   bandalart("android-compose")
+  bandalart("android-hilt")
 }
 
 android {

--- a/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingScreen.kt
+++ b/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingScreen.kt
@@ -46,6 +46,7 @@ import com.nexters.bandalart.android.core.ui.component.PagerIndicator
 import com.nexters.bandalart.android.core.util.extension.getCurrentLocale
 import java.util.Locale
 
+// TODO 테블릿 대응
 @Composable
 internal fun OnBoardingRoute(
   navigateToHome: (NavOptions) -> Unit,

--- a/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingScreen.kt
+++ b/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingScreen.kt
@@ -8,9 +8,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
@@ -34,19 +32,19 @@ import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.LottieConstants
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
-import com.nexters.bandalart.android.core.ui.R
-import com.nexters.bandalart.android.core.ui.component.BandalartButton
-import com.nexters.bandalart.android.core.ui.component.TitleText
 import com.nexters.bandalart.android.core.designsystem.theme.Gray50
 import com.nexters.bandalart.android.core.ui.ObserveAsEvents
+import com.nexters.bandalart.android.core.ui.R
 import com.nexters.bandalart.android.core.ui.component.AppEnglishTitle
 import com.nexters.bandalart.android.core.ui.component.AppKoreanTitle
-import com.nexters.bandalart.android.feature.onboarding.navigation.ONBOARDING_NAVIGATION_ROUTE
+import com.nexters.bandalart.android.core.ui.component.BandalartButton
 import com.nexters.bandalart.android.core.ui.component.PagerIndicator
+import com.nexters.bandalart.android.core.ui.component.TitleText
+import com.nexters.bandalart.android.core.ui.extension.aspectRatioBasedOnOrientation
 import com.nexters.bandalart.android.core.util.extension.getCurrentLocale
+import com.nexters.bandalart.android.feature.onboarding.navigation.ONBOARDING_NAVIGATION_ROUTE
 import java.util.Locale
 
-// TODO 테블릿 대응
 @Composable
 internal fun OnBoardingRoute(
   navigateToHome: (NavOptions) -> Unit,
@@ -150,8 +148,7 @@ internal fun OnBoardingScreen(
               ) {
                 Box(
                   modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(1f)
+                    .aspectRatioBasedOnOrientation(1f)
                     .background(Gray50),
                   contentAlignment = Alignment.Center,
                 ) {
@@ -206,8 +203,7 @@ internal fun OnBoardingScreen(
                 ) {
                   Box(
                     modifier = Modifier
-                      .fillMaxWidth()
-                      .aspectRatio(1f)
+                      .aspectRatioBasedOnOrientation(1f)
                       .background(Gray50),
                     contentAlignment = Alignment.Center,
                   ) {

--- a/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingScreen.kt
+++ b/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingScreen.kt
@@ -63,14 +63,14 @@ internal fun OnBoardingRoute(
   }
 
   OnBoardingScreen(
-    navigateToHome = viewModel::navigateToHome,
+    setOnboardingCompletedStatus = viewModel::setOnboardingCompletedStatus,
     modifier = modifier,
   )
 }
 
 @Composable
 internal fun OnBoardingScreen(
-  navigateToHome: () -> Unit,
+  setOnboardingCompletedStatus: (Boolean) -> Unit,
   modifier: Modifier = Modifier,
 ) {
   val context = LocalContext.current
@@ -216,7 +216,7 @@ internal fun OnBoardingScreen(
                 }
               }
               BandalartButton(
-                onClick = navigateToHome,
+                onClick = { setOnboardingCompletedStatus(true) },
                 text = context.getString(R.string.onboarding_start),
                 modifier = Modifier
                   .align(Alignment.BottomCenter)

--- a/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingScreen.kt
+++ b/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingScreen.kt
@@ -9,8 +9,10 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -22,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
@@ -75,6 +78,11 @@ internal fun OnBoardingScreen(
 ) {
   val context = LocalContext.current
   val currentLocale = context.getCurrentLocale()
+  val configuration = LocalConfiguration.current
+  val screenWidth = configuration.screenWidthDp.dp
+  val screenHeight = configuration.screenHeightDp.dp
+
+  val isLandscape = screenWidth > screenHeight
 
   when (currentLocale.language) {
     Locale.KOREAN.language -> {
@@ -215,13 +223,25 @@ internal fun OnBoardingScreen(
                   }
                 }
               }
-              BandalartButton(
-                onClick = { setOnboardingCompletedStatus(true) },
-                text = context.getString(R.string.onboarding_start),
-                modifier = Modifier
-                  .align(Alignment.BottomCenter)
-                  .padding(bottom = 32.dp),
-              )
+              if (isLandscape) {
+                BandalartButton(
+                  onClick = { setOnboardingCompletedStatus(true) },
+                  text = context.getString(R.string.onboarding_start),
+                  modifier = Modifier
+                    .wrapContentWidth()
+                    .align(Alignment.BottomEnd)
+                    .padding(bottom = 32.dp),
+                )
+              } else {
+                BandalartButton(
+                  onClick = { setOnboardingCompletedStatus(true) },
+                  text = context.getString(R.string.onboarding_start),
+                  modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = 32.dp),
+                )
+              }
             }
           }
         }

--- a/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingScreen.kt
+++ b/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingScreen.kt
@@ -50,7 +50,7 @@ import java.util.Locale
 internal fun OnBoardingRoute(
   navigateToHome: (NavOptions) -> Unit,
   modifier: Modifier = Modifier,
-  viewModel: SplashViewModel = hiltViewModel(),
+  viewModel: OnboardingViewModel = hiltViewModel(),
 ) {
   ObserveAsEvents(flow = viewModel.eventFlow) { event ->
     when (event) {

--- a/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingViewModel.kt
+++ b/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingViewModel.kt
@@ -14,7 +14,7 @@ sealed interface OnBoardingUiEvent {
 }
 
 @HiltViewModel
-class SplashViewModel @Inject constructor() : ViewModel() {
+class OnboardingViewModel @Inject constructor() : ViewModel() {
   private val _eventFlow = MutableSharedFlow<OnBoardingUiEvent>()
   val eventFlow: SharedFlow<OnBoardingUiEvent> = _eventFlow.asSharedFlow()
 

--- a/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingViewModel.kt
+++ b/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingViewModel.kt
@@ -2,6 +2,7 @@ package com.nexters.bandalart.android.feature.onboarding
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.nexters.bandalart.android.core.domain.usecase.bandalart.SetOnboardingCompletedStatusUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -14,11 +15,20 @@ sealed interface OnBoardingUiEvent {
 }
 
 @HiltViewModel
-class OnboardingViewModel @Inject constructor() : ViewModel() {
+class OnboardingViewModel @Inject constructor(
+  private val setOnboardingCompletedStatusUseCase: SetOnboardingCompletedStatusUseCase,
+) : ViewModel() {
   private val _eventFlow = MutableSharedFlow<OnBoardingUiEvent>()
   val eventFlow: SharedFlow<OnBoardingUiEvent> = _eventFlow.asSharedFlow()
 
-  fun navigateToHome() {
+  fun setOnboardingCompletedStatus(flag: Boolean) {
+    viewModelScope.launch {
+      setOnboardingCompletedStatusUseCase(flag)
+      navigateToHome()
+    }
+  }
+
+  private fun navigateToHome() {
     viewModelScope.launch {
       _eventFlow.emit(OnBoardingUiEvent.NavigateToHome)
     }

--- a/feature/splash/src/main/kotlin/com/nexters/bandalart/android/feature/splash/SplashScreen.kt
+++ b/feature/splash/src/main/kotlin/com/nexters/bandalart/android/feature/splash/SplashScreen.kt
@@ -91,11 +91,15 @@ fun SplashScreen(
       )
     }
 
-    !uiState.isLoggedIn && uiState.isLoginTokenCreated -> {
+    !uiState.isLoggedIn && uiState.isGuestLoginTokenCreated -> {
       navigateToOnBoarding()
     }
 
-    uiState.isLoggedIn -> {
+    !uiState.isOnboardingCompleted -> {
+      navigateToOnBoarding()
+    }
+
+    uiState.isLoggedIn && uiState.isOnboardingCompleted -> {
       navigateToHome()
     }
   }

--- a/feature/splash/src/main/kotlin/com/nexters/bandalart/android/feature/splash/SplashScreen.kt
+++ b/feature/splash/src/main/kotlin/com/nexters/bandalart/android/feature/splash/SplashScreen.kt
@@ -91,6 +91,7 @@ fun SplashScreen(
       )
     }
 
+    // TODO 에러처리 보완
     !uiState.isLoggedIn -> {
       navigateToOnBoarding()
     }

--- a/feature/splash/src/main/kotlin/com/nexters/bandalart/android/feature/splash/SplashScreen.kt
+++ b/feature/splash/src/main/kotlin/com/nexters/bandalart/android/feature/splash/SplashScreen.kt
@@ -91,8 +91,7 @@ fun SplashScreen(
       )
     }
 
-    // TODO 에러처리 보완
-    !uiState.isLoggedIn -> {
+    !uiState.isLoggedIn && uiState.isLoginTokenCreated -> {
       navigateToOnBoarding()
     }
 

--- a/feature/splash/src/main/kotlin/com/nexters/bandalart/android/feature/splash/SplashViewModel.kt
+++ b/feature/splash/src/main/kotlin/com/nexters/bandalart/android/feature/splash/SplashViewModel.kt
@@ -23,12 +23,14 @@ import javax.inject.Inject
  * SplashUiState
  *
  * @param isLoggedIn 로그인 여부 확인
+ * @param isLoginTokenCreated 로그인 토큰 생성 확인
  * @param isNetworkErrorAlertDialogOpened 네트워크 에러 발생
  * @param isLoading 서버와의 통신 중 로딩 상태
  */
 
 data class SplashUiState(
   val isLoggedIn: Boolean = false,
+  val isLoginTokenCreated: Boolean = false,
   val isNetworkErrorAlertDialogOpened: Boolean = false,
   val isLoading: Boolean = true,
 )
@@ -68,6 +70,7 @@ class SplashViewModel @Inject constructor(
         _uiState.update {
           it.copy(
             isLoggedIn = true,
+            isLoginTokenCreated = true,
             isLoading = false,
           )
         }
@@ -87,7 +90,12 @@ class SplashViewModel @Inject constructor(
         result.isSuccess && result.getOrNull() != null -> {
           val newGuestLoginToken = result.getOrNull()!!
           setGuestLoginTokenUseCase(newGuestLoginToken.key)
-          _uiState.update { it.copy(isLoggedIn = false) }
+          _uiState.update {
+            it.copy(
+              isLoggedIn = false,
+              isLoginTokenCreated = true,
+            )
+          }
           createBandalartUseCase()
         }
 
@@ -96,7 +104,13 @@ class SplashViewModel @Inject constructor(
         }
 
         result.isFailure -> {
-          _uiState.update { it.copy(isNetworkErrorAlertDialogOpened = true) }
+          _uiState.update {
+            it.copy(
+              isLoggedIn = false,
+              isLoginTokenCreated = false,
+              isNetworkErrorAlertDialogOpened = true,
+            )
+          }
         }
       }
       _uiState.update { it.copy(isLoading = false) }

--- a/feature/splash/src/main/kotlin/com/nexters/bandalart/android/feature/splash/SplashViewModel.kt
+++ b/feature/splash/src/main/kotlin/com/nexters/bandalart/android/feature/splash/SplashViewModel.kt
@@ -62,14 +62,15 @@ class SplashViewModel @Inject constructor(
   private fun getGuestLoginToken() {
     viewModelScope.launch {
       val guestLoginToken = getGuestLoginTokenUseCase()
-      Timber.d(guestLoginToken)
       if (guestLoginToken.isEmpty()) {
         createGuestLoginToken()
       } else {
-        _uiState.value = _uiState.value.copy(
-          isLoggedIn = true,
-          isLoading = false,
-        )
+        _uiState.update {
+          it.copy(
+            isLoggedIn = true,
+            isLoading = false,
+          )
+        }
       }
     }
   }


### PR DESCRIPTION
- 로그인 토큰을 정상적으로 발급받지 못할 경우 온보딩 화면에도 진입하지 못하도록 설정(네트워크 에러 다이얼로그 호출)
- 온보딩을 완료해야지만 홈화면으로 이동할 수 있도록 온보딩 완료 여부 확인 로직 추가
- 온보딩 화면 태블릿 대응 

|이전 1|이전  2|
|:-----:|:-----:|
|<img width="360" src="https://github.com/Nexters/BandalArt-Android/assets/51016231/c5d93bf9-b321-4c6e-a692-99a67953d004">|<img width="360" src="https://github.com/Nexters/BandalArt-Android/assets/51016231/89ad5381-1441-4c69-951b-fe9b96928008">|

|이후 1|이후 2|
|:-----:|:-----:|
|<img width="360" src="https://github.com/Nexters/BandalArt-Android/assets/51016231/86116f23-9201-4584-b648-f8d09a6ae417">|<img width="360" src="https://github.com/Nexters/BandalArt-Android/assets/51016231/17f72a24-7d13-40ff-a241-fd3b4f958670">|