### PR TITLE
일회성 이벤트를 처리하는 방법을 SharedFlow 에서 Channel 로 변경

### DIFF
--- a/feature/complete/src/main/kotlin/com/nexters/bandalart/android/feature/complete/CompleteViewModel.kt
+++ b/feature/complete/src/main/kotlin/com/nexters/bandalart/android/feature/complete/CompleteViewModel.kt
@@ -12,12 +12,11 @@ import com.nexters.bandalart.android.feature.complete.navigation.BANDALART_TITLE
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -58,8 +57,8 @@ class CompleteViewModel @Inject constructor(
   private val _uiState = MutableStateFlow(CompleteUiState())
   val uiState: StateFlow<CompleteUiState> = this._uiState.asStateFlow()
 
-  private val _eventFlow = MutableSharedFlow<CompleteUiEvent>()
-  val eventFlow: SharedFlow<CompleteUiEvent> = _eventFlow.asSharedFlow()
+  private val _eventChannel = Channel<CompleteUiEvent>()
+  val eventFlow = _eventChannel.receiveAsFlow()
 
   init {
     initComplete()
@@ -98,7 +97,7 @@ class CompleteViewModel @Inject constructor(
 
         result.isFailure -> {
           val exception = result.exceptionOrNull()!!
-          _eventFlow.emit(CompleteUiEvent.ShowToast(UiText.DirectString(exception.message.toString())))
+          _eventChannel.send(CompleteUiEvent.ShowToast(UiText.DirectString(exception.message.toString())))
           Timber.e(exception)
         }
       }
@@ -112,7 +111,7 @@ class CompleteViewModel @Inject constructor(
 
   fun navigateToHome() {
     viewModelScope.launch {
-      _eventFlow.emit(CompleteUiEvent.NavigateToHome)
+      _eventChannel.send(CompleteUiEvent.NavigateToHome)
     }
   }
 }

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/BandalartBottomSheetViewModel.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/android/feature/home/BandalartBottomSheetViewModel.kt
@@ -13,16 +13,15 @@ import com.nexters.bandalart.android.feature.home.model.UpdateBandalartMainCellM
 import com.nexters.bandalart.android.feature.home.model.UpdateBandalartSubCellModel
 import com.nexters.bandalart.android.feature.home.model.UpdateBandalartTaskCellModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import javax.inject.Inject
 
 /**
  * BottomSheetUiState
@@ -65,8 +64,8 @@ class BottomSheetViewModel @Inject constructor(
   private val _uiState = MutableStateFlow(BottomSheetUiState())
   val uiState: StateFlow<BottomSheetUiState> = _uiState.asStateFlow()
 
-  private val _eventFlow = MutableSharedFlow<BottomSheetUiEvent>()
-  val eventFlow: SharedFlow<BottomSheetUiEvent> = _eventFlow.asSharedFlow()
+  private val _eventChannel = Channel<BottomSheetUiEvent>()
+  val eventFlow = _eventChannel.receiveAsFlow()
 
   fun copyCellData(cellData: BandalartCellUiModel) {
     _uiState.update {
@@ -102,7 +101,7 @@ class BottomSheetViewModel @Inject constructor(
 
         result.isFailure -> {
           val exception = result.exceptionOrNull()!!
-          _eventFlow.emit(BottomSheetUiEvent.ShowToast(UiText.DirectString(exception.message.toString())))
+          _eventChannel.send(BottomSheetUiEvent.ShowToast(UiText.DirectString(exception.message.toString())))
           Timber.e(exception.message)
         }
       }
@@ -132,7 +131,7 @@ class BottomSheetViewModel @Inject constructor(
 
         result.isFailure -> {
           val exception = result.exceptionOrNull()!!
-          _eventFlow.emit(BottomSheetUiEvent.ShowToast(UiText.DirectString(exception.message.toString())))
+          _eventChannel.send(BottomSheetUiEvent.ShowToast(UiText.DirectString(exception.message.toString())))
           Timber.e(exception.message)
         }
       }
@@ -162,7 +161,7 @@ class BottomSheetViewModel @Inject constructor(
 
         result.isFailure -> {
           val exception = result.exceptionOrNull()!!
-          _eventFlow.emit(BottomSheetUiEvent.ShowToast(UiText.DirectString(exception.message.toString())))
+          _eventChannel.send(BottomSheetUiEvent.ShowToast(UiText.DirectString(exception.message.toString())))
           Timber.e(exception.message)
         }
       }
@@ -189,7 +188,7 @@ class BottomSheetViewModel @Inject constructor(
             it.copy(isCellDeleted = false)
           }
           openDeleteCellDialog(false)
-          _eventFlow.emit(BottomSheetUiEvent.ShowToast(UiText.DirectString(exception.message.toString())))
+          _eventChannel.send(BottomSheetUiEvent.ShowToast(UiText.DirectString(exception.message.toString())))
           Timber.e(exception.message)
         }
       }

--- a/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingViewModel.kt
+++ b/feature/onboarding/src/main/kotlin/com/nexters/bandalart/android/feature/onboarding/OnBoardingViewModel.kt
@@ -4,9 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nexters.bandalart.android.core.domain.usecase.bandalart.SetOnboardingCompletedStatusUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -18,8 +17,8 @@ sealed interface OnBoardingUiEvent {
 class OnboardingViewModel @Inject constructor(
   private val setOnboardingCompletedStatusUseCase: SetOnboardingCompletedStatusUseCase,
 ) : ViewModel() {
-  private val _eventFlow = MutableSharedFlow<OnBoardingUiEvent>()
-  val eventFlow: SharedFlow<OnBoardingUiEvent> = _eventFlow.asSharedFlow()
+  private val _eventChannel = Channel<OnBoardingUiEvent>()
+  val eventFlow = _eventChannel.receiveAsFlow()
 
   fun setOnboardingCompletedStatus(flag: Boolean) {
     viewModelScope.launch {
@@ -30,7 +29,7 @@ class OnboardingViewModel @Inject constructor(
 
   private fun navigateToHome() {
     viewModelScope.launch {
-      _eventFlow.emit(OnBoardingUiEvent.NavigateToHome)
+      _eventChannel.send(OnBoardingUiEvent.NavigateToHome)
     }
   }
 }

--- a/feature/splash/src/main/kotlin/com/nexters/bandalart/android/feature/splash/SplashViewModel.kt
+++ b/feature/splash/src/main/kotlin/com/nexters/bandalart/android/feature/splash/SplashViewModel.kt
@@ -8,13 +8,12 @@ import com.nexters.bandalart.android.core.domain.usecase.login.CreateGuestLoginT
 import com.nexters.bandalart.android.core.domain.usecase.login.GetGuestLoginTokenUseCase
 import com.nexters.bandalart.android.core.domain.usecase.login.SetGuestLoginTokenUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -54,8 +53,8 @@ class SplashViewModel @Inject constructor(
   private val _uiState = MutableStateFlow(SplashUiState())
   val uiState: StateFlow<SplashUiState> = _uiState.asStateFlow()
 
-  private val _eventFlow = MutableSharedFlow<SplashUiEvent>()
-  val eventFlow: SharedFlow<SplashUiEvent> = _eventFlow.asSharedFlow()
+  private val _eventChannel = Channel<SplashUiEvent>()
+  val eventFlow = _eventChannel.receiveAsFlow()
 
   init {
     viewModelScope.launch {
@@ -138,13 +137,13 @@ class SplashViewModel @Inject constructor(
 
   fun navigateToOnBoarding() {
     viewModelScope.launch {
-      _eventFlow.emit(SplashUiEvent.NavigateToOnBoarding)
+      _eventChannel.send(SplashUiEvent.NavigateToOnBoarding)
     }
   }
 
   fun navigateToHome() {
     viewModelScope.launch {
-      _eventFlow.emit(SplashUiEvent.NavigateToHome)
+      _eventChannel.send(SplashUiEvent.NavigateToHome)
     }
   }
 }


### PR DESCRIPTION
- SharedFlow 의 경우 Shared 라는 키워드 처럼, 여러 Observer 가 동시에 event 를 구독할 수 있음, Channel 은 단일한 Observer
- 일회성 이벤트의 경우 해당 이벤트를 구독하는 Observer 는 그 화면 하나가 전부(하나의 구독자를 위한 이벤트)
- 또한 sharedFlow 는 hotFlow 이기 때문에 observer 가 존재하지 않는 경우에도 계속 이벤트를 방출함, 따라서 앱이 백그라운드에 진입했을 때 에도, 계속해서 이벤트가 방출됨
- 앱이 백그라운드에 진입할 경우, Observer 는 이벤트를 수집하지 않기에, 백그라운드에 진입된 동안 sharedFlow 가 방출한 이벤트들은 유실됨
- 따라서 이벤트를 방출하는 동안 configuration change 가 발생할 경우, 극히 적은 확률이지만 이벤트가 유실될 가능성이 존재
- Channel 의 경우 백그라운드에 진입하여 이벤트를 수집할 구독자가 존재하지 않을 경우, 이벤트를 캐싱하고, 다시 구독자가 수집을 시작할 경우, 캐싱한 이벤트를 방출함
- Channel 역시 이벤트가 방출되는 동안 configration change 가 발생할 경우, 이벤트가 유실될 가능성이 존재하지만 ObserveAsEvent 함수가 이를 방지할 수 있음(Main.immediate Dispatcher 에서 이벤트를 수집하는 방식)
- StateFlow 를 통해 일회성 이벤트를 처리해줄 경우, configuration change 가 발생할 경우, 이벤트가 유실될 가능성은 존재하지 않지만, 이벤트가 종료 후, 이전 상태로 다시 원복해줘야하만 하는 번거로움이 존재(휴먼 에러 발생 가능성)

참고)
https://medium.com/androiddevelopers/viewmodel-one-off-event-antipatterns-16a1da869b95
https://proandroiddev.com/viewmodel-events-as-state-are-an-antipattern-35ff4fbc6fb6
https://www.youtube.com/watch?v=njchj9d_Lf8
https://www.youtube.com/watch?v=QNrNKPKe5oc&t=11s
https://velog.io/@morning-la/Kotlin-Coroutine%EC%9D%98-SharedFlow-%EC%99%80-Channel