### PR TITLE
refactor: Home 읽기 상태를 Circuit으로 전환

### DIFF
--- a/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/di/metro/AppGraphTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/di/metro/AppGraphTest.kt
@@ -29,6 +29,7 @@ import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
 import com.nexters.bandalart.core.domain.repository.OnboardingRepository
 import com.nexters.bandalart.core.navigation.LegacyHomeScreen
 import com.nexters.bandalart.feature.complete.CompleteScreen
+import com.nexters.bandalart.feature.home.HomeScreen
 import com.nexters.bandalart.feature.onboarding.OnboardingScreen
 import com.nexters.bandalart.feature.splash.SplashScreen
 import com.slack.circuit.test.FakeNavigator
@@ -92,6 +93,7 @@ class AppGraphTest {
             )
         assertNotNull(appGraph.circuit.presenter(completeScreen, FakeNavigator(completeScreen)))
         assertNotNull(appGraph.circuit.ui(completeScreen))
+        assertNotNull(appGraph.circuit.presenter(HomeScreen, FakeNavigator(HomeScreen)))
     }
 
     @Test

--- a/docs/CIRCUIT_COMPLETE_MIGRATION_STRATEGY.md
+++ b/docs/CIRCUIT_COMPLETE_MIGRATION_STRATEGY.md
@@ -118,7 +118,8 @@ BandalartApp
 - Metro graph에서 Complete와 LegacyHome의 UI/Presenter factory 생성 확인
 - `feature:complete`, `core:navigation`, `composeApp` Spotless/Detekt 통과
 - Android common/host test compile에서 Metro Circuit codegen 확인
-- iOS Simulator Arm64 framework link와 실제 기기 동작은 아직 검증하지 않음
+- CI에서 iOS Simulator Arm64 framework link 통과
+- Android/iOS 실제 기기의 이동·뒤로가기·저장·공유는 수동 검증 필요
 
 ## 8. 참고 자료
 

--- a/docs/CIRCUIT_HOME_READ_MIGRATION_STRATEGY.md
+++ b/docs/CIRCUIT_HOME_READ_MIGRATION_STRATEGY.md
@@ -1,0 +1,146 @@
+# Circuit Home 읽기 전환 전략
+
+## 1. 목적
+
+이 문서는 이슈 #182의 6-B 단계인 Home 읽기 책임의 Circuit Presenter 전환 범위와 검증 기준을 구현 전에 고정한다.
+
+- 기준 브랜치: `main` (`4ff6de78c69526b7228d4a44931b6e72eacf8c21`)
+- 작업 브랜치: `refactor/circuit-home-read`
+- 대상: 반다라트 목록 구독, 최근 항목 선택, 빈 목록 초기 생성, 상세·셀 트리 조회, 완료 전환 감지
+- 목표: repository 기반 Home 읽기 상태를 KMP Circuit Presenter와 Metro factory로 옮기고 공식 Presenter test로 동작을 고정
+- 비목표: Home 런타임 화면 교체, 생성 버튼·편집·삭제, modal 상태, 이미지 capture/save/share, Android 선택 업데이트, Koin 제거
+
+## 2. 관찰된 현재 동작
+
+### `main`
+
+- `LegacyHomeScreen` 안의 Compose Navigation이 `HomeRoute`를 열고 Koin `HomeViewModel`이 모든 상태를 소유한다.
+- 목록을 구독한 뒤 이전 완료 스냅샷과 비교해 새로 완료된 첫 항목을 선택한다.
+- 새 완료 항목이 없으면 목록의 완료 상태를 DataStore에 동기화한다.
+- 목록이 비어 있으면 반다라트를 하나 생성하고 최근 ID와 완료 스냅샷을 기록한다.
+- 목록이 있으면 최근 ID가 유효할 때 해당 항목을, 아니면 첫 항목을 연다.
+- 선택한 항목의 main → sub → task 셀을 조회해 중첩 `BandalartCellEntity`를 만든다.
+- 완료 전환 후 이미지 capture와 Complete 이동은 ViewModel UI event와 `LegacyHomePresenter` bridge를 거친다.
+
+### `develop` 참고 구현
+
+- 하나의 `HomePresenter`가 읽기, 편집/modal, 플랫폼 effect와 업데이트를 모두 소유한다.
+- Android Hilt scope, `java.util.Locale`, Android resource와 과거 Circuit retained/coroutine 패턴이 섞여 있어 전체 파일을 그대로 이식하지 않는다.
+- 목록·최근 항목·빈 목록 생성 흐름과 Presenter test의 시나리오만 동작 참고 자료로 사용한다.
+
+## 3. 단계 분리 결정
+
+### 3.1 이번 PR은 shadow Presenter 단계다
+
+`6-B`에서는 새 Home Circuit Screen/Presenter를 구현하고 Metro에 등록하되 앱의 root BackStack에는 아직 연결하지 않는다.
+
+```text
+현재 runtime
+  LegacyHomeScreen → HomeRoute → HomeViewModel
+
+6-B에서 추가
+  HomeScreen → HomePresenter(read only, runtime 미연결)
+```
+
+이유는 새 Presenter와 기존 ViewModel을 동시에 composition하면 둘 다 목록을 구독하고 빈 목록 생성·완료 스냅샷 갱신을 수행해 중복 쓰기와 중복 Complete 이동이 발생할 수 있기 때문이다.
+
+- `LegacyHomeScreen`, `HomeViewModel`, Koin module과 Compose Navigation을 유지한다.
+- 새 Presenter는 직접 Presenter test와 Metro graph test에서만 실행한다.
+- `6-C`에서 편집/modal 책임을 추가하고 `6-D`에서 플랫폼 effect를 추가한 뒤, 완성된 Home Screen으로 runtime을 한 번에 교체한다.
+- runtime 교체 PR에서만 legacy ViewModel/Koin/NavHost를 제거한다.
+
+### 3.2 Screen과 읽기 State
+
+- 기존 `HomeScreen` composable은 동작 변경 없이 `HomeContent`로 이름을 정리해 Circuit `HomeScreen` 타입과 구분한다.
+- `HomeScreen`은 파라미터가 없는 `ParcelableScreen`과 `StaticScreen`으로 정의한다.
+- 이번 단계의 State는 다음 읽기 값만 소유한다.
+  - 반다라트 목록
+  - 선택한 반다라트
+  - main/sub/task 셀 트리
+  - 초기 조회 여부
+  - 새 완료 항목 여부
+  - 읽기 event sink
+- repository에서 다시 만들 수 있는 목록·상세 상태는 일반 `remember`와 `LaunchedEffect`로 관리한다.
+- 사용자 입력 초안과 modal 같은 retained state는 `6-C`에서 `rememberRetained` 적용 대상을 별도로 판단한다.
+
+### 3.3 읽기 이벤트
+
+- 목록에서 항목 선택 시 최근 ID를 저장하고 해당 상세와 셀 트리를 다시 읽는다.
+- 완료 전환 감지는 State에만 노출한다. 이미지 capture와 Complete navigation은 `6-D` 플랫폼 effect 전환 전까지 새 Presenter에서 실행하지 않는다.
+- 생성 버튼, 편집, 삭제와 modal event는 이번 계약에 넣지 않고 `6-C`에서 추가한다.
+- `InAppUpdateRepository`는 Android 플랫폼 effect 단계인 `6-D` 전까지 주입하지 않는다.
+
+## 4. 읽기 알고리즘
+
+1. Presenter composition당 목록 collector를 하나 시작한다.
+2. repository 목록을 `BandalartUiModel`의 immutable list로 변환한다.
+3. 이전 완료 스냅샷과 비교해 `false → true`로 바뀐 항목을 찾는다.
+4. 새 완료 항목이 있으면 첫 항목을 선택하고 `isBandalartCompleted = true`로 상세와 셀 트리를 읽는다.
+5. 새 완료 항목이 없으면 현재 목록의 완료 상태를 스냅샷에 동기화한다.
+6. 목록이 비어 있으면 정확히 한 번 새 반다라트를 생성한다.
+   - 생성 ID를 최근 ID로 저장한다.
+   - 완료 스냅샷을 초기화한다.
+   - 생성된 상세와 셀 트리를 읽는다.
+7. 목록이 있으면 유효한 최근 ID를 우선하고, 없으면 첫 항목을 선택한다.
+8. 상세 조회 후 main, sub, task 순서로 셀을 읽어 기존 UI와 동일한 중첩 구조를 만든다.
+
+완료 항목을 선택한 경로에서는 Complete 진입 전에 완료 스냅샷을 `true`로 덮어쓰지 않는다. 실제 완료 처리는 이미 전환된 `CompletePresenter`가 담당하며, `6-D`에서 navigation을 연결할 때 이 경계를 회귀 테스트한다.
+
+## 5. 구현 순서
+
+1. Home feature에 Circuit/Metro/Parcelable 및 Presenter test 의존성을 추가한다.
+2. KMP `HomeScreen` 읽기 State/Event 계약을 작성하고 기존 UI composable 이름 충돌을 정리한다.
+3. `HomePresenter`에 목록, 최근 선택, 빈 목록 초기 생성과 상세·셀 트리 조회를 구현한다.
+4. 완료 전환을 읽기 State로 노출하되 capture/navigation은 실행하지 않는다.
+5. fake repository와 Circuit 공식 `Presenter.test` 기반 테스트를 작성한다.
+6. Metro graph에서 Home Presenter factory 생성을 확인한다.
+7. 마이그레이션 맵과 트러블슈팅 문서를 갱신한다.
+
+## 6. 테스트 및 완료 기준
+
+### Presenter test
+
+- 목록을 받고 유효한 최근 ID의 항목을 선택한다.
+- 최근 ID가 목록에 없으면 첫 항목을 선택한다.
+- 빈 목록이면 하나만 생성하고 최근 ID·완료 스냅샷·상세 상태를 갱신한다.
+- main/sub/task 셀을 기존과 동일한 중첩 트리로 만든다.
+- `false → true` 완료 항목이 여러 개면 기존과 같이 첫 항목을 선택한다.
+- 완료 전환 State를 노출하는 동안 완료 스냅샷을 먼저 덮어쓰거나 Navigator를 호출하지 않는다.
+- 목록 항목 선택 event가 최근 ID와 상세 상태를 갱신한다.
+
+### 통합 검증
+
+- Metro graph가 Home Presenter factory를 생성한다.
+- 기존 `LegacyHomeScreen` UI/Presenter와 Home ViewModel test가 계속 통과한다.
+- Home feature 및 composeApp Android host test가 통과한다.
+- 이번 변경 Kotlin 파일의 Spotless 포맷과 Home/composeApp Detekt가 통과한다.
+- CI의 Android/iOS build가 통과한다.
+
+### 수동 검증
+
+이번 단계는 runtime 미연결이므로 새 Presenter에 대한 별도 UI 수동 검증은 없다. 기존 Home 동작이 바뀌지 않았는지만 확인한다.
+
+## 7. 롤백 경계
+
+- 새 Home Screen/Presenter와 Metro binding은 runtime에서 참조되지 않으므로 해당 파일과 build 설정만 제거하면 된다.
+- repository, DB, DataStore 형식과 legacy ViewModel을 변경하지 않는다.
+- `6-C/6-D` 진행 중 설계 문제가 발견돼도 현재 앱의 Home 경로는 그대로 동작한다.
+
+## 8. 참고 자료
+
+- [Circuit Presenter testing](https://slackhq.github.io/circuit/docs/testing/)
+- [Circuit code generation](https://slackhq.github.io/circuit/docs/code-gen/)
+- [Metro Circuit integration](https://zacsweers.github.io/metro/1.1.1/circuit/)
+- [`develop` HomePresenter 참고 구현](https://github.com/Nexters/BandalArt-KMP)
+
+## 9. 구현 및 로컬 검증 결과
+
+- Home feature에 Circuit/Metro codegen과 Presenter test 구성을 추가했다.
+- 기존 runtime composable을 `HomeContent`로 이름만 변경하고 `LegacyHomeScreen → HomeRoute → HomeViewModel` 경로는 유지했다.
+- `HomeScreen` 읽기 계약과 Metro assisted `HomePresenter`를 추가했다.
+- 목록·최근 항목·빈 목록 생성·상세와 main/sub/task 트리·완료 전환·선택 event를 Circuit 공식 `Presenter.test` 5개로 검증했다.
+- composeApp Metro graph에서 Home Presenter factory 생성을 검증했다.
+- `:feature:home:testAndroidHostTest`, `:composeApp:testAndroidHostTest`가 통과했다.
+- 이번 변경 Kotlin 파일의 Spotless IDE hook과 `:feature:home:detekt`, `:composeApp:detekt`가 통과했다.
+- 전체 Home Spotless check는 기존 파일들의 상수 naming/format baseline 위반도 함께 검사하므로 이번 PR에서 일괄 수정하지 않았다. 필수 CI에는 Spotless가 포함돼 있지 않으며, 새 파일과 변경 라인은 별도로 포맷했다.
+- Android/iOS build와 전체 회귀 테스트는 PR CI에서 확인한다.

--- a/docs/CIRCUIT_METRO_KMP_MIGRATION_MAP.md
+++ b/docs/CIRCUIT_METRO_KMP_MIGRATION_MAP.md
@@ -335,12 +335,18 @@ Presenter 테스트는 Circuit 공식 `Presenter.test`/Turbine 패턴을 유지�
 - [x] Metro가 주입한 KMP `ImageHandlerProvider`로 save/share side effect 연결
 - [x] Complete/LegacyHome Presenter와 Metro factory Android host test 통과
 - [x] 변경 모듈 Spotless/Detekt 통과
-- [ ] iOS Simulator Arm64 framework link 검증
+- [x] CI에서 iOS Simulator Arm64 framework link 검증
 - [ ] 양 플랫폼 이동·뒤로가기·저장·공유 수동 검증
 
 ### 6-B. Home 읽기
 
-- 목록, 최근 항목, 빈 목록 생성, 완료 감지
+- [x] runtime 미연결 `HomeScreen`/Metro assisted Presenter 계약 추가
+- [x] 목록, 최근 항목, 빈 목록 생성, 상세·셀 트리와 완료 감지 이식
+- [x] Circuit 공식 Presenter test로 대표 읽기 상태 전이 검증
+- [x] Metro graph에서 Home Presenter factory 생성 검증
+- [x] 변경 Kotlin 파일 Spotless 포맷과 Home/composeApp Detekt 통과
+- [ ] CI에서 전체 unit test, Android Lint, Android/iOS build 검증
+- runtime 교체는 편집/modal과 플랫폼 effect까지 이식한 뒤 한 번에 수행한다.
 
 ### 6-C. Home 편집/modal
 

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -1,9 +1,22 @@
 plugins {
     id("bandalart.kmp.feature")
     id("bandalart.kotlin.serialization")
+    id("org.jetbrains.kotlin.plugin.parcelize")
+    alias(libs.plugins.metro)
+}
+
+metro {
+    enableCircuitCodegen.set(true)
 }
 
 kotlin {
+    targets.withType<com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget>().configureEach {
+        compilerOptions.freeCompilerArgs.addAll(
+            "-P",
+            "plugin:org.jetbrains.kotlin.parcelize:additionalAnnotation=com.nexters.bandalart.core.navigation.CommonParcelize",
+        )
+    }
+
     sourceSets {
         commonMain.dependencies {
             implementation(projects.core.common)
@@ -20,6 +33,9 @@ kotlin {
             implementation(libs.koin.compose.viewmodel)
             implementation(libs.koin.compose.viewmodel.navigation)
 
+            implementation(libs.circuit.runtime)
+            implementation(libs.circuit.runtime.presenter)
+
             implementation(libs.kotlinx.collections.immutable)
             implementation(libs.kotlinx.datetime)
             implementation(libs.kotlinx.coroutines.core)
@@ -30,6 +46,7 @@ kotlin {
 
         androidHostTest.dependencies {
             implementation(libs.bundles.android.unit.test)
+            implementation(libs.circuit.test)
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.turbine)
         }

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home.presenter
+
+import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
+import com.nexters.bandalart.core.domain.entity.BandalartEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartEmojiEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
+import com.nexters.bandalart.core.domain.repository.BandalartRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+internal class FakeBandalartRepository(
+    initialBandalarts: List<BandalartEntity>,
+    recentBandalartId: Long = 0L,
+    private val previousBandalartList: List<Pair<Long, Boolean>> =
+        initialBandalarts.map { it.id to it.isCompleted },
+    private val createdBandalart: BandalartEntity? = null,
+    details: Map<Long, BandalartEntity> = initialBandalarts.associateBy { it.id },
+    private val mainCells: Map<Long, BandalartCellEntity> = emptyMap(),
+    private val childCells: Map<Long, List<BandalartCellEntity>> = emptyMap(),
+) : BandalartRepository {
+    private val bandalartFlow = MutableStateFlow(initialBandalarts)
+    private val details = details.toMutableMap()
+
+    var recentBandalartId: Long = recentBandalartId
+        private set
+
+    var createCalls: Int = 0
+        private set
+
+    val completionUpdates = mutableListOf<Pair<Long, Boolean>>()
+
+    override suspend fun createBandalart(): BandalartEntity? {
+        createCalls += 1
+        return createdBandalart?.also { bandalart ->
+            details[bandalart.id] = bandalart
+            bandalartFlow.value = bandalartFlow.value + bandalart
+        }
+    }
+
+    override fun getBandalartList(): Flow<List<BandalartEntity>> = bandalartFlow
+
+    override suspend fun getBandalart(bandalartId: Long): BandalartEntity = requireNotNull(details[bandalartId])
+
+    override suspend fun getBandalartMainCell(bandalartId: Long): BandalartCellEntity? = mainCells[bandalartId]
+
+    override suspend fun getChildCells(parentId: Long): List<BandalartCellEntity> = childCells[parentId].orEmpty()
+
+    override suspend fun setRecentBandalartId(recentBandalartId: Long) {
+        this.recentBandalartId = recentBandalartId
+    }
+
+    override suspend fun getRecentBandalartId(): Long = recentBandalartId
+
+    override suspend fun getPrevBandalartList(): List<Pair<Long, Boolean>> = previousBandalartList
+
+    override suspend fun upsertBandalartId(
+        bandalartId: Long,
+        isCompleted: Boolean,
+    ) {
+        completionUpdates += bandalartId to isCompleted
+    }
+
+    override suspend fun deleteBandalart(bandalartId: Long) = error("Not used")
+
+    override suspend fun updateBandalartMainCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartMainCellEntity: UpdateBandalartMainCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartSubCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartSubCellEntity: UpdateBandalartSubCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartTaskCell(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartTaskCellEntity: UpdateBandalartTaskCellEntity,
+    ) = error("Not used")
+
+    override suspend fun updateBandalartEmoji(
+        bandalartId: Long,
+        cellId: Long,
+        updateBandalartEmojiEntity: UpdateBandalartEmojiEntity,
+    ) = error("Not used")
+
+    override suspend fun deleteBandalartCell(cellId: Long) = error("Not used")
+
+    override suspend fun checkCompletedBandalartId(bandalartId: Long): Boolean = error("Not used")
+
+    override suspend fun deleteCompletedBandalartId(bandalartId: Long) = error("Not used")
+}

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home.presenter
+
+import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
+import com.nexters.bandalart.core.domain.entity.BandalartEntity
+import com.nexters.bandalart.feature.home.HomeScreen
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuit.test.test
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class HomePresenterTest {
+    @Test
+    fun mostRecentlyOpenedBandalartAndCellTreeAreLoaded() =
+        runTest {
+            val mainCell = cell(id = 20L, parentId = null)
+            val subCell = cell(id = 21L, parentId = mainCell.id)
+            val taskCell = cell(id = 22L, parentId = subCell.id)
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1L), bandalart(2L)),
+                    recentBandalartId = 2L,
+                    mainCells = mapOf(2L to mainCell),
+                    childCells =
+                        mapOf(
+                            mainCell.id to listOf(subCell),
+                            subCell.id to listOf(taskCell),
+                        ),
+                )
+            val presenter = HomePresenter(FakeNavigator(HomeScreen), repository)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != 2L || state.isLoading) {
+                    state = awaitItem()
+                }
+
+                assertEquals(2, state.bandalartList.size)
+                assertEquals(2L, state.bandalartData?.id)
+                assertEquals(mainCell.id, state.bandalartCellData?.id)
+                assertEquals(
+                    subCell.id,
+                    state.bandalartCellData
+                        ?.children
+                        ?.single()
+                        ?.id,
+                )
+                assertEquals(
+                    taskCell.id,
+                    state.bandalartCellData
+                        ?.children
+                        ?.single()
+                        ?.children
+                        ?.single()
+                        ?.id,
+                )
+            }
+        }
+
+    @Test
+    fun firstBandalartIsUsedWhenRecentIdIsMissing() =
+        runTest {
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1L), bandalart(2L)),
+                    recentBandalartId = 99L,
+                )
+            val presenter = HomePresenter(FakeNavigator(HomeScreen), repository)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData == null || state.isLoading) {
+                    state = awaitItem()
+                }
+
+                assertEquals(1L, state.bandalartData?.id)
+            }
+        }
+
+    @Test
+    fun emptyListCreatesOneInitialBandalart() =
+        runTest {
+            val created = bandalart(3L)
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = emptyList(),
+                    createdBandalart = created,
+                )
+            val presenter = HomePresenter(FakeNavigator(HomeScreen), repository)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != created.id || state.isLoading) {
+                    state = awaitItem()
+                }
+
+                assertEquals(1, repository.createCalls)
+                assertEquals(created.id, repository.recentBandalartId)
+                assertTrue(repository.completionUpdates.contains(created.id to false))
+            }
+        }
+
+    @Test
+    fun newlyCompletedBandalartIsSelectedWithoutAdvancingCompletionSnapshot() =
+        runTest {
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts =
+                        listOf(
+                            bandalart(1L),
+                            bandalart(2L, isCompleted = true),
+                        ),
+                    recentBandalartId = 1L,
+                    previousBandalartList = listOf(1L to false, 2L to false),
+                )
+            val presenter = HomePresenter(FakeNavigator(HomeScreen), repository)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != 2L || state.isLoading) {
+                    state = awaitItem()
+                }
+
+                assertTrue(state.isBandalartCompleted)
+                assertTrue(repository.completionUpdates.isEmpty())
+            }
+        }
+
+    @Test
+    fun selectingBandalartUpdatesRecentIdAndDetail() =
+        runTest {
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1L), bandalart(2L)),
+                    recentBandalartId = 1L,
+                )
+            val presenter = HomePresenter(FakeNavigator(HomeScreen), repository)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != 1L || state.isLoading) {
+                    state = awaitItem()
+                }
+
+                state.eventSink(HomeScreen.Event.SelectBandalart(2L))
+                do {
+                    state = awaitItem()
+                } while (state.bandalartData?.id != 2L || state.isLoading)
+
+                assertEquals(2L, repository.recentBandalartId)
+                assertFalse(state.isBandalartCompleted)
+            }
+        }
+
+    private fun bandalart(
+        id: Long,
+        isCompleted: Boolean = false,
+    ) = BandalartEntity(
+        id = id,
+        mainColor = "#3FFFBA",
+        subColor = "#111827",
+        profileEmoji = "🎯",
+        title = "반다라트 $id",
+        description = "설명 $id",
+        dueDate = null,
+        isCompleted = isCompleted,
+        completionRatio = if (isCompleted) 100 else 0,
+    )
+
+    private fun cell(
+        id: Long,
+        parentId: Long?,
+    ) = BandalartCellEntity(
+        id = id,
+        title = "셀 $id",
+        description = "설명 $id",
+        dueDate = null,
+        isCompleted = false,
+        parentId = parentId,
+    )
+}

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home
+
+import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
+import com.nexters.bandalart.core.navigation.CommonParcelize
+import com.nexters.bandalart.feature.home.model.BandalartUiModel
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+import com.slack.circuit.runtime.screen.ParcelableScreen
+import com.slack.circuit.runtime.screen.StaticScreen
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+@CommonParcelize
+data object HomeScreen : ParcelableScreen, StaticScreen {
+    data class State(
+        val bandalartList: ImmutableList<BandalartUiModel> = persistentListOf(),
+        val bandalartData: BandalartUiModel? = null,
+        val bandalartCellData: BandalartCellEntity? = null,
+        val isLoading: Boolean = true,
+        val isBandalartCompleted: Boolean = false,
+        val eventSink: (Event) -> Unit,
+    ) : CircuitUiState
+
+    sealed interface Event : CircuitUiEvent {
+        data class SelectBandalart(
+            val bandalartId: Long,
+        ) : Event
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
@@ -204,7 +204,7 @@ internal fun HomeRoute(
         }
     }
 
-    HomeScreen(
+    HomeContent(
         uiState = uiState,
         onHomeUiAction = viewModel::onAction,
         shareBandalart = viewModel::shareBandalart,
@@ -216,7 +216,7 @@ internal fun HomeRoute(
 }
 
 @Composable
-internal fun HomeScreen(
+internal fun HomeContent(
     uiState: HomeUiState,
     onHomeUiAction: (HomeUiAction) -> Unit,
     shareBandalart: (ImageBitmap) -> Unit,
@@ -320,7 +320,7 @@ internal fun HomeScreen(
 @Composable
 private fun HomeScreenSingleBandalartPreview() {
     BandalartTheme {
-        HomeScreen(
+        HomeContent(
             uiState = HomeUiState(
                 bandalartList = listOf(dummyBandalartList[0]).toImmutableList(),
                 bandalartData = dummyBandalartData,
@@ -340,7 +340,7 @@ private fun HomeScreenSingleBandalartPreview() {
 @Composable
 private fun HomeScreenMultipleBandalartPreview() {
     BandalartTheme {
-        HomeScreen(
+        HomeContent(
             uiState = HomeUiState(
                 bandalartList = dummyBandalartList.toImmutableList(),
                 bandalartData = dummyBandalartData,

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home.presenter
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
+import com.nexters.bandalart.core.domain.repository.BandalartRepository
+import com.nexters.bandalart.feature.home.HomeScreen
+import com.nexters.bandalart.feature.home.mapper.toUiModel
+import com.nexters.bandalart.feature.home.model.BandalartUiModel
+import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.launch
+
+@AssistedInject
+class HomePresenter(
+    @Suppress("UnusedPrivateProperty")
+    @Assisted navigator: Navigator,
+    private val bandalartRepository: BandalartRepository,
+) : Presenter<HomeScreen.State> {
+    @Composable
+    override fun present(): HomeScreen.State {
+        var bandalartList by remember { mutableStateOf(persistentListOf<BandalartUiModel>()) }
+        var bandalartData by remember { mutableStateOf<BandalartUiModel?>(null) }
+        var bandalartCellData by remember { mutableStateOf<BandalartCellEntity?>(null) }
+        var isLoading by remember { mutableStateOf(true) }
+        var isBandalartCompleted by remember { mutableStateOf(false) }
+        var isCreatingEmptyBandalart by remember { mutableStateOf(false) }
+        val scope = rememberCoroutineScope()
+
+        suspend fun loadBandalart(
+            bandalartId: Long,
+            isCompleted: Boolean = false,
+        ) {
+            isLoading = true
+            bandalartData = bandalartRepository.getBandalart(bandalartId).toUiModel()
+
+            val mainCell = bandalartRepository.getBandalartMainCell(bandalartId)
+            val subCells = bandalartRepository.getChildCells(mainCell?.id ?: 0L)
+            val children =
+                subCells.map { subCell ->
+                    val taskCells = bandalartRepository.getChildCells(subCell.id)
+                    BandalartCellEntity(
+                        id = subCell.id,
+                        title = subCell.title,
+                        description = subCell.description,
+                        dueDate = subCell.dueDate,
+                        isCompleted = subCell.isCompleted,
+                        parentId = subCell.parentId,
+                        children =
+                            taskCells.map { taskCell ->
+                                BandalartCellEntity(
+                                    id = taskCell.id,
+                                    title = taskCell.title,
+                                    description = taskCell.description,
+                                    dueDate = taskCell.dueDate,
+                                    isCompleted = taskCell.isCompleted,
+                                    parentId = taskCell.parentId,
+                                    children = emptyList(),
+                                )
+                            },
+                    )
+                }
+
+            bandalartCellData =
+                BandalartCellEntity(
+                    id = mainCell?.id ?: 0L,
+                    title = mainCell?.title,
+                    description = mainCell?.description,
+                    dueDate = mainCell?.dueDate,
+                    isCompleted = mainCell?.isCompleted ?: false,
+                    parentId = mainCell?.parentId,
+                    children = children,
+                )
+            isBandalartCompleted = isCompleted
+            isLoading = false
+        }
+
+        suspend fun createInitialBandalart() {
+            if (isCreatingEmptyBandalart) return
+
+            isCreatingEmptyBandalart = true
+            bandalartRepository.createBandalart()?.let { bandalart ->
+                bandalartRepository.setRecentBandalartId(bandalart.id)
+                bandalartRepository.upsertBandalartId(bandalart.id, bandalart.isCompleted)
+                loadBandalart(bandalart.id)
+            }
+        }
+
+        LaunchedEffect(Unit) {
+            bandalartRepository.getBandalartList().collect { entities ->
+                val currentList = entities.map { it.toUiModel() }
+                bandalartList = currentList.toPersistentList()
+
+                val previousList = bandalartRepository.getPrevBandalartList()
+                val newlyCompletedIds =
+                    currentList
+                        .filter { bandalart ->
+                            val previous = previousList.find { it.first == bandalart.id }
+                            previous != null && !previous.second && bandalart.isCompleted
+                        }.map { it.id }
+
+                if (newlyCompletedIds.isNotEmpty()) {
+                    loadBandalart(
+                        bandalartId = newlyCompletedIds.first(),
+                        isCompleted = true,
+                    )
+                    return@collect
+                }
+
+                currentList.forEach { bandalart ->
+                    bandalartRepository.upsertBandalartId(
+                        bandalartId = bandalart.id,
+                        isCompleted = bandalart.isCompleted,
+                    )
+                }
+
+                if (currentList.isEmpty()) {
+                    createInitialBandalart()
+                    return@collect
+                }
+
+                isCreatingEmptyBandalart = false
+                val recentBandalartId = bandalartRepository.getRecentBandalartId()
+                val selectedId =
+                    recentBandalartId.takeIf { recentId ->
+                        currentList.any { it.id == recentId }
+                    } ?: currentList.first().id
+                loadBandalart(selectedId)
+            }
+        }
+
+        return HomeScreen.State(
+            bandalartList = bandalartList,
+            bandalartData = bandalartData,
+            bandalartCellData = bandalartCellData,
+            isLoading = isLoading,
+            isBandalartCompleted = isBandalartCompleted,
+        ) { event ->
+            when (event) {
+                is HomeScreen.Event.SelectBandalart -> {
+                    scope.launch {
+                        bandalartRepository.setRecentBandalartId(event.bandalartId)
+                        loadBandalart(event.bandalartId)
+                    }
+                }
+            }
+        }
+    }
+
+    @CircuitInject(HomeScreen::class, AppScope::class)
+    @AssistedFactory
+    fun interface Factory {
+        fun create(
+            @Assisted navigator: Navigator,
+        ): HomePresenter
+    }
+}


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #182

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- Home 목록·최근 항목·빈 목록 생성·상세와 셀 트리·완료 전환 감지를 KMP Circuit Presenter로 이식했습니다.
- 새 Home Presenter를 Metro Circuit graph에 등록하되, 편집/modal과 플랫폼 effect 이식 전까지 기존 ViewModel runtime 경로는 유지했습니다.
- Circuit 공식 Presenter test 5개와 Metro graph test를 추가하고 단계 전략/마이그레이션 문서를 갱신했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `./gradlew :feature:home:testAndroidHostTest :composeApp:testAndroidHostTest`
- `./gradlew :feature:home:detekt :composeApp:detekt`
- 이번 변경 Kotlin 파일 Spotless IDE hook

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| UI 변경 없음 | - | runtime 미연결 | - |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 이번 6-B는 shadow Presenter 단계입니다. `LegacyHomeScreen → HomeRoute → HomeViewModel` runtime은 그대로이며, 6-C 편집/modal과 6-D 플랫폼 effect 완료 후 한 번에 교체합니다.
- 전체 Home Spotless check의 기존 baseline 위반은 이 PR에서 일괄 수정하지 않았고 새 파일과 변경 라인만 포맷했습니다.

## 💡 코드리뷰 Tip

Gemini Code Assist 리뷰 코멘트가 달리면 `resolve-gemini-review`를 실행하여 미해결 코멘트를 반영하거나 거절 사유를 남길 수 있습니다.
