### PR TITLE
refactor: Metro AppGraph 부트스트랩 추가

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -20,11 +20,11 @@ jobs:
         steps:
             -   uses: actions/checkout@v3
 
-            -   name: Setup JDK 17
+            -   name: Setup JDK 21
                 uses: actions/setup-java@v3
                 with:
                     distribution: zulu
-                    java-version: 17
+                    java-version: 21
 
             -   name: Setup Android SDK
                 uses: android-actions/setup-android@v2

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 ### Required
 
 - IDE : Android Studio Ladybug
-- JDK : Java 17을 실행할 수 있는 JDK
+- JDK : Java 21을 실행할 수 있는 JDK
 - Kotlin Language : 2.1.10
 
 ### Language
@@ -162,4 +162,3 @@ Beginner in testing([Studying...](https://github.com/Nexters/BandalArt-KMP/issue
 |<img src="https://github.com/Nexters/BandalArt-Android/assets/51016231/e7b05305-b831-4c81-8635-84b478726c55" width=200>|<img src="https://github.com/Nexters/BandalArt-Android/assets/51016231/bbcf9941-5fbb-4f8a-8e8d-8f78db396808" width=200>|
 |[@easyhooon](https://github.com/easyhooon)|[@likppi10](https://github.com/likppi10)|
 <br/>
-

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
@@ -20,13 +20,20 @@ import android.app.Application
 import com.google.firebase.Firebase
 import com.google.firebase.initialize
 import com.nexters.bandalart.di.initKoin
+import com.nexters.bandalart.di.metro.AppGraph
+import com.nexters.bandalart.di.metro.createAndroidAppGraph
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
 import org.koin.android.ext.koin.androidContext
 
 class BandalartApplication : Application() {
+    lateinit var appGraph: AppGraph
+        private set
+
     override fun onCreate() {
         super.onCreate()
+
+        appGraph = createAndroidAppGraph()
 
         if (BuildConfig.DEBUG) {
             Napier.base(DebugAntilog())

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/MainActivity.kt
@@ -30,7 +30,9 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             BandalartTheme {
-                BandalartApp()
+                BandalartApp(
+                    appGraph = (application as BandalartApplication).appGraph,
+                )
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     alias(libs.plugins.google.service) apply false
     alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.ksp.gradle.plugin) apply false
+    alias(libs.plugins.metro) apply false
     alias(libs.plugins.android.test) apply false
     alias(libs.plugins.baselineprofile) apply false
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("bandalart.kmp.compose")
     id("bandalart.kmp.ios")
     id("bandalart.kmp.firebase")
+    alias(libs.plugins.metro)
 }
 
 kotlin {
@@ -24,6 +25,10 @@ kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(libs.koin.android)
+        }
+
+        androidHostTest.dependencies {
+            implementation(libs.junit.jupiter.api)
         }
 
         commonMain.dependencies {
@@ -52,4 +57,8 @@ kotlin {
     }
 
     compilerOptions.freeCompilerArgs.add("-Xexpect-actual-classes")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
 }

--- a/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/di/metro/AppGraphTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/di/metro/AppGraphTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.di.metro
+
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Metro AppGraph")
+class AppGraphTest {
+    @Test
+    fun `platform binding을 사용하는 app scoped probe를 생성한다`() {
+        val platformBindings = TestPlatformBindings
+        val appGraph = createAppGraph(platformBindings)
+
+        assertSame(platformBindings, appGraph.bootstrapProbe.platformBindings)
+        assertSame(appGraph.bootstrapProbe, appGraph.bootstrapProbe)
+    }
+
+    private object TestPlatformBindings : PlatformBindings
+}

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
@@ -14,21 +14,8 @@
  * limitations under the License.
  */
 
-package com.nexters.bandalart
+package com.nexters.bandalart.di.metro
 
-import androidx.compose.ui.window.ComposeUIViewController
-import com.nexters.bandalart.di.initKoin
-import com.nexters.bandalart.di.metro.createIosAppGraph
-import platform.UIKit.UIViewController
+private object AndroidPlatformBindings : PlatformBindings
 
-fun MainViewController(): UIViewController {
-    val appGraph = createIosAppGraph()
-
-    return ComposeUIViewController(
-        configure = {
-            initKoin()
-        },
-    ) {
-        BandalartApp(appGraph = appGraph)
-    }
-}
+fun createAndroidAppGraph(): AppGraph = createAppGraph(AndroidPlatformBindings)

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/BandalartApp.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/BandalartApp.kt
@@ -26,48 +26,52 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
+import com.nexters.bandalart.di.metro.AppGraph
 import com.nexters.bandalart.navigation.BandalartNavHost
 import com.nexters.bandalart.ui.BandalartSnackbar
 import org.koin.compose.KoinContext
 
 @Composable
-fun BandalartApp() {
-    BandalartTheme {
-        KoinContext {
-            val snackbarHostState = remember { SnackbarHostState() }
+fun BandalartApp(appGraph: AppGraph) {
+    key(appGraph.bootstrapProbe) {
+        BandalartTheme {
+            KoinContext {
+                val snackbarHostState = remember { SnackbarHostState() }
 
-            Scaffold(
-                snackbarHost = {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.TopCenter,
-                    ) {
-                        SnackbarHost(
-                            modifier = Modifier
-                                .padding(top = 96.dp)
-                                .height(36.dp),
-                            hostState = snackbarHostState,
-                            snackbar = {
-                                BandalartSnackbar(message = it.visuals.message)
-                            },
-                        )
-                    }
-                },
-            ) { innerPadding ->
-                BandalartNavHost(
-                    modifier = Modifier.padding(innerPadding),
-                    onShowSnackbar = { message ->
-                        snackbarHostState.showSnackbar(
-                            message = message,
-                            duration = SnackbarDuration.Short,
-                        ) == SnackbarResult.ActionPerformed
+                Scaffold(
+                    snackbarHost = {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.TopCenter,
+                        ) {
+                            SnackbarHost(
+                                modifier = Modifier
+                                    .padding(top = 96.dp)
+                                    .height(36.dp),
+                                hostState = snackbarHostState,
+                                snackbar = {
+                                    BandalartSnackbar(message = it.visuals.message)
+                                },
+                            )
+                        }
                     },
-                )
+                ) { innerPadding ->
+                    BandalartNavHost(
+                        modifier = Modifier.padding(innerPadding),
+                        onShowSnackbar = { message ->
+                            snackbarHostState.showSnackbar(
+                                message = message,
+                                duration = SnackbarDuration.Short,
+                            ) == SnackbarResult.ActionPerformed
+                        },
+                    )
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/AppGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/AppGraph.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.di.metro
+
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.DependencyGraph
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.Provides
+import dev.zacsweers.metro.SingleIn
+import dev.zacsweers.metro.createGraphFactory
+
+interface PlatformBindings
+
+@Inject
+@SingleIn(AppScope::class)
+class MetroBootstrapProbe(
+    val platformBindings: PlatformBindings,
+)
+
+@DependencyGraph(AppScope::class)
+interface AppGraph {
+    val bootstrapProbe: MetroBootstrapProbe
+
+    @DependencyGraph.Factory
+    fun interface Factory {
+        fun create(
+            @Provides platformBindings: PlatformBindings,
+        ): AppGraph
+    }
+}
+
+fun createAppGraph(platformBindings: PlatformBindings): AppGraph =
+    createGraphFactory<AppGraph.Factory>().create(platformBindings)

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/di/metro/IosAppGraph.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/di/metro/IosAppGraph.kt
@@ -14,21 +14,8 @@
  * limitations under the License.
  */
 
-package com.nexters.bandalart
+package com.nexters.bandalart.di.metro
 
-import androidx.compose.ui.window.ComposeUIViewController
-import com.nexters.bandalart.di.initKoin
-import com.nexters.bandalart.di.metro.createIosAppGraph
-import platform.UIKit.UIViewController
+private object IosPlatformBindings : PlatformBindings
 
-fun MainViewController(): UIViewController {
-    val appGraph = createIosAppGraph()
-
-    return ComposeUIViewController(
-        configure = {
-            initKoin()
-        },
-    ) {
-        BandalartApp(appGraph = appGraph)
-    }
-}
+internal fun createIosAppGraph(): AppGraph = createAppGraph(IosPlatformBindings)

--- a/docs/CIRCUIT_METRO_KMP_INTEGRATION_STRATEGY.md
+++ b/docs/CIRCUIT_METRO_KMP_INTEGRATION_STRATEGY.md
@@ -75,7 +75,7 @@
 
 1. `main`의 KMP 코드 위에 `develop`의 Circuit 계약과 Presenter 동작을 선택적으로 재작성한다.
 2. `develop`의 Android UI, Hilt annotation, network/guest-login 계층은 이식하지 않는다.
-3. Metro 1.3.2의 Circuit codegen을 사용하려면 Kotlin 2.3.20 이상이 필요하므로 현재 `main`의 Kotlin 2.1.20을 먼저 올린다.
+3. Metro 1.1.1을 Kotlin 2.3.21과 함께 사용한다. Metro 1.2.0 이상은 iOS runtime KLIB가 Kotlin 2.4 ABI라 현재 Kotlin/Native에서 사용할 수 없다.
 4. AGP 9 이상에서는 KMP와 `com.android.application`을 한 모듈에 둘 수 없으므로 `composeApp`의 Android entry point를 별도 `androidApp` 모듈로 분리한다.
 5. Koin과 Metro의 공존 방향은 `Koin → Metro accessor`만 허용한다. Metro graph가 Koin service locator를 조회하지 않는다.
 6. 최초에는 `AppScope` 하나만 사용한다. Presenter는 assisted factory가 화면마다 생성하고 DI graph에 Activity/Screen scope를 추가하지 않는다.
@@ -84,9 +84,9 @@
 
 - [KMP 프로젝트의 AGP 9 마이그레이션](https://kotlinlang.org/docs/multiplatform/multiplatform-project-agp-9-migration.html)
 - [KMP 권장 모듈 구조](https://kotlinlang.org/docs/multiplatform/multiplatform-project-recommended-structure.html)
-- [Metro 1.3.2 설치](https://zacsweers.github.io/metro/1.3.2/installation/)
-- [Metro Kotlin 호환성](https://zacsweers.github.io/metro/1.3.2/compatibility/)
-- [Metro dependency graph](https://zacsweers.github.io/metro/1.3.2/dependency-graphs/)
-- [Metro Circuit integration](https://zacsweers.github.io/metro/1.3.2/circuit/)
-- [Metro adoption strategy](https://zacsweers.github.io/metro/1.3.2/adoption/)
-- [Metro KMP 제약](https://zacsweers.github.io/metro/1.3.2/features/)
+- [Metro 1.1.1 설치](https://zacsweers.github.io/metro/1.1.1/installation/)
+- [Metro Kotlin 호환성](https://zacsweers.github.io/metro/1.1.1/compatibility/)
+- [Metro dependency graph](https://zacsweers.github.io/metro/1.1.1/dependency-graphs/)
+- [Metro Circuit integration](https://zacsweers.github.io/metro/1.1.1/circuit/)
+- [Metro adoption strategy](https://zacsweers.github.io/metro/1.1.1/adoption/)
+- [Metro KMP 제약](https://zacsweers.github.io/metro/1.1.1/features/)

--- a/docs/CIRCUIT_METRO_KMP_MIGRATION_MAP.md
+++ b/docs/CIRCUIT_METRO_KMP_MIGRATION_MAP.md
@@ -207,7 +207,7 @@ interface PlatformBindings {
 }
 ```
 
-실제 annotation/import 문법은 Metro 1.3.2 compile spike에서 확정한다. 이 코드는 책임 경계를 설명하기 위한 설계안이다.
+실제 annotation/import 문법은 Metro 1.1.1 compile spike에서 확정한다. 이 코드는 책임 경계를 설명하기 위한 설계안이다.
 
 ### 7.2 플랫폼 생성 지점
 
@@ -243,7 +243,7 @@ Metro는 KMP를 지원하지만 Native target에서 `@Contributes*`를 사용한
 
 ## 8. Circuit factory 설계
 
-Metro 1.3.2는 `metro { enableCircuitCodegen.set(true) }`로 Circuit factory를 생성하고 `Presenter.Factory`/`Ui.Factory` set에 기여할 수 있다. 이 기능은 Kotlin 2.3.20 이상이 필요하다.
+Metro 1.1.1은 `metro { enableCircuitCodegen.set(true) }`로 Circuit factory를 생성하고 `Presenter.Factory`/`Ui.Factory` set에 기여할 수 있다. 실제 활성화는 첫 Circuit vertical slice 전에 Android/iOS compile spike로 검증한다.
 
 - `@CircuitInject`는 Hilt component를 인자로 받는 기존 형태로 복사하지 않는다.
 - Presenter의 nested `@AssistedFactory`에 Metro/Circuit이 요구하는 annotation을 적용한다.
@@ -281,7 +281,7 @@ Presenter 테스트는 Circuit 공식 `Presenter.test`/Turbine 패턴을 유지�
 
 ### 3-B. Metro bootstrap
 
-- Metro 1.3.2 plugin/runtime 추가
+- Metro 1.1.1 plugin/runtime 추가
 - `AppScope`, 최소 `AppGraph`, `PlatformBindings` 추가
 - 기존 Koin graph는 그대로 두고 신규 bootstrap probe만 Metro가 소유
 - Android/iOS에서 graph 생성 및 앱 기동 확인
@@ -355,7 +355,7 @@ toolchain/DI 전환 PR은 기능 변경을 포함하지 않고, 기능 전환 PR
 
 | 항목 | 현재 판단 | 확정 시점 |
 | --- | --- | --- |
-| Metro 정확한 버전 | 1.3.2 우선 | 3-B dependency resolution/build 결과 |
+| Metro 정확한 버전 | 1.1.1 | 3-B에서 Android test와 iOS framework link로 확정 |
 | Circuit 정확한 버전 | develop의 0.35.1 이상 호환 버전 | 3-A toolchain 및 3-B codegen spike |
 | Android/iOS 앱 버전 | 배포 이력이 갈라져 별도 확인 필요 | 3-A에서 Play/App Store 기준 확인 후 결정 |
 | `@Parcelize` 대체 | 공통 Screen compile/상태 복원 spike 필요 | 5단계 시작 전 |

--- a/docs/KMP_AGP_9_MIGRATION_STRATEGY.md
+++ b/docs/KMP_AGP_9_MIGRATION_STRATEGY.md
@@ -36,6 +36,8 @@ AGP 9.3의 공식 호환 조합은 다음과 같다:
 
 Android-KMP DSL은 AGP 9.3 기준 `kotlin { android { ... } }`를 사용한다. 초기 문서의 `androidLibrary {}` 표기는 최신 DSL에서 사용하지 않는다.
 
+이 표는 AGP 9 전환 시점의 최소 요구사항이다. 후속 Metro 부트스트랩부터는 Metro Gradle 플러그인 실행 요구사항에 맞춰 Gradle runtime을 JDK 21로 사용하되, 앱의 Java/Kotlin target과 toolchain은 17로 유지한다.
+
 ## 3. 현재 구조와 문제
 
 현재 `composeApp`은 다음 책임을 한 모듈에 가진다:

--- a/docs/METRO_BOOTSTRAP_STRATEGY.md
+++ b/docs/METRO_BOOTSTRAP_STRATEGY.md
@@ -1,0 +1,150 @@
+# Metro 부트스트랩 전략
+
+## 목적
+
+이 문서는 이슈 #182의 3단계인 Metro 부트스트랩 작업 범위를 고정한다. 기능 객체의 생성 책임은 아직 Koin에 두고, Android와 iOS가 공유하는 최소 Metro graph의 컴파일·생성·수명 경계만 먼저 검증한다.
+
+## 기준점
+
+- 기준 브랜치: `main`
+- 기준 리비전: `38dbfe2a84f65cf665d1c42005d0afb71509ef4a`
+- 작업 브랜치: `refactor/metro-bootstrap`
+- Kotlin: 2.3.21
+- AGP / Gradle: 9.3.0 / 9.5.0
+- Compose Multiplatform: 1.10.3
+- Android SDK: compileSdk 37 / targetSdk 36
+- 기존 DI: Koin 4.1.0-Beta5
+
+## Metro 버전 결정
+
+Metro 1.1.1을 사용한다.
+
+- 1.2.0부터 최신 1.4.0까지는 compiler 호환성 표에 Kotlin 2.3.21을 포함하지만, 실제 iOS runtime KLIB가 Kotlin 2.4 ABI로 배포돼 Kotlin/Native 2.3.21에서 읽을 수 없었다.
+- 1.1.1은 Kotlin 2.3 계열로 빌드된 runtime과 현재 toolchain을 함께 유지할 수 있는 최신 안정 릴리스다.
+- Gradle 플러그인을 적용하면 runtime과 Kotlin compiler plugin 연결이 함께 구성된다.
+- 이번 단계에서는 Circuit codegen과 contribution aggregation을 활성화하지 않는다.
+
+공식 참고 자료:
+
+- [Metro 1.1.1 릴리스](https://github.com/ZacSweers/metro/releases/tag/1.1.1)
+- [설치](https://zacsweers.github.io/metro/1.1.1/installation/)
+- [Kotlin compiler 호환성](https://zacsweers.github.io/metro/1.1.1/compatibility/)
+- [Dependency graph](https://zacsweers.github.io/metro/1.1.1/dependency-graphs/)
+
+## 포함 범위
+
+1. version catalog에 Metro 1.1.1 Gradle 플러그인을 추가한다.
+2. 공통 UI와 Android/iOS entry point를 가진 `composeApp`에만 Metro 플러그인을 적용한다.
+3. `commonMain`에 app scope의 최소 `AppGraph`를 만든다.
+4. graph factory 입력으로 `PlatformBindings` 경계를 만든다.
+5. Metro가 생성하는 app-scoped bootstrap probe를 graph accessor로 노출한다.
+6. Android `Application`과 iOS `MainViewController`가 각각 플랫폼 binding으로 graph를 한 번 생성한다.
+7. 생성한 graph를 `BandalartApp`에 명시적으로 전달해 composition root 수명에 연결한다.
+8. bootstrap probe 생성과 scope 동일성을 Android host test로 고정한다.
+9. 기존 CI 명령으로 Android test/lint/build와 iOS framework link를 검증한다.
+
+## 제외 범위
+
+- Room, DataStore, repository, ViewModel의 Metro binding 전환
+- Koin module, `startKoin`, `KoinContext` 제거 또는 수정
+- Koin이 생성하는 객체를 Metro graph에 입력하거나 Metro가 Koin을 조회하는 bridge
+- Circuit 의존성, Screen, Presenter, factory codegen 추가
+- Android/iOS 플랫폼 provider 구현 변경
+- 화면 동작, 내비게이션, 디자인 변경
+- 신규 Activity, Screen, Session scope 도입
+
+## graph 설계
+
+```text
+Android BandalartApplication              iOS MainViewController
+            │                                      │
+            ├── AndroidPlatformBindings            ├── IosPlatformBindings
+            │                                      │
+            └──────────────┬───────────────────────┘
+                           ▼
+                   AppGraph.Factory
+                           │
+                           ▼
+                 AppGraph(AppScope)
+                           │
+                           └── MetroBootstrapProbe
+
+Koin composition root ── 기존 경로 그대로 유지
+```
+
+`PlatformBindings`는 이번 단계에서 플랫폼 경계를 표시하는 빈 계약이다. 다음 4단계에서 기존 DB/DataStore/AppVersion/ImageHandler factory를 이 계약에 추가한다. 지금부터 실제 객체를 옮기면 Koin과 Metro가 같은 singleton을 중복 생성할 위험이 있으므로 추가하지 않는다.
+
+`MetroBootstrapProbe`는 제품 기능을 갖지 않는다. graph factory 입력이 정상 해석되고 app scope가 동일 인스턴스를 반환하는지만 검증한 뒤, 최종 composition root 정리 단계에서 제거할 수 있다.
+
+## 수명과 소유권
+
+- Android: `BandalartApplication`이 `AppGraph`를 프로세스 수명 동안 한 번 소유한다.
+- iOS: `MainViewController` 생성 시 graph를 만들고 root composable이 controller 수명 동안 참조한다.
+- 공통: `BandalartApp(appGraph)`는 graph를 명시적으로 받지만 아직 Koin으로부터 제품 의존성을 조회한다.
+- 금지: 전역 mutable graph holder, Metro에서 Koin 조회, Koin에서 bootstrap probe 재생성.
+
+## 구현 순서
+
+1. Metro 플러그인 버전과 Kotlin 2.3.21 Android/iOS 호환성을 고정한다.
+2. `composeApp`에 플러그인을 적용하고 의존성 해석만 확인한다.
+3. 공통 graph, factory input, bootstrap probe를 추가한다.
+4. Android와 iOS entry point에서 graph를 생성한다.
+5. root composable에 graph identity를 연결한다.
+6. bootstrap probe test를 추가한다.
+7. Android/iOS 전체 검증 후 이 문서에 실제 결과를 기록한다.
+
+## 검증 계획
+
+```shell
+./gradlew :composeApp:testAndroidHostTest
+./gradlew allTests :androidApp:testDebugUnitTest
+./gradlew :androidApp:lintDebug
+./gradlew :androidApp:assembleDebug
+./gradlew :composeApp:linkDebugFrameworkIosSimulatorArm64
+./gradlew :androidApp:bundleRelease -x :androidApp:uploadCrashlyticsMappingFileRelease
+```
+
+정적 확인:
+
+- Koin module과 `initKoin` 변경 없음
+- Metro graph에서 기존 DB/DataStore/repository binding 없음
+- Android/iOS가 같은 공통 `AppGraph` 타입을 생성
+- bootstrap probe accessor가 app scope 안에서 같은 인스턴스 반환
+- DB schema와 DataStore key 변경 없음
+
+## 완료 조건
+
+- Metro 1.1.1 compiler plugin과 runtime이 Kotlin 2.3.21의 Android/iOS compilation에서 동작한다.
+- Android와 iOS entry point가 공통 `AppGraph`를 생성한다.
+- 앱의 기존 Koin 기반 기능과 UI 흐름은 변경되지 않는다.
+- bootstrap probe test, Android unit test, Android Lint, Android debug/release, iOS framework link가 통과한다.
+- 다음 단계에서 `PlatformBindings`에 기존 core factory를 추가할 수 있는 경계가 준비된다.
+
+## 검증 결과
+
+2026-08-04 기준 아래 통합 검증을 통과했다.
+
+```shell
+./gradlew allTests \
+  :androidApp:testDebugUnitTest \
+  :androidApp:lintDebug \
+  :androidApp:assembleDebug \
+  :composeApp:linkDebugFrameworkIosSimulatorArm64 \
+  :androidApp:bundleRelease \
+  -x :androidApp:uploadCrashlyticsMappingFileRelease \
+  --no-daemon \
+  --stacktrace
+```
+
+- 전체 테스트와 Metro `AppGraph` Android host test 통과
+- Android Lint와 debug APK 생성 통과
+- iOS Simulator arm64 debug framework link 통과
+- R8이 적용된 서명 release AAB 생성 통과
+- 기존 Koin module과 `initKoin` 변경 없음
+- Metro graph에 기존 DB, DataStore, repository binding 없음
+
+Gradle 10에서 제거될 deprecated API 경고와 기존 Android Manifest의 불필요한 `tools:replace` 경고는 남아 있지만, 이번 Metro 변경에서 추가된 빌드 오류는 없다.
+
+## 롤백
+
+이 단계는 제품 객체의 소유권을 변경하지 않는다. 문제가 생기면 Metro 플러그인 선언, 공통 graph 파일, 플랫폼별 bootstrap 파일, entry point의 graph 전달만 되돌리면 기존 Koin 앱으로 완전히 복귀한다.

--- a/docs/METRO_BOOTSTRAP_STRATEGY.md
+++ b/docs/METRO_BOOTSTRAP_STRATEGY.md
@@ -11,6 +11,8 @@
 - 작업 브랜치: `refactor/metro-bootstrap`
 - Kotlin: 2.3.21
 - AGP / Gradle: 9.3.0 / 9.5.0
+- Gradle 실행 JDK: 21
+- 앱 Java/Kotlin target: 17
 - Compose Multiplatform: 1.10.3
 - Android SDK: compileSdk 37 / targetSdk 36
 - 기존 DI: Koin 4.1.0-Beta5
@@ -22,6 +24,7 @@ Metro 1.1.1을 사용한다.
 - 1.2.0부터 최신 1.4.0까지는 compiler 호환성 표에 Kotlin 2.3.21을 포함하지만, 실제 iOS runtime KLIB가 Kotlin 2.4 ABI로 배포돼 Kotlin/Native 2.3.21에서 읽을 수 없었다.
 - 1.1.1은 Kotlin 2.3 계열로 빌드된 runtime과 현재 toolchain을 함께 유지할 수 있는 최신 안정 릴리스다.
 - Gradle 플러그인을 적용하면 runtime과 Kotlin compiler plugin 연결이 함께 구성된다.
+- Metro Gradle 플러그인은 JVM 21 이상에서 실행해야 한다. Gradle 실행 JDK만 21로 올리고 앱의 Java/Kotlin target과 toolchain은 17을 유지한다.
 - 이번 단계에서는 Circuit codegen과 contribution aggregation을 활성화하지 않는다.
 
 공식 참고 자료:
@@ -142,6 +145,7 @@ Koin composition root ── 기존 경로 그대로 유지
 - R8이 적용된 서명 release AAB 생성 통과
 - 기존 Koin module과 `initKoin` 변경 없음
 - Metro graph에 기존 DB, DataStore, repository binding 없음
+- CI의 Gradle 실행 JDK를 21로 정렬
 
 Gradle 10에서 제거될 deprecated API 경고와 기존 Android Manifest의 불필요한 `tools:replace` 경고는 남아 있지만, 이번 Metro 변경에서 추가된 빌드 오류는 없다.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ androidx-sqlite = "2.5.0"
 
 # DI
 koin = "4.1.0-Beta5"
+metro = "1.1.1"
 
 # Image Load
 coil3 = "3.1.0"
@@ -230,6 +231,7 @@ androidx-room = { id = "androidx.room", version.ref = "androidx-room" }
 # Util
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebase-crashlytics" }
 ksp-gradle-plugin = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 detekt-gradle-plugin = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig" }


### PR DESCRIPTION
## 작업 내용
- Metro 1.1.1 Gradle plugin과 공통 AppGraph를 추가했습니다.
- Android Application과 iOS MainViewController가 플랫폼별 binding으로 graph를 한 번 생성합니다.
- app-scoped bootstrap probe의 factory 입력과 동일 인스턴스를 Android host test로 검증합니다.
- 기존 Koin module과 initKoin, 제품 객체 생성 책임은 그대로 유지합니다.

## 버전 결정
- 프로젝트 Kotlin 2.3.21을 유지하기 위해 Metro 1.1.1을 사용합니다.
- Metro 1.2.0 이상은 실제 iOS runtime KLIB가 Kotlin 2.4 ABI여서 현재 Kotlin/Native에서 link할 수 없음을 확인했습니다.

## 검증
- 전체 KMP/Android 단위 테스트
- Metro AppGraph Android host test
- Android Lint
- debug APK
- iOS Simulator arm64 debug framework
- R8 적용 release AAB

모두 통과했습니다.

## 범위 외
- Room, DataStore, repository, ViewModel의 Metro 이전
- Koin 제거 또는 Metro-Koin bridge
- Circuit codegen/contribution 적용

Related to #182