### PR TITLE
refactor: Circuit 첫 출하 안정성 개선

### DIFF
--- a/docs/CIRCUIT_RELEASE_READINESS_STRATEGY.md
+++ b/docs/CIRCUIT_RELEASE_READINESS_STRATEGY.md
@@ -1,0 +1,58 @@
+# Circuit 첫 출하 준비 전략
+
+## 배경
+
+- `develop`의 Circuit 기반 화면을 Android에서 처음 출하한다.
+- Play Console 전체 트랙의 최대 `versionCode`는 `20204`이며, 다음 배포 버전은 `2.2.5 (20205)`다.
+- 기존 ViewModel 테스트는 현재 Presenter 구조와 맞지 않으므로 테스트 의도만 선별해 Circuit Presenter 테스트로 옮긴다.
+
+## 목표
+
+1. 첫 출하를 막는 확인된 Presenter 회귀를 수정한다.
+2. 상태 복원과 코루틴 사용에서 불안정한 API를 제거한다.
+3. 핵심 화면 흐름을 Presenter 공개 인터페이스로 검증한다.
+4. 앱 버전을 `2.2.5 (20205)`로 올려 Play Console 업로드 조건을 충족한다.
+
+## 작업 범위
+
+### 코드 수정
+
+- 완료 화면이 `CompleteScreen`의 ID, 제목, 이모지, 이미지 URI를 상태에 반영하도록 수정한다.
+- 이미지 저장 이벤트가 토스트 이벤트에 덮어써지는 문제를 제거한다. 저장 성공 토스트는 기존 UI 효과 처리부가 담당한다.
+- Home 화면의 바텀시트와 다이얼로그 상태는 Bundle 저장 대상이 아니므로 Circuit retained 상태로 관리한다.
+- Circuit 내부 코루틴 API 대신 Compose 공개 API를 사용한다.
+
+### 테스트
+
+- Circuit의 `Presenter.test()`와 가짜 Navigator/Repository를 사용한다.
+- 완료 화면: 초기 상태, 완료 처리, 뒤로 가기, 저장·공유 효과를 검증한다.
+- 온보딩: 완료 상태 저장 후 Home으로 이동하는지 검증한다.
+- 스플래시: 온보딩 완료 여부에 따른 이동을 검증한다.
+- Home은 기존 ViewModel 테스트의 모든 세부 구현을 복제하지 않고, 생성·제한·업데이트 판단 등 대표 사용자 흐름을 우선 검증한다.
+- 인앱 업데이트 테스트의 가상 신규 버전은 새 앱 버전보다 큰 값으로 변경한다.
+
+#### 테스트 환경
+
+- 앱의 `compileSdk`와 `targetSdk`는 36을 유지한다.
+- Presenter JVM 테스트는 Android 16 API 동작을 검증하지 않으므로 Robolectric SDK 35에서 실행한다. 프로젝트 Java toolchain 17에서는 Robolectric SDK 36이 요구하는 JDK 21 테스트 worker를 사용할 수 없기 때문이다.
+- Android 16 고유 동작은 SDK 36 기기 또는 에뮬레이터에서 별도 수동 검증한다.
+- 구현 기준: [Circuit 공식 Testing 문서](https://slackhq.github.io/circuit/docs/testing/)
+
+### 버전 및 문서
+
+- `patchVersion`을 `5`로 변경해 `versionName=2.2.5`, `versionCode=20205`를 생성한다.
+- 배포 전략 문서의 후보 버전과 실제 패키지 ID를 현재 값으로 정리한다.
+
+## 제외 범위
+
+- 첫 출하 직전의 대규모 Home Presenter 분할이나 상태 모델 재설계
+- CMP/iOS 구현 변경
+- Fastlane 도입
+- 이 브랜치에서 Play Store 업로드 실행
+
+## 완료 조건
+
+- 변경 모듈의 Presenter 단위 테스트가 통과한다.
+- `ktlintCheck`와 `detekt`가 통과한다.
+- 생성되는 앱 버전이 `2.2.5 (20205)`임을 확인한다.
+- 머지 후 `develop`에서 Play Store Internal 트랙 배포를 다시 실행할 수 있다.

--- a/docs/PLAYSTORE_DEPLOY_STRATEGY.md
+++ b/docs/PLAYSTORE_DEPLOY_STRATEGY.md
@@ -14,7 +14,7 @@
 - 서비스 계정 키: 로컬 `playstore/service-account-key.json`
 - 서명 설정: 로컬 `keystore.properties`가 가리키는 release keystore
 - 버전 규칙: `major * 10000 + minor * 100 + patch`
-- 현재 배포 후보: `2.2.2 (20202)`
+- 현재 배포 후보: `2.2.5 (20205)`
 
 ## 3. 구현 범위
 

--- a/docs/PRESENTER_TEST_FIXTURE_STRATEGY.md
+++ b/docs/PRESENTER_TEST_FIXTURE_STRATEGY.md
@@ -1,0 +1,25 @@
+# Presenter Test Fixture 분리 전략
+
+## 목표
+
+- Presenter 테스트 파일에는 테스트 시나리오와 검증만 남긴다.
+- Repository 대역과 테스트 데이터 생성 코드를 역할별 파일로 분리한다.
+- 기존 테스트 동작과 가시성 범위는 유지한다.
+
+## 대상
+
+- `CompletePresenterTest`: `RecordingBandalartRepository` 분리
+- `HomePresenterTest`: `FakeBandalartRepository`, `FakeInAppUpdateRepository`, Bandalart fixture 분리
+- `OnboardingPresenterTest`: `FakeOnboardingRepository` 분리
+- `SplashPresenterTest`: `FakeOnboardingRepository` 분리
+
+## 원칙
+
+- 대역은 해당 feature의 test source set 안에서만 접근 가능한 `internal`로 둔다.
+- 서로 다른 feature에서 모양이 다른 대역을 무리하게 공용화하지 않는다.
+- 테스트 시나리오와 검증 내용은 변경하지 않는다.
+
+## 검증
+
+- 각 feature Presenter 테스트 실행
+- 변경된 모듈의 코드 스타일 검사 실행

--- a/docs/TARGET_SDK_36_STRATEGY.md
+++ b/docs/TARGET_SDK_36_STRATEGY.md
@@ -3,7 +3,7 @@
 - 작성일: 2026-08-03
 - 작업 브랜치: `chore/target-sdk-36`
 - 기준 브랜치: `develop`
-- 대상 앱: Android (`com.nexters.bandalart.android`)
+- 대상 앱: Android (`com.nexters.bandalart`)
 
 ## 1. 목표
 
@@ -11,7 +11,7 @@ Google Play의 Android 16(API 36) 타깃 요구사항을 만족하는 업데이�
 
 - `compileSdk`와 `targetSdk`를 36으로 올린다.
 - API 36을 공식 지원하는 최소 빌드 도구 조합으로 갱신한다.
-- 앱 버전을 `2.2.2 (20202)` 후보로 올린다.
+- 앱 버전을 우선 `2.2.2 (20202)` 후보로 올리고, Play 검증 후 `2.2.5 (20205)`로 확정한다.
 - Android 16에서 바뀌는 edge-to-edge, predictive back, 대화면 동작을 검증한다.
 - Target SDK 대응이 끝난 최종 코드에서 인앱 업데이트를 Play 경유로 검증한다.
 
@@ -38,10 +38,10 @@ Google Play의 Android 16(API 36) 타깃 요구사항을 만족하는 업데이�
 | Gradle | 8.10.2 | 8.11.1 |
 | JDK | 17 | 17 유지 |
 | Kotlin | 2.1.21 | 우선 유지 |
-| versionName | 2.2.1 | 2.2.2 |
-| versionCode | 20201 | 20202 후보 |
+| versionName | 2.2.1 | 2.2.5 |
+| versionCode | 20201 | 20205 확정 |
 
-API 36의 공식 최소 AGP는 8.9.1이며, AGP 8.9의 최소 Gradle은 8.11.1이다. Play 전체 트랙의 최대 versionCode가 20201 이하인지 확인한 뒤 20202를 최종 확정한다.
+API 36의 공식 최소 AGP는 8.9.1이며, AGP 8.9의 최소 Gradle은 8.11.1이다. Play 전체 트랙 조회 결과 최대 versionCode가 Internal 트랙의 20204였으므로 20205를 최종 확정한다.
 
 ## 4. 구현 전략
 
@@ -51,7 +51,7 @@ API 36의 공식 최소 AGP는 8.9.1이며, AGP 8.9의 최소 Gradle은 8.11.1�
 2. Version Catalog에서 `compileSdk`와 `targetSdk`를 36으로 변경한다.
 3. AGP를 8.9.1로 변경한다.
 4. Gradle Wrapper를 8.11.1로 변경한다.
-5. 앱 patch version을 2로 변경해 `2.2.2 (20202)`를 생성한다.
+5. Target SDK 작업에서 patch version을 2로 변경하고, Play 검증 후 5로 변경해 `2.2.5 (20205)`를 생성한다.
 6. 빌드 오류가 실제 발생한 경우에만 관련 플러그인 또는 의존성을 추가 조정한다.
 
 ### 4.2 Edge-to-edge와 IME
@@ -122,7 +122,8 @@ API 36 타깃 앱에서는 predictive back이 기본 활성화되고 기존 `onB
 - `./gradlew help`: 성공
 - `./gradlew ktlintCheck detekt :feature:home:testDebugUnitTest :app:lintDebug`: 성공
 - 생성된 Debug manifest의 `targetSdkVersion=36`, `windowSoftInputMode=adjustResize` 확인
-- 생성된 BuildConfig의 `VERSION_NAME=2.2.2`, `VERSION_CODE=20202` 확인
+- Target SDK PR에서 생성된 BuildConfig의 `VERSION_NAME=2.2.2`, `VERSION_CODE=20202` 확인
+- 첫 Internal 배포 후보는 별도 출하 준비 브랜치에서 `VERSION_NAME=2.2.5`, `VERSION_CODE=20205`로 갱신
 - 기존 Kotlin DSL 및 Gradle deprecated API 경고는 남아 있으나 이번 변경으로 발생한 실패는 없음
 
 ## 6. Play 검증 및 출시
@@ -141,7 +142,7 @@ Internal App Sharing 빌드의 versionCode override 방식은 배포 자동화 �
 
 - [x] `compileSdk`와 `targetSdk`가 36이다.
 - [x] AGP 8.9.1과 Gradle 8.11.1 조합으로 동기화 및 자동 검증이 통과한다.
-- [ ] 앱 버전이 최종 승인된 versionName/versionCode로 변경된다.
+- [x] 앱 버전이 최종 승인된 `2.2.5 (20205)`로 변경된다.
 - [ ] Android 16 휴대전화에서 edge-to-edge, IME, predictive back 검증이 통과한다.
 - [ ] Android 16 `sw600dp` 화면에서 핵심 기능을 사용할 수 있다.
 - [ ] 공유 및 이미지 저장 회귀 검증이 통과한다.

--- a/feature/complete/build.gradle.kts
+++ b/feature/complete/build.gradle.kts
@@ -10,6 +10,10 @@ android {
     buildFeatures {
         buildConfig = true
     }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 ksp {
@@ -24,4 +28,9 @@ dependencies {
 
         libs.bundles.landscapist,
     )
+
+    testImplementation(libs.circuit.test)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.test.junit)
+    testImplementation(libs.test.robolectric)
 }

--- a/feature/complete/src/main/kotlin/com/nexters/bandalart/feature/complete/presenter/CompletePresenter.kt
+++ b/feature/complete/src/main/kotlin/com/nexters/bandalart/feature/complete/presenter/CompletePresenter.kt
@@ -5,9 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import com.nexters.bandalart.core.common.utils.UiText
 import com.nexters.bandalart.core.domain.repository.BandalartRepository
-import com.nexters.bandalart.core.ui.R
 import com.nexters.bandalart.feature.complete.CompleteScreen
 import com.nexters.bandalart.feature.complete.CompleteScreen.Event
 import com.nexters.bandalart.feature.complete.CompleteScreen.State
@@ -37,26 +35,22 @@ class CompletePresenter @AssistedInject constructor(
             )
         }
 
-        fun showToast(message: UiText) {
-            sideEffect = CompleteScreen.SideEffect.ShowToast(message)
-        }
-
         fun clearSideEffect() {
             sideEffect = null
         }
 
         return State(
-            id = 0L,
-            title = "",
-            profileEmoji = "",
+            id = screen.bandalartId,
+            title = screen.bandalartTitle,
+            profileEmoji = screen.bandalartProfileEmoji,
             isShared = false,
-            bandalartChartImageUri = "",
+            bandalartChartImageUri = screen.bandalartChartImageUri,
+            sideEffect = sideEffect,
         ) { event ->
             when (event) {
                 is Event.NavigateBack -> navigator.pop()
                 is Event.SaveBandalart -> {
                     sideEffect = CompleteScreen.SideEffect.SaveImage(event.imageUri)
-                    showToast(UiText.StringResource(R.string.save_bandalart_image))
                 }
 
                 is Event.ShareBandalart -> {

--- a/feature/complete/src/test/kotlin/com/nexters/bandalart/feature/complete/presenter/CompletePresenterTest.kt
+++ b/feature/complete/src/test/kotlin/com/nexters/bandalart/feature/complete/presenter/CompletePresenterTest.kt
@@ -1,18 +1,9 @@
 package com.nexters.bandalart.feature.complete.presenter
 
 import android.net.Uri
-import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
-import com.nexters.bandalart.core.domain.entity.BandalartEntity
-import com.nexters.bandalart.core.domain.entity.UpdateBandalartEmojiEntity
-import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
-import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
-import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
-import com.nexters.bandalart.core.domain.repository.BandalartRepository
 import com.nexters.bandalart.feature.complete.CompleteScreen
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -86,56 +77,4 @@ class CompletePresenterTest {
             assertTrue(navigator.awaitPop().result == null)
         }
     }
-}
-
-private class RecordingBandalartRepository : BandalartRepository {
-    var completion: Pair<Long, Boolean>? = null
-        private set
-
-    private val completionRecorded = kotlinx.coroutines.CompletableDeferred<Unit>()
-
-    suspend fun awaitCompletion() = completionRecorded.await()
-
-    override suspend fun upsertBandalartId(bandalartId: Long, isCompleted: Boolean) {
-        completion = bandalartId to isCompleted
-        completionRecorded.complete(Unit)
-    }
-
-    override suspend fun createBandalart(): BandalartEntity? = error("Not used")
-    override fun getBandalartList(): Flow<List<BandalartEntity>> = emptyFlow()
-    override suspend fun getBandalart(bandalartId: Long): BandalartEntity = error("Not used")
-    override suspend fun deleteBandalart(bandalartId: Long) = error("Not used")
-    override suspend fun getBandalartMainCell(bandalartId: Long): BandalartCellEntity? = error("Not used")
-    override suspend fun getChildCells(parentId: Long): List<BandalartCellEntity> = error("Not used")
-
-    override suspend fun updateBandalartMainCell(
-        bandalartId: Long,
-        cellId: Long,
-        updateBandalartMainCellEntity: UpdateBandalartMainCellEntity,
-    ) = error("Not used")
-
-    override suspend fun updateBandalartSubCell(
-        bandalartId: Long,
-        cellId: Long,
-        updateBandalartSubCellEntity: UpdateBandalartSubCellEntity,
-    ) = error("Not used")
-
-    override suspend fun updateBandalartTaskCell(
-        bandalartId: Long,
-        cellId: Long,
-        updateBandalartTaskCellEntity: UpdateBandalartTaskCellEntity,
-    ) = error("Not used")
-
-    override suspend fun updateBandalartEmoji(
-        bandalartId: Long,
-        cellId: Long,
-        updateBandalartEmojiEntity: UpdateBandalartEmojiEntity,
-    ) = error("Not used")
-
-    override suspend fun deleteBandalartCell(cellId: Long) = error("Not used")
-    override suspend fun setRecentBandalartId(recentBandalartId: Long) = error("Not used")
-    override suspend fun getRecentBandalartId(): Long = error("Not used")
-    override suspend fun getPrevBandalartList(): List<Pair<Long, Boolean>> = error("Not used")
-    override suspend fun checkCompletedBandalartId(bandalartId: Long): Boolean = error("Not used")
-    override suspend fun deleteCompletedBandalartId(bandalartId: Long) = error("Not used")
 }

--- a/feature/complete/src/test/kotlin/com/nexters/bandalart/feature/complete/presenter/CompletePresenterTest.kt
+++ b/feature/complete/src/test/kotlin/com/nexters/bandalart/feature/complete/presenter/CompletePresenterTest.kt
@@ -1,0 +1,141 @@
+package com.nexters.bandalart.feature.complete.presenter
+
+import android.net.Uri
+import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
+import com.nexters.bandalart.core.domain.entity.BandalartEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartEmojiEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
+import com.nexters.bandalart.core.domain.repository.BandalartRepository
+import com.nexters.bandalart.feature.complete.CompleteScreen
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuit.test.test
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class CompletePresenterTest {
+    private val screen = CompleteScreen(
+        bandalartId = 42L,
+        bandalartTitle = "출시 준비",
+        bandalartProfileEmoji = "🚀",
+        bandalartChartImageUri = "content://bandalart/chart",
+    )
+
+    @Test
+    fun `screen data is exposed and bandalart is marked complete`() = runTest {
+        val repository = RecordingBandalartRepository()
+        val presenter = CompletePresenter(FakeNavigator(screen), screen, repository)
+
+        presenter.test {
+            val state = awaitItem()
+
+            assertEquals(screen.bandalartId, state.id)
+            assertEquals(screen.bandalartTitle, state.title)
+            assertEquals(screen.bandalartProfileEmoji, state.profileEmoji)
+            assertEquals(screen.bandalartChartImageUri, state.bandalartChartImageUri)
+
+            repository.awaitCompletion()
+            assertEquals(screen.bandalartId to true, repository.completion)
+        }
+    }
+
+    @Test
+    fun `save and share events are exposed as side effects`() = runTest {
+        val presenter = CompletePresenter(
+            navigator = FakeNavigator(screen),
+            screen = screen,
+            bandalartRepository = RecordingBandalartRepository(),
+        )
+        val imageUri = Uri.parse(screen.bandalartChartImageUri)
+
+        presenter.test {
+            var state = awaitItem()
+
+            state.eventSink(CompleteScreen.Event.SaveBandalart(imageUri))
+            state = awaitItem()
+            assertEquals(CompleteScreen.SideEffect.SaveImage(imageUri), state.sideEffect)
+
+            state.eventSink(CompleteScreen.Event.ShareBandalart(imageUri))
+            state = awaitItem()
+            assertEquals(CompleteScreen.SideEffect.ShareImage(imageUri), state.sideEffect)
+
+            state.eventSink(CompleteScreen.Event.InitSideEffect)
+            assertNull(awaitItem().sideEffect)
+        }
+    }
+
+    @Test
+    fun `navigate back pops current screen`() = runTest {
+        val navigator = FakeNavigator(screen)
+        val presenter = CompletePresenter(navigator, screen, RecordingBandalartRepository())
+
+        presenter.test {
+            awaitItem().eventSink(CompleteScreen.Event.NavigateBack)
+
+            assertTrue(navigator.awaitPop().result == null)
+        }
+    }
+}
+
+private class RecordingBandalartRepository : BandalartRepository {
+    var completion: Pair<Long, Boolean>? = null
+        private set
+
+    private val completionRecorded = kotlinx.coroutines.CompletableDeferred<Unit>()
+
+    suspend fun awaitCompletion() = completionRecorded.await()
+
+    override suspend fun upsertBandalartId(bandalartId: Long, isCompleted: Boolean) {
+        completion = bandalartId to isCompleted
+        completionRecorded.complete(Unit)
+    }
+
+    override suspend fun createBandalart(): BandalartEntity? = error("Not used")
+    override fun getBandalartList(): Flow<List<BandalartEntity>> = emptyFlow()
+    override suspend fun getBandalart(bandalartId: Long): BandalartEntity = error("Not used")
+    override suspend fun deleteBandalart(bandalartId: Long) = error("Not used")
+    override suspend fun getBandalartMainCell(bandalartId: Long): BandalartCellEntity? = error("Not used")
+    override suspend fun getChildCells(parentId: Long): List<BandalartCellEntity> = error("Not used")
+
+    override suspend fun updateBandalartMainCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartMainCellEntity: UpdateBandalartMainCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartSubCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartSubCellEntity: UpdateBandalartSubCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartTaskCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartTaskCellEntity: UpdateBandalartTaskCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartEmoji(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartEmojiEntity: UpdateBandalartEmojiEntity,
+    ) = error("Not used")
+
+    override suspend fun deleteBandalartCell(cellId: Long) = error("Not used")
+    override suspend fun setRecentBandalartId(recentBandalartId: Long) = error("Not used")
+    override suspend fun getRecentBandalartId(): Long = error("Not used")
+    override suspend fun getPrevBandalartList(): List<Pair<Long, Boolean>> = error("Not used")
+    override suspend fun checkCompletedBandalartId(bandalartId: Long): Boolean = error("Not used")
+    override suspend fun deleteCompletedBandalartId(bandalartId: Long) = error("Not used")
+}

--- a/feature/complete/src/test/kotlin/com/nexters/bandalart/feature/complete/presenter/RecordingBandalartRepository.kt
+++ b/feature/complete/src/test/kotlin/com/nexters/bandalart/feature/complete/presenter/RecordingBandalartRepository.kt
@@ -1,0 +1,64 @@
+package com.nexters.bandalart.feature.complete.presenter
+
+import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
+import com.nexters.bandalart.core.domain.entity.BandalartEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartEmojiEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
+import com.nexters.bandalart.core.domain.repository.BandalartRepository
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+
+internal class RecordingBandalartRepository : BandalartRepository {
+    var completion: Pair<Long, Boolean>? = null
+        private set
+
+    private val completionRecorded = CompletableDeferred<Unit>()
+
+    suspend fun awaitCompletion() = completionRecorded.await()
+
+    override suspend fun upsertBandalartId(bandalartId: Long, isCompleted: Boolean) {
+        completion = bandalartId to isCompleted
+        completionRecorded.complete(Unit)
+    }
+
+    override suspend fun createBandalart(): BandalartEntity? = error("Not used")
+    override fun getBandalartList(): Flow<List<BandalartEntity>> = emptyFlow()
+    override suspend fun getBandalart(bandalartId: Long): BandalartEntity = error("Not used")
+    override suspend fun deleteBandalart(bandalartId: Long) = error("Not used")
+    override suspend fun getBandalartMainCell(bandalartId: Long): BandalartCellEntity? = error("Not used")
+    override suspend fun getChildCells(parentId: Long): List<BandalartCellEntity> = error("Not used")
+
+    override suspend fun updateBandalartMainCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartMainCellEntity: UpdateBandalartMainCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartSubCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartSubCellEntity: UpdateBandalartSubCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartTaskCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartTaskCellEntity: UpdateBandalartTaskCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartEmoji(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartEmojiEntity: UpdateBandalartEmojiEntity,
+    ) = error("Not used")
+
+    override suspend fun deleteBandalartCell(cellId: Long) = error("Not used")
+    override suspend fun setRecentBandalartId(recentBandalartId: Long) = error("Not used")
+    override suspend fun getRecentBandalartId(): Long = error("Not used")
+    override suspend fun getPrevBandalartList(): List<Pair<Long, Boolean>> = error("Not used")
+    override suspend fun checkCompletedBandalartId(bandalartId: Long): Boolean = error("Not used")
+    override suspend fun deleteCompletedBandalartId(bandalartId: Long) = error("Not used")
+}

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -13,6 +13,7 @@ android {
 
     testOptions {
         unitTests.isIncludeAndroidResources = true
+        unitTests.isReturnDefaultValues = true
     }
 }
 
@@ -39,6 +40,8 @@ dependencies {
 
     testImplementation(platform(libs.androidx.compose.bom))
     testImplementation(libs.androidx.compose.ui.test.junit4)
+    testImplementation(libs.circuit.test)
+    testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.test.junit)
     testImplementation(libs.test.robolectric)
     debugImplementation(libs.androidx.compose.ui.test.manifest)

--- a/feature/home/src/main/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/main/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.ImageBitmap
 import com.nexters.bandalart.core.common.utils.UiText
@@ -27,7 +27,6 @@ import com.nexters.bandalart.feature.home.model.CellType
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.Navigator
-import com.slack.circuit.runtime.internal.rememberStableCoroutineScope
 import com.slack.circuit.runtime.presenter.Presenter
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -52,8 +51,8 @@ class HomePresenter @AssistedInject constructor(
         var bandalartCellData by rememberRetained { mutableStateOf<BandalartCellEntity?>(null) }
         var bandalartChartUrl by rememberRetained { mutableStateOf("") }
         var isBandalartCompleted by rememberRetained { mutableStateOf(false) }
-        var bottomSheet by rememberSaveable { mutableStateOf<HomeScreen.BottomSheetState?>(null) }
-        var dialog by rememberSaveable { mutableStateOf<HomeScreen.DialogState?>(null) }
+        var bottomSheet by rememberRetained { mutableStateOf<HomeScreen.BottomSheetState?>(null) }
+        var dialog by rememberRetained { mutableStateOf<HomeScreen.DialogState?>(null) }
         var isDropDownMenuOpened by rememberRetained { mutableStateOf(false) }
         var isSharing by rememberRetained { mutableStateOf(false) }
         var isCapturing by rememberRetained { mutableStateOf(false) }
@@ -62,7 +61,7 @@ class HomePresenter @AssistedInject constructor(
         var updateVersionCode by rememberRetained { mutableStateOf<Int?>(null) }
         var sideEffect by rememberRetained { mutableStateOf<HomeScreen.SideEffect?>(null) }
 
-        val scope = rememberStableCoroutineScope()
+        val scope = rememberCoroutineScope()
 
         fun requestCapture() {
             isCapturing = true

--- a/feature/home/src/test/kotlin/com/nexters/bandalart/feature/home/HandleAppUpdateTest.kt
+++ b/feature/home/src/test/kotlin/com/nexters/bandalart/feature/home/HandleAppUpdateTest.kt
@@ -32,14 +32,14 @@ class HandleAppUpdateTest {
         val snackbarHostState = SnackbarHostState()
         val restartLabel = composeRule.activity.getString(R.string.update_action_restart)
 
-        appUpdateManager.setUpdateAvailable(20202, AppUpdateType.FLEXIBLE)
+        appUpdateManager.setUpdateAvailable(20206, AppUpdateType.FLEXIBLE)
 
         composeRule.setContent {
             Scaffold(
                 snackbarHost = { SnackbarHost(snackbarHostState) },
             ) {
                 HandleAppUpdate(
-                    state = State(updateVersionCode = 20202, eventSink = {}),
+                    state = State(updateVersionCode = 20206, eventSink = {}),
                     snackbarHostState = snackbarHostState,
                     eventSink = {},
                     appUpdateManager = appUpdateManager,

--- a/feature/home/src/test/kotlin/com/nexters/bandalart/feature/home/presenter/BandalartTestFixtures.kt
+++ b/feature/home/src/test/kotlin/com/nexters/bandalart/feature/home/presenter/BandalartTestFixtures.kt
@@ -1,0 +1,15 @@
+package com.nexters.bandalart.feature.home.presenter
+
+import com.nexters.bandalart.core.domain.entity.BandalartEntity
+
+internal fun bandalart(id: Long) = BandalartEntity(
+    id = id,
+    mainColor = "#3FFFBA",
+    subColor = "#111827",
+    profileEmoji = "🚀",
+    title = "반다라트 $id",
+    description = null,
+    dueDate = null,
+    isCompleted = false,
+    completionRatio = 0,
+)

--- a/feature/home/src/test/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
+++ b/feature/home/src/test/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
@@ -1,0 +1,87 @@
+package com.nexters.bandalart.feature.home.presenter
+
+import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
+import com.nexters.bandalart.core.domain.entity.BandalartEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartEmojiEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
+import com.nexters.bandalart.core.domain.repository.BandalartRepository
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+internal class FakeBandalartRepository(
+    bandalarts: List<BandalartEntity>,
+    var recentBandalartId: Long = bandalarts.firstOrNull()?.id ?: 0L,
+    private val createdBandalart: BandalartEntity? = null,
+) : BandalartRepository {
+    private val bandalartFlow = MutableStateFlow(bandalarts)
+    private val createCalled = CompletableDeferred<Unit>()
+
+    var createCalls = 0
+        private set
+
+    suspend fun awaitCreate() = createCalled.await()
+
+    override suspend fun createBandalart(): BandalartEntity? {
+        createCalls += 1
+        createCalled.complete(Unit)
+        return createdBandalart
+    }
+
+    override fun getBandalartList(): Flow<List<BandalartEntity>> = bandalartFlow
+
+    override suspend fun getBandalart(bandalartId: Long): BandalartEntity {
+        return bandalartFlow.value.find { it.id == bandalartId }
+            ?: createdBandalart?.takeIf { it.id == bandalartId }
+            ?: error("Unknown bandalart: $bandalartId")
+    }
+
+    override suspend fun getBandalartMainCell(bandalartId: Long): BandalartCellEntity {
+        return BandalartCellEntity(id = bandalartId, bandalartId = bandalartId, parentId = null)
+    }
+
+    override suspend fun getChildCells(parentId: Long): List<BandalartCellEntity> = emptyList()
+
+    override suspend fun setRecentBandalartId(recentBandalartId: Long) {
+        this.recentBandalartId = recentBandalartId
+    }
+
+    override suspend fun getRecentBandalartId(): Long = recentBandalartId
+
+    override suspend fun getPrevBandalartList(): List<Pair<Long, Boolean>> {
+        return bandalartFlow.value.map { it.id to it.isCompleted }
+    }
+
+    override suspend fun upsertBandalartId(bandalartId: Long, isCompleted: Boolean) = Unit
+    override suspend fun deleteBandalart(bandalartId: Long) = error("Not used")
+
+    override suspend fun updateBandalartMainCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartMainCellEntity: UpdateBandalartMainCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartSubCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartSubCellEntity: UpdateBandalartSubCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartTaskCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartTaskCellEntity: UpdateBandalartTaskCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartEmoji(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartEmojiEntity: UpdateBandalartEmojiEntity,
+    ) = error("Not used")
+
+    override suspend fun deleteBandalartCell(cellId: Long) = error("Not used")
+    override suspend fun checkCompletedBandalartId(bandalartId: Long): Boolean = false
+    override suspend fun deleteCompletedBandalartId(bandalartId: Long) = error("Not used")
+}

--- a/feature/home/src/test/kotlin/com/nexters/bandalart/feature/home/presenter/FakeInAppUpdateRepository.kt
+++ b/feature/home/src/test/kotlin/com/nexters/bandalart/feature/home/presenter/FakeInAppUpdateRepository.kt
@@ -1,0 +1,16 @@
+package com.nexters.bandalart.feature.home.presenter
+
+import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
+
+internal class FakeInAppUpdateRepository : InAppUpdateRepository {
+    var rejectedVersionCode: Int? = null
+        private set
+
+    override suspend fun setLastRejectedUpdateVersion(rejectedVersionCode: Int) {
+        this.rejectedVersionCode = rejectedVersionCode
+    }
+
+    override suspend fun isUpdateAlreadyRejected(updateVersionCode: Int): Boolean {
+        return rejectedVersionCode == updateVersionCode
+    }
+}

--- a/feature/home/src/test/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
+++ b/feature/home/src/test/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
@@ -1,19 +1,8 @@
 package com.nexters.bandalart.feature.home.presenter
 
-import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
-import com.nexters.bandalart.core.domain.entity.BandalartEntity
-import com.nexters.bandalart.core.domain.entity.UpdateBandalartEmojiEntity
-import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
-import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
-import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
-import com.nexters.bandalart.core.domain.repository.BandalartRepository
-import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
-import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -130,103 +119,3 @@ class HomePresenterTest {
         }
     }
 }
-
-private class FakeInAppUpdateRepository : InAppUpdateRepository {
-    var rejectedVersionCode: Int? = null
-        private set
-
-    override suspend fun setLastRejectedUpdateVersion(rejectedVersionCode: Int) {
-        this.rejectedVersionCode = rejectedVersionCode
-    }
-
-    override suspend fun isUpdateAlreadyRejected(updateVersionCode: Int): Boolean {
-        return rejectedVersionCode == updateVersionCode
-    }
-}
-
-private class FakeBandalartRepository(
-    bandalarts: List<BandalartEntity>,
-    var recentBandalartId: Long = bandalarts.firstOrNull()?.id ?: 0L,
-    private val createdBandalart: BandalartEntity? = null,
-) : BandalartRepository {
-    private val bandalartFlow = MutableStateFlow(bandalarts)
-    private val createCalled = CompletableDeferred<Unit>()
-
-    var createCalls = 0
-        private set
-
-    suspend fun awaitCreate() = createCalled.await()
-
-    override suspend fun createBandalart(): BandalartEntity? {
-        createCalls += 1
-        createCalled.complete(Unit)
-        return createdBandalart
-    }
-
-    override fun getBandalartList(): Flow<List<BandalartEntity>> = bandalartFlow
-
-    override suspend fun getBandalart(bandalartId: Long): BandalartEntity {
-        return bandalartFlow.value.find { it.id == bandalartId }
-            ?: createdBandalart?.takeIf { it.id == bandalartId }
-            ?: error("Unknown bandalart: $bandalartId")
-    }
-
-    override suspend fun getBandalartMainCell(bandalartId: Long): BandalartCellEntity {
-        return BandalartCellEntity(id = bandalartId, bandalartId = bandalartId, parentId = null)
-    }
-
-    override suspend fun getChildCells(parentId: Long): List<BandalartCellEntity> = emptyList()
-
-    override suspend fun setRecentBandalartId(recentBandalartId: Long) {
-        this.recentBandalartId = recentBandalartId
-    }
-
-    override suspend fun getRecentBandalartId(): Long = recentBandalartId
-
-    override suspend fun getPrevBandalartList(): List<Pair<Long, Boolean>> {
-        return bandalartFlow.value.map { it.id to it.isCompleted }
-    }
-
-    override suspend fun upsertBandalartId(bandalartId: Long, isCompleted: Boolean) = Unit
-    override suspend fun deleteBandalart(bandalartId: Long) = error("Not used")
-
-    override suspend fun updateBandalartMainCell(
-        bandalartId: Long,
-        cellId: Long,
-        updateBandalartMainCellEntity: UpdateBandalartMainCellEntity,
-    ) = error("Not used")
-
-    override suspend fun updateBandalartSubCell(
-        bandalartId: Long,
-        cellId: Long,
-        updateBandalartSubCellEntity: UpdateBandalartSubCellEntity,
-    ) = error("Not used")
-
-    override suspend fun updateBandalartTaskCell(
-        bandalartId: Long,
-        cellId: Long,
-        updateBandalartTaskCellEntity: UpdateBandalartTaskCellEntity,
-    ) = error("Not used")
-
-    override suspend fun updateBandalartEmoji(
-        bandalartId: Long,
-        cellId: Long,
-        updateBandalartEmojiEntity: UpdateBandalartEmojiEntity,
-    ) = error("Not used")
-
-    override suspend fun deleteBandalartCell(cellId: Long) = error("Not used")
-    override suspend fun checkCompletedBandalartId(bandalartId: Long): Boolean = false
-    override suspend fun deleteCompletedBandalartId(bandalartId: Long) = error("Not used")
-}
-
-private fun bandalart(id: Long) = BandalartEntity(
-    id = id,
-    mainColor = "#3FFFBA",
-    subColor = "#111827",
-    profileEmoji = "🚀",
-    title = "반다라트 $id",
-    description = null,
-    dueDate = null,
-    isCompleted = false,
-    completionRatio = 0,
-)

--- a/feature/home/src/test/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
+++ b/feature/home/src/test/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
@@ -1,0 +1,232 @@
+package com.nexters.bandalart.feature.home.presenter
+
+import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
+import com.nexters.bandalart.core.domain.entity.BandalartEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartEmojiEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
+import com.nexters.bandalart.core.domain.repository.BandalartRepository
+import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
+import com.nexters.bandalart.feature.home.HomeScreen
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuit.test.test
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class HomePresenterTest {
+    @Test
+    fun `loads the most recently opened bandalart`() = runTest {
+        val repository = FakeBandalartRepository(
+            bandalarts = listOf(bandalart(1L), bandalart(2L)),
+            recentBandalartId = 2L,
+        )
+        val presenter = HomePresenter(
+            navigator = FakeNavigator(HomeScreen),
+            bandalartRepository = repository,
+            inAppUpdateRepository = FakeInAppUpdateRepository(),
+        )
+
+        presenter.test {
+            var state = awaitItem()
+            while (state.bandalartData?.id != 2L) {
+                state = awaitItem()
+            }
+
+            assertEquals(2, state.bandalartList.size)
+            assertEquals(2L, state.bandalartData?.id)
+        }
+    }
+
+    @Test
+    fun `creates a bandalart when the list is empty`() = runTest {
+        val repository = FakeBandalartRepository(
+            bandalarts = emptyList(),
+            createdBandalart = bandalart(1L),
+        )
+        val presenter = HomePresenter(
+            navigator = FakeNavigator(HomeScreen),
+            bandalartRepository = repository,
+            inAppUpdateRepository = FakeInAppUpdateRepository(),
+        )
+
+        presenter.test {
+            var state = awaitItem()
+            repository.awaitCreate()
+            while (state.sideEffect !is HomeScreen.SideEffect.ShowSnackbar) {
+                state = awaitItem()
+            }
+
+            assertEquals(1, repository.createCalls)
+            assertEquals(1L, repository.recentBandalartId)
+            assertEquals(1L, state.bandalartData?.id)
+        }
+    }
+
+    @Test
+    fun `does not create more than five bandalarts`() = runTest {
+        val repository = FakeBandalartRepository(
+            bandalarts = List(5) { index -> bandalart(index + 1L) },
+        )
+        val presenter = HomePresenter(
+            navigator = FakeNavigator(HomeScreen),
+            bandalartRepository = repository,
+            inAppUpdateRepository = FakeInAppUpdateRepository(),
+        )
+
+        presenter.test {
+            var state = awaitItem()
+            while (state.bandalartList.size != 5) {
+                state = awaitItem()
+            }
+
+            state.eventSink(HomeScreen.Event.OnAddClick)
+            while (state.sideEffect !is HomeScreen.SideEffect.ShowToast) {
+                state = awaitItem()
+            }
+
+            assertEquals(0, repository.createCalls)
+        }
+    }
+
+    @Test
+    fun `canceled update is not offered again`() = runTest {
+        val updateRepository = FakeInAppUpdateRepository()
+        val presenter = HomePresenter(
+            navigator = FakeNavigator(HomeScreen),
+            bandalartRepository = FakeBandalartRepository(listOf(bandalart(1L))),
+            inAppUpdateRepository = updateRepository,
+        )
+
+        presenter.test {
+            var state = awaitItem()
+            while (state.bandalartCellData == null) {
+                state = awaitItem()
+            }
+
+            state.eventSink(HomeScreen.Event.OnUpdateCheck(20206))
+            while (state.updateVersionCode != 20206) {
+                state = awaitItem()
+            }
+
+            state.eventSink(HomeScreen.Event.OnUpdateCanceled)
+            while (state.updateVersionCode != null) {
+                state = awaitItem()
+            }
+
+            assertEquals(20206, updateRepository.rejectedVersionCode)
+
+            state.eventSink(HomeScreen.Event.OnUpdateCheck(20206))
+            expectNoEvents()
+        }
+    }
+}
+
+private class FakeInAppUpdateRepository : InAppUpdateRepository {
+    var rejectedVersionCode: Int? = null
+        private set
+
+    override suspend fun setLastRejectedUpdateVersion(rejectedVersionCode: Int) {
+        this.rejectedVersionCode = rejectedVersionCode
+    }
+
+    override suspend fun isUpdateAlreadyRejected(updateVersionCode: Int): Boolean {
+        return rejectedVersionCode == updateVersionCode
+    }
+}
+
+private class FakeBandalartRepository(
+    bandalarts: List<BandalartEntity>,
+    var recentBandalartId: Long = bandalarts.firstOrNull()?.id ?: 0L,
+    private val createdBandalart: BandalartEntity? = null,
+) : BandalartRepository {
+    private val bandalartFlow = MutableStateFlow(bandalarts)
+    private val createCalled = CompletableDeferred<Unit>()
+
+    var createCalls = 0
+        private set
+
+    suspend fun awaitCreate() = createCalled.await()
+
+    override suspend fun createBandalart(): BandalartEntity? {
+        createCalls += 1
+        createCalled.complete(Unit)
+        return createdBandalart
+    }
+
+    override fun getBandalartList(): Flow<List<BandalartEntity>> = bandalartFlow
+
+    override suspend fun getBandalart(bandalartId: Long): BandalartEntity {
+        return bandalartFlow.value.find { it.id == bandalartId }
+            ?: createdBandalart?.takeIf { it.id == bandalartId }
+            ?: error("Unknown bandalart: $bandalartId")
+    }
+
+    override suspend fun getBandalartMainCell(bandalartId: Long): BandalartCellEntity {
+        return BandalartCellEntity(id = bandalartId, bandalartId = bandalartId, parentId = null)
+    }
+
+    override suspend fun getChildCells(parentId: Long): List<BandalartCellEntity> = emptyList()
+
+    override suspend fun setRecentBandalartId(recentBandalartId: Long) {
+        this.recentBandalartId = recentBandalartId
+    }
+
+    override suspend fun getRecentBandalartId(): Long = recentBandalartId
+
+    override suspend fun getPrevBandalartList(): List<Pair<Long, Boolean>> {
+        return bandalartFlow.value.map { it.id to it.isCompleted }
+    }
+
+    override suspend fun upsertBandalartId(bandalartId: Long, isCompleted: Boolean) = Unit
+    override suspend fun deleteBandalart(bandalartId: Long) = error("Not used")
+
+    override suspend fun updateBandalartMainCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartMainCellEntity: UpdateBandalartMainCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartSubCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartSubCellEntity: UpdateBandalartSubCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartTaskCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartTaskCellEntity: UpdateBandalartTaskCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartEmoji(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartEmojiEntity: UpdateBandalartEmojiEntity,
+    ) = error("Not used")
+
+    override suspend fun deleteBandalartCell(cellId: Long) = error("Not used")
+    override suspend fun checkCompletedBandalartId(bandalartId: Long): Boolean = false
+    override suspend fun deleteCompletedBandalartId(bandalartId: Long) = error("Not used")
+}
+
+private fun bandalart(id: Long) = BandalartEntity(
+    id = id,
+    mainColor = "#3FFFBA",
+    subColor = "#111827",
+    profileEmoji = "🚀",
+    title = "반다라트 $id",
+    description = null,
+    dueDate = null,
+    isCompleted = false,
+    completionRatio = 0,
+)

--- a/feature/onboarding/build.gradle.kts
+++ b/feature/onboarding/build.gradle.kts
@@ -10,6 +10,10 @@ android {
     buildFeatures {
         buildConfig = true
     }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 ksp {
@@ -23,4 +27,8 @@ dependencies {
         libs.lottie.compose,
         libs.timber,
     )
+
+    testImplementation(libs.circuit.test)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.test.junit)
 }

--- a/feature/onboarding/src/main/kotlin/com/nexters/bandalart/feature/onboarding/presenter/OnboardingPresenter.kt
+++ b/feature/onboarding/src/main/kotlin/com/nexters/bandalart/feature/onboarding/presenter/OnboardingPresenter.kt
@@ -1,6 +1,7 @@
 package com.nexters.bandalart.feature.onboarding.presenter
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import com.nexters.bandalart.core.domain.repository.OnboardingRepository
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.nexters.bandalart.feature.onboarding.OnboardingScreen
@@ -8,7 +9,6 @@ import com.nexters.bandalart.feature.onboarding.OnboardingScreen.Event
 import com.nexters.bandalart.feature.onboarding.OnboardingScreen.State
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
-import com.slack.circuit.runtime.internal.rememberStableCoroutineScope
 import com.slack.circuit.runtime.presenter.Presenter
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -23,7 +23,7 @@ class OnboardingPresenter @AssistedInject constructor(
 
     @Composable
     override fun present(): State {
-        val scope = rememberStableCoroutineScope()
+        val scope = rememberCoroutineScope()
 
         return State { event ->
             when (event) {

--- a/feature/onboarding/src/test/kotlin/com/nexters/bandalart/feature/onboarding/presenter/FakeOnboardingRepository.kt
+++ b/feature/onboarding/src/test/kotlin/com/nexters/bandalart/feature/onboarding/presenter/FakeOnboardingRepository.kt
@@ -1,0 +1,16 @@
+package com.nexters.bandalart.feature.onboarding.presenter
+
+import com.nexters.bandalart.core.domain.repository.OnboardingRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+internal class FakeOnboardingRepository : OnboardingRepository {
+    var isCompleted = false
+        private set
+
+    override suspend fun setOnboardingCompletedStatus(flag: Boolean) {
+        isCompleted = flag
+    }
+
+    override fun flowIsOnboardingCompleted(): Flow<Boolean> = flowOf(isCompleted)
+}

--- a/feature/onboarding/src/test/kotlin/com/nexters/bandalart/feature/onboarding/presenter/OnboardingPresenterTest.kt
+++ b/feature/onboarding/src/test/kotlin/com/nexters/bandalart/feature/onboarding/presenter/OnboardingPresenterTest.kt
@@ -1,0 +1,40 @@
+package com.nexters.bandalart.feature.onboarding.presenter
+
+import com.nexters.bandalart.core.domain.repository.OnboardingRepository
+import com.nexters.bandalart.feature.home.HomeScreen
+import com.nexters.bandalart.feature.onboarding.OnboardingScreen
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuit.test.test
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OnboardingPresenterTest {
+    @Test
+    fun `complete onboarding persists status and opens home`() = runTest {
+        val repository = FakeOnboardingRepository()
+        val navigator = FakeNavigator(OnboardingScreen)
+        val presenter = OnboardingPresenter(navigator, repository)
+
+        presenter.test {
+            awaitItem().eventSink(OnboardingScreen.Event.NavigateToHome)
+
+            assertEquals(HomeScreen, navigator.awaitResetRoot().newRoot)
+            assertTrue(repository.isCompleted)
+        }
+    }
+}
+
+private class FakeOnboardingRepository : OnboardingRepository {
+    var isCompleted = false
+        private set
+
+    override suspend fun setOnboardingCompletedStatus(flag: Boolean) {
+        isCompleted = flag
+    }
+
+    override fun flowIsOnboardingCompleted(): Flow<Boolean> = flowOf(isCompleted)
+}

--- a/feature/onboarding/src/test/kotlin/com/nexters/bandalart/feature/onboarding/presenter/OnboardingPresenterTest.kt
+++ b/feature/onboarding/src/test/kotlin/com/nexters/bandalart/feature/onboarding/presenter/OnboardingPresenterTest.kt
@@ -1,12 +1,9 @@
 package com.nexters.bandalart.feature.onboarding.presenter
 
-import com.nexters.bandalart.core.domain.repository.OnboardingRepository
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.nexters.bandalart.feature.onboarding.OnboardingScreen
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -26,15 +23,4 @@ class OnboardingPresenterTest {
             assertTrue(repository.isCompleted)
         }
     }
-}
-
-private class FakeOnboardingRepository : OnboardingRepository {
-    var isCompleted = false
-        private set
-
-    override suspend fun setOnboardingCompletedStatus(flag: Boolean) {
-        isCompleted = flag
-    }
-
-    override fun flowIsOnboardingCompleted(): Flow<Boolean> = flowOf(isCompleted)
 }

--- a/feature/splash/build.gradle.kts
+++ b/feature/splash/build.gradle.kts
@@ -10,6 +10,10 @@ android {
     buildFeatures {
         buildConfig = true
     }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 ksp {
@@ -27,4 +31,8 @@ dependencies {
         libs.lottie.compose,
         libs.timber,
     )
+
+    testImplementation(libs.circuit.test)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.test.junit)
 }

--- a/feature/splash/src/test/kotlin/com/nexters/bandalart/feature/splash/presenter/FakeOnboardingRepository.kt
+++ b/feature/splash/src/test/kotlin/com/nexters/bandalart/feature/splash/presenter/FakeOnboardingRepository.kt
@@ -1,0 +1,15 @@
+package com.nexters.bandalart.feature.splash.presenter
+
+import com.nexters.bandalart.core.domain.repository.OnboardingRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+internal class FakeOnboardingRepository(isCompleted: Boolean) : OnboardingRepository {
+    private val completed = MutableStateFlow(isCompleted)
+
+    override suspend fun setOnboardingCompletedStatus(flag: Boolean) {
+        completed.value = flag
+    }
+
+    override fun flowIsOnboardingCompleted(): Flow<Boolean> = completed
+}

--- a/feature/splash/src/test/kotlin/com/nexters/bandalart/feature/splash/presenter/SplashPresenterTest.kt
+++ b/feature/splash/src/test/kotlin/com/nexters/bandalart/feature/splash/presenter/SplashPresenterTest.kt
@@ -1,14 +1,11 @@
 package com.nexters.bandalart.feature.splash.presenter
 
-import com.nexters.bandalart.core.domain.repository.OnboardingRepository
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.nexters.bandalart.feature.onboarding.OnboardingScreen
 import com.nexters.bandalart.feature.splash.SplashScreen
 import com.slack.circuit.runtime.screen.Screen
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -40,14 +37,4 @@ class SplashPresenterTest {
             assertEquals(expected, navigator.awaitResetRoot().newRoot)
         }
     }
-}
-
-private class FakeOnboardingRepository(isCompleted: Boolean) : OnboardingRepository {
-    private val completed = MutableStateFlow(isCompleted)
-
-    override suspend fun setOnboardingCompletedStatus(flag: Boolean) {
-        completed.value = flag
-    }
-
-    override fun flowIsOnboardingCompleted(): Flow<Boolean> = completed
 }

--- a/feature/splash/src/test/kotlin/com/nexters/bandalart/feature/splash/presenter/SplashPresenterTest.kt
+++ b/feature/splash/src/test/kotlin/com/nexters/bandalart/feature/splash/presenter/SplashPresenterTest.kt
@@ -1,0 +1,53 @@
+package com.nexters.bandalart.feature.splash.presenter
+
+import com.nexters.bandalart.core.domain.repository.OnboardingRepository
+import com.nexters.bandalart.feature.home.HomeScreen
+import com.nexters.bandalart.feature.onboarding.OnboardingScreen
+import com.nexters.bandalart.feature.splash.SplashScreen
+import com.slack.circuit.runtime.screen.Screen
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuit.test.test
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SplashPresenterTest {
+    @Test
+    fun `completed onboarding opens home`() = runTest {
+        assertDestination(isCompleted = true, expected = HomeScreen)
+    }
+
+    @Test
+    fun `incomplete onboarding opens onboarding`() = runTest {
+        assertDestination(isCompleted = false, expected = OnboardingScreen)
+    }
+
+    private suspend fun assertDestination(isCompleted: Boolean, expected: Screen) {
+        val repository = FakeOnboardingRepository(isCompleted)
+        val navigator = FakeNavigator(SplashScreen)
+        val presenter = SplashPresenter(navigator, repository)
+
+        presenter.test {
+            var state = awaitItem()
+            if (state.isOnboardingCompleted != isCompleted) {
+                state = awaitItem()
+            }
+
+            state.eventSink(SplashScreen.Event.CheckOnboardingStatus)
+
+            assertEquals(expected, navigator.awaitResetRoot().newRoot)
+        }
+    }
+}
+
+private class FakeOnboardingRepository(isCompleted: Boolean) : OnboardingRepository {
+    private val completed = MutableStateFlow(isCompleted)
+
+    override suspend fun setOnboardingCompletedStatus(flag: Boolean) {
+        completed.value = flag
+    }
+
+    override fun flowIsOnboardingCompleted(): Flow<Boolean> = completed
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ targetSdk = "36"
 compileSdk = "36"
 majorVersion = "2"
 minorVersion = "2"
-patchVersion = "2"
+patchVersion = "5"
 packageName = "com.nexters.bandalart"
 
 android-gradle-plugin = "8.9.1"
@@ -142,11 +142,13 @@ circuit-codegen-ksp = { group = "com.slack.circuit", name = "circuit-codegen", v
 circuitx-android = { group = "com.slack.circuit", name = "circuitx-android", version.ref = "circuit" }
 circuitx-overlays = { group = "com.slack.circuit", name = "circuitx-overlays", version.ref = "circuit" }
 circuitx-gesture-navigation = { group = "com.slack.circuit", name = "circuitx-gesture-navigation", version.ref = "circuit" }
+circuit-test = { group = "com.slack.circuit", name = "circuit-test", version.ref = "circuit" }
 
 test-kotest-framework = { module = "io.kotest:kotest-runner-junit5-jvm", version.ref = "test-kotest" }
 test-kotest-assertion = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "test-kotest" }
 test-junit = { module = "junit:junit", version.ref = "test-junit" }
 test-robolectric = { module = "org.robolectric:robolectric", version.ref = "test-robolectric" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 

--- a/plugins/yb/skills/deploy-playstore/SKILL.md
+++ b/plugins/yb/skills/deploy-playstore/SKILL.md
@@ -77,7 +77,7 @@ versionCode = major * 10000 + minor * 100 + patch
 예:
 
 ```text
-2.2.2 -> 20202
+2.2.5 -> 20205
 ```
 
 - 계산한 versionCode가 `CURRENT_MAX`보다 클 때만 진행한다.


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #YB-00

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- Complete Presenter가 화면 데이터와 저장·공유 SideEffect를 올바르게 전달하도록 수정
- Home modal 상태를 Circuit retained 상태로 변경하고 내부 코루틴 API 제거
- Circuit 공식 `Presenter.test()`와 `FakeNavigator` 기반 테스트를 Complete, Home, Onboarding, Splash에 추가
- 인앱 업데이트 테스트 버전을 신규 앱 버전에 맞춰 갱신
- Internal 배포 버전을 `2.2.5 (20205)`로 올리고 관련 전략 문서 갱신

## 🧪 테스트 내역 (선택)

- [ ] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [ ] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 기능 설명 | <img src="링크" width="300" /> | 기능 설명 | <img src="링크" width="300" /> |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
-

## 💡 코드리뷰 Tip

Gemini Code Assist 리뷰 코멘트가 달리면 Claude Code에서 `/yb:resolve-gemini-review`를 실행하여 미해결 코멘트를 일괄 반영하거나 거절 사유를 남길 수 있습니다.
