### PR TITLE
refactor: Home 편집 상태를 Circuit으로 전환

### DIFF
--- a/docs/CIRCUIT_HOME_EDIT_MIGRATION_STRATEGY.md
+++ b/docs/CIRCUIT_HOME_EDIT_MIGRATION_STRATEGY.md
@@ -1,0 +1,213 @@
+# Circuit Home 편집/modal 전환 전략
+
+## 1. 목적
+
+이 문서는 이슈 #182의 6-C 단계인 Home 생성·편집·삭제와 modal 상태의 Circuit Presenter 전환 범위와 검증 기준을 구현 전에 고정한다.
+
+- 기준 브랜치: `main` (`596859a884560cebce9aa006e5892d344a3f3bd8`)
+- 작업 브랜치: `refactor/circuit-home-edit`
+- 선행 작업: PR #196의 Home 읽기 shadow Presenter
+- 대상: 반다라트 생성 제한, 셀 편집 draft, 목록/셀/emoji bottom sheet, 삭제 dialog, dropdown, repository mutation
+- 목표: 사용자 편집 상태를 `rememberRetained`로 보존하고 기존 KMP repository mutation을 Circuit Event로 연결한다.
+- 비목표: Home runtime 교체, 공유·저장·capture, Complete 이동, Android 선택 업데이트, 앱 버전 effect, Koin/ViewModel/Compose Navigation 제거
+
+## 2. 기준 구현과 우선순위
+
+### `main`은 제품 동작 기준이다
+
+- KMP `HomeViewModel`, `HomeUiState/Action/Event`, `HomeBottomSheets`, `HomeDialogs`와 현재 repository entity를 기준으로 한다.
+- 이미 KMP로 이전된 `Locale`, Compose resources, Room/DataStore와 Android/iOS UI를 재구현하지 않는다.
+- 색상/emoji draft가 실제 Home state에 반영되는 시점처럼 `develop`과 동작이 다르면 `main` 동작을 보존한다.
+
+### `develop`은 Circuit 구조 참고다
+
+- Screen 내부 `BottomSheetState`, `DialogState`, Event 계약과 Presenter의 `rememberRetained` 사용 방식을 참고한다.
+- Hilt `ActivityRetainedComponent`, `java.util.Locale`, Android resource, `InAppUpdateRepository`와 플랫폼 image effect는 가져오지 않는다.
+- `develop`의 모든 Presenter state를 retained로 두는 방식은 복사하지 않는다.
+
+## 3. 단계 경계
+
+6-C에서도 새 Home Presenter는 runtime에 연결하지 않는다.
+
+```text
+현재 runtime
+  LegacyHomeScreen → HomeRoute → HomeViewModel
+
+6-C shadow graph
+  HomeScreen → HomePresenter(read + edit/modal, runtime 미연결)
+```
+
+새 Presenter와 기존 ViewModel을 동시에 composition하면 repository collector와 mutation이 중복 실행될 수 있다. runtime 교체는 6-D 플랫폼 effect와 Home UI factory까지 준비된 뒤 한 번에 수행한다.
+
+## 4. State 보존 정책
+
+### 일반 `remember`
+
+repository에서 다시 만들 수 있는 아래 상태는 PR #196과 같이 일반 `remember`를 유지한다.
+
+- 반다라트 목록과 선택 상세
+- main/sub/task 셀 트리
+- loading과 완료 전환 여부
+- 빈 목록 생성 guard
+
+### `rememberRetained`
+
+사용자가 modal에서 작성 중이며 화면 재생성 시 잃으면 안 되는 상태만 retained 처리한다.
+
+- 현재 `BottomSheetState`
+- 현재 `DialogState`
+- cell 편집 draft에 포함된 title, description, due date, completion
+- main cell 편집 draft에 포함된 emoji와 theme color
+- date picker/emoji picker 펼침 상태
+
+dropdown은 사용자 입력 draft가 아닌 일시적 UI이므로 일반 `remember`로 둔다. repository state 전체나 one-shot effect를 retained로 두지 않는다.
+
+## 5. Screen 계약 확장
+
+### State
+
+PR #196의 읽기 State에 다음을 추가한다.
+
+- `bottomSheet`
+- `dialog`
+- `isDropDownMenuOpened`
+- 클릭한 cell type/data 또는 삭제 dialog에 필요한 동등 정보
+- UI가 한 번 소비할 snackbar/toast effect
+
+### Bottom sheet
+
+- `Cell`: 원본 cell/Bandalart와 편집 draft, date/emoji picker 펼침 상태
+- `BandalartList`: 현재 목록과 선택 ID
+- `Emoji`: 현재 반다라트/셀 ID와 emoji
+
+### Dialog
+
+- 반다라트 삭제 확인
+- cell type/title/id를 포함한 셀 삭제 확인
+
+삭제 실행에 필요한 값을 dialog 자체에 포함할 수 있으면 별도 `clickedCellData` 복제를 줄인다. 다만 기존 Home UI 변경이 커지면 현재 State 형태를 우선 유지한다.
+
+### Event
+
+- modal/dropdown 열기·닫기
+- 목록 항목 선택과 최대 5개 제한이 있는 새 반다라트 생성
+- cell 클릭과 main goal 선행 검증
+- title/description/due date/completion/emoji/color draft 갱신
+- main/sub/task update 확정
+- 반다라트/cell 삭제 확정
+- main emoji 빠른 변경
+- snackbar/toast effect 소비
+
+공유·저장·capture·Complete·업데이트와 앱 버전 Event는 6-D에서 추가한다.
+
+## 6. mutation 동작
+
+### 생성
+
+1. 현재 목록이 5개면 repository를 호출하지 않고 제한 toast effect를 노출한다.
+2. 생성 성공 시 최근 ID와 완료 snapshot을 기록한다.
+3. 생성된 상세를 선택하고 열린 bottom sheet를 닫는다.
+4. 생성 snackbar effect를 노출한다.
+
+빈 목록 자동 생성은 PR #196의 읽기 책임을 그대로 사용하고, 사용자 `Add` Event만 이번 단계에서 추가한다.
+
+### cell 편집
+
+- main goal이 비어 있을 때 sub/task 편집 진입을 막고 toast effect를 노출한다.
+- title은 현재 KMP `Locale` 기준으로 한국어/일본어 15자, 그 외 24자를 유지한다.
+- description은 1000자를 초과하면 직전 유효값을 유지한다.
+- due date의 빈 문자열은 repository update 직전에 `null`로 정규화한다.
+- main update에는 emoji와 main/sub color를 포함한다.
+- task update에만 completion 값을 전달한다.
+- update 성공 후 bottom sheet를 닫는다.
+
+### 삭제
+
+- 반다라트 삭제 후 완료 snapshot ID도 제거한다.
+- cell 삭제는 선택한 cell ID만 repository에 전달한다.
+- 삭제 완료 후 dialog와 bottom sheet를 함께 닫는다.
+- 반다라트 삭제 시 dropdown도 닫는다.
+- 성공 snackbar는 반다라트 삭제에만 현재 `main` 동작대로 노출한다.
+
+## 7. one-shot effect 경계
+
+생성 제한, main goal 선행 검증, 생성/삭제 안내는 6-C 동작 검증에 필요하므로 공통 UI effect로 모델링한다.
+
+- effect는 retained state로 보존하지 않는다.
+- UI가 `ConsumeEffect` Event로 명시적으로 지운다.
+- `ImageBitmap`, Android Play API와 플랫폼 handler를 Screen 계약에 넣지 않는다.
+- runtime이 아직 legacy이므로 실제 Snackbar/Toast UI 연결은 6-D runtime 교체 시 검증한다.
+
+## 8. 테스트 계획
+
+기존 `FakeBandalartRepository`를 별도 파일에서 확장하고 mutation 호출을 기록한다.
+
+### 생성
+
+- 5개 미만에서 생성, 최근 ID와 완료 snapshot 갱신, 상세 선택, modal 닫힘
+- 5개에서 생성 미호출과 제한 effect
+
+### modal/draft
+
+- 목록/emoji/cell bottom sheet 열기·닫기
+- 반다라트/cell 삭제 dialog 열기·취소
+- cell draft의 title 길이, description 길이, due date와 picker 상태
+- main draft의 emoji/color와 task completion 갱신
+- `rememberRetained` 대상이 Presenter 재생성 후 유지되는지 Circuit test API로 가능한 범위에서 검증
+
+### repository mutation
+
+- main/sub/task update entity가 정확한 값으로 호출되는지 검증
+- 반다라트 삭제 시 completion snapshot ID도 제거되는지 검증
+- cell 삭제 ID와 modal 종료 검증
+- 빠른 emoji update 호출과 bottom sheet 종료 검증
+
+### 회귀
+
+- PR #196의 최근 항목, fallback, 빈 목록, 셀 트리, 완료 전환 테스트 유지
+- Metro graph의 Home Presenter factory 생성 테스트 유지
+
+## 9. 검증 기준
+
+- `feature:home` Android host Presenter/ViewModel test 통과
+- `composeApp` Metro graph test 통과
+- 이번 변경 Kotlin 파일 Spotless 포맷 통과
+- `feature:home`, `composeApp` Detekt 통과
+- PR CI의 전체 unit test, Android Lint, Android assemble, iOS simulator framework link 통과
+- runtime 미연결이므로 이 단계에서 별도 UI 수동 검증은 하지 않는다.
+
+## 10. 예상 구현 순서
+
+1. `HomeScreen`에 edit/modal State/Event/effect 계약을 추가한다.
+2. `HomePresenter`에 retained modal/draft와 일반 dropdown/effect 상태를 추가한다.
+3. 생성, draft validation과 main/sub/task update를 연결한다.
+4. 삭제 dialog와 repository delete를 연결한다.
+5. fake repository mutation 기록과 Presenter test를 추가한다.
+6. Metro graph와 기존 legacy 테스트를 함께 검증한다.
+7. 마이그레이션 맵과 실제 troubleshooting을 갱신한다.
+
+## 11. 롤백 경계
+
+- 새 edit/modal 계약과 Presenter 로직은 shadow graph에서만 실행된다.
+- repository interface, DB schema, DataStore key와 legacy runtime은 변경하지 않는다.
+- 문제가 생기면 PR #196의 read-only Home Presenter 상태로 되돌릴 수 있다.
+
+## 12. 참고 자료
+
+- [Circuit retained state](https://slackhq.github.io/circuit/state/)
+- [Circuit Presenter testing](https://slackhq.github.io/circuit/docs/testing/)
+- `main`의 `HomeViewModel`, `HomeUiState/Action/Event`
+- `origin/develop`의 `HomeScreen`, `HomePresenter`
+
+## 13. 구현 및 로컬 검증 결과
+
+- `circuit-retained`를 Home feature에 직접 선언하고 bottom sheet/dialog에만 `rememberRetained`를 적용했다.
+- repository에서 다시 읽는 목록·상세·셀 트리와 loading/completion은 일반 `remember`를 유지했다.
+- Cell bottom sheet가 원본과 편집 draft, cell type, date/emoji picker 상태를 함께 소유하도록 계약을 확장했다.
+- 생성 제한, 목록/emoji/cell modal, title/description/due date/completion/emoji/color draft와 main/sub/task update를 Presenter Event로 연결했다.
+- 반다라트/cell 삭제와 완료 snapshot 정리를 연결하고 삭제 대상은 dialog State에 포함했다.
+- snackbar/toast는 플랫폼 문자열이나 UI를 참조하지 않는 공통 Effect 종류로만 추가했다.
+- 기존 read test 5개와 legacy HomeViewModel test를 유지하고 edit/modal Presenter test 7개를 별도 파일로 추가했다.
+- `:feature:home:testAndroidHostTest`, `:composeApp:testAndroidHostTest`가 통과했다.
+- 변경 Kotlin 파일 Spotless IDE hook과 `:feature:home:detekt`, `:composeApp:detekt`가 통과했다.
+- 전체 unit test, Android Lint, Android/iOS build는 PR CI에서 확인한다.

--- a/docs/CIRCUIT_HOME_READ_MIGRATION_STRATEGY.md
+++ b/docs/CIRCUIT_HOME_READ_MIGRATION_STRATEGY.md
@@ -114,7 +114,7 @@
 - 기존 `LegacyHomeScreen` UI/Presenter와 Home ViewModel test가 계속 통과한다.
 - Home feature 및 composeApp Android host test가 통과한다.
 - 이번 변경 Kotlin 파일의 Spotless 포맷과 Home/composeApp Detekt가 통과한다.
-- CI의 Android/iOS build가 통과한다.
+- PR #196 CI의 전체 unit test, Android Lint, Android assemble와 iOS simulator framework link가 통과했다.
 
 ### 수동 검증
 
@@ -143,4 +143,4 @@
 - `:feature:home:testAndroidHostTest`, `:composeApp:testAndroidHostTest`가 통과했다.
 - 이번 변경 Kotlin 파일의 Spotless IDE hook과 `:feature:home:detekt`, `:composeApp:detekt`가 통과했다.
 - 전체 Home Spotless check는 기존 파일들의 상수 naming/format baseline 위반도 함께 검사하므로 이번 PR에서 일괄 수정하지 않았다. 필수 CI에는 Spotless가 포함돼 있지 않으며, 새 파일과 변경 라인은 별도로 포맷했다.
-- Android/iOS build와 전체 회귀 테스트는 PR CI에서 확인한다.
+- PR #196 CI의 전체 unit test, Android Lint, Android assemble와 iOS simulator framework link가 20분 46초에 통과했다.

--- a/docs/CIRCUIT_METRO_KMP_MIGRATION_MAP.md
+++ b/docs/CIRCUIT_METRO_KMP_MIGRATION_MAP.md
@@ -345,12 +345,18 @@ Presenter 테스트는 Circuit 공식 `Presenter.test`/Turbine 패턴을 유지�
 - [x] Circuit 공식 Presenter test로 대표 읽기 상태 전이 검증
 - [x] Metro graph에서 Home Presenter factory 생성 검증
 - [x] 변경 Kotlin 파일 Spotless 포맷과 Home/composeApp Detekt 통과
-- [ ] CI에서 전체 unit test, Android Lint, Android/iOS build 검증
+- [x] PR #196 CI에서 전체 unit test, Android Lint, Android/iOS build 검증
 - runtime 교체는 편집/modal과 플랫폼 effect까지 이식한 뒤 한 번에 수행한다.
 
 ### 6-C. Home 편집/modal
 
-- 생성/편집/삭제, bottom sheet/dialog retained state
+- [x] 최대 5개 제한을 포함한 사용자 생성 Event
+- [x] main/sub/task 편집 draft와 repository update
+- [x] 반다라트/cell 삭제와 완료 snapshot 정리
+- [x] bottom sheet/dialog 사용자 draft만 `rememberRetained` 적용
+- [x] 생성·삭제·validation UI effect와 Presenter test
+- [x] Home/composeApp Android host test와 Detekt 통과
+- [ ] CI에서 전체 unit test, Android Lint, Android/iOS build 검증
 
 ### 6-D. Home 플랫폼 effect
 

--- a/docs/KMP_METRO_MIGRATION_TROUBLESHOOTING.md
+++ b/docs/KMP_METRO_MIGRATION_TROUBLESHOOTING.md
@@ -400,6 +400,24 @@ KMP Android convention의 host unit test option에 `isReturnDefaultValues = true
 
 KMP test source set에서는 다른 module의 transitive test dependency를 가정하지 않고, 사용하는 test runtime을 해당 source set에 직접 선언한다.
 
+## 20. Presenter test에서 동일한 State를 기다리면 timeout 발생
+
+### 증상
+
+Home 편집 Presenter test에서 최대 길이를 초과한 title을 입력한 뒤 `awaitItem()`을 호출하자 `No value produced in 3s`로 실패했다.
+
+### 원인
+
+validation은 초과 입력을 버리고 기존 draft를 그대로 유지한다. `mutableStateOf`의 새 값이 기존 State와 구조적으로 같으므로 recomposition과 새 Turbine item이 발생하지 않는다. timeout은 Presenter 실패가 아니라 테스트가 존재하지 않는 State 변경을 기다린 결과다.
+
+### 해결
+
+- 거절된 입력은 `expectNoEvents()`로 검증한다.
+- 기존에 받은 State의 draft 값이 유지되는지도 함께 확인한다.
+- 실제 State가 바뀌는 유효 입력과 repository mutation은 계속 `awaitItem()`으로 검증한다.
+
+Circuit Presenter test에서 모든 Event가 새 item을 만든다고 가정하지 않는다. no-op과 validation 거절은 이벤트 없음 자체가 계약이다.
+
 ## 참고 문서
 
 - [KMP AGP 9 마이그레이션 전략](KMP_AGP_9_MIGRATION_STRATEGY.md)

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -35,6 +35,7 @@ kotlin {
 
             implementation(libs.circuit.runtime)
             implementation(libs.circuit.runtime.presenter)
+            implementation(libs.circuit.retained)
 
             implementation(libs.kotlinx.collections.immutable)
             implementation(libs.kotlinx.datetime)

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
@@ -46,6 +46,16 @@ internal class FakeBandalartRepository(
         private set
 
     val completionUpdates = mutableListOf<Pair<Long, Boolean>>()
+    val deletedBandalartIds = mutableListOf<Long>()
+    val deletedCellIds = mutableListOf<Long>()
+    val deletedCompletionIds = mutableListOf<Long>()
+    val emojiUpdates = mutableListOf<EmojiUpdate>()
+    var mainCellUpdate: MainCellUpdate? = null
+        private set
+    var subCellUpdate: SubCellUpdate? = null
+        private set
+    var taskCellUpdate: TaskCellUpdate? = null
+        private set
 
     override suspend fun createBandalart(): BandalartEntity? {
         createCalls += 1
@@ -78,35 +88,95 @@ internal class FakeBandalartRepository(
         completionUpdates += bandalartId to isCompleted
     }
 
-    override suspend fun deleteBandalart(bandalartId: Long) = error("Not used")
+    override suspend fun deleteBandalart(bandalartId: Long) {
+        deletedBandalartIds += bandalartId
+        details.remove(bandalartId)
+        bandalartFlow.value = bandalartFlow.value.filterNot { it.id == bandalartId }
+    }
 
     override suspend fun updateBandalartMainCell(
         bandalartId: Long,
         cellId: Long,
         updateBandalartMainCellEntity: UpdateBandalartMainCellEntity,
-    ) = error("Not used")
+    ) {
+        mainCellUpdate =
+            MainCellUpdate(
+                bandalartId = bandalartId,
+                cellId = cellId,
+                entity = updateBandalartMainCellEntity,
+            )
+    }
 
     override suspend fun updateBandalartSubCell(
         bandalartId: Long,
         cellId: Long,
         updateBandalartSubCellEntity: UpdateBandalartSubCellEntity,
-    ) = error("Not used")
+    ) {
+        subCellUpdate =
+            SubCellUpdate(
+                bandalartId = bandalartId,
+                cellId = cellId,
+                entity = updateBandalartSubCellEntity,
+            )
+    }
 
     override suspend fun updateBandalartTaskCell(
         bandalartId: Long,
         cellId: Long,
         updateBandalartTaskCellEntity: UpdateBandalartTaskCellEntity,
-    ) = error("Not used")
+    ) {
+        taskCellUpdate =
+            TaskCellUpdate(
+                bandalartId = bandalartId,
+                cellId = cellId,
+                entity = updateBandalartTaskCellEntity,
+            )
+    }
 
     override suspend fun updateBandalartEmoji(
         bandalartId: Long,
         cellId: Long,
         updateBandalartEmojiEntity: UpdateBandalartEmojiEntity,
-    ) = error("Not used")
+    ) {
+        emojiUpdates +=
+            EmojiUpdate(
+                bandalartId = bandalartId,
+                cellId = cellId,
+                entity = updateBandalartEmojiEntity,
+            )
+    }
 
-    override suspend fun deleteBandalartCell(cellId: Long) = error("Not used")
+    override suspend fun deleteBandalartCell(cellId: Long) {
+        deletedCellIds += cellId
+    }
 
     override suspend fun checkCompletedBandalartId(bandalartId: Long): Boolean = error("Not used")
 
-    override suspend fun deleteCompletedBandalartId(bandalartId: Long) = error("Not used")
+    override suspend fun deleteCompletedBandalartId(bandalartId: Long) {
+        deletedCompletionIds += bandalartId
+    }
+
+    data class MainCellUpdate(
+        val bandalartId: Long,
+        val cellId: Long,
+        val entity: UpdateBandalartMainCellEntity,
+    )
+
+    data class SubCellUpdate(
+        val bandalartId: Long,
+        val cellId: Long,
+        val entity: UpdateBandalartSubCellEntity,
+    )
+
+    data class TaskCellUpdate(
+        val bandalartId: Long,
+        val cellId: Long,
+        val entity: UpdateBandalartTaskCellEntity,
+    )
+
+    data class EmojiUpdate(
+        val bandalartId: Long,
+        val cellId: Long,
+        val entity: UpdateBandalartEmojiEntity,
+    )
 }

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterEditTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterEditTest.kt
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home.presenter
+
+import app.cash.turbine.ReceiveTurbine
+import com.nexters.bandalart.core.common.Language
+import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
+import com.nexters.bandalart.core.domain.entity.BandalartEntity
+import com.nexters.bandalart.feature.home.HomeScreen
+import com.nexters.bandalart.feature.home.model.CellType
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuit.test.test
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class HomePresenterEditTest {
+    @Test
+    fun addingBandalartSelectsCreatedItemAndClosesListSheet() =
+        runTest {
+            val created = bandalart(2L)
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1L)),
+                    recentBandalartId = 1L,
+                    createdBandalart = created,
+                )
+            val presenter = HomePresenter(FakeNavigator(HomeScreen), repository)
+
+            presenter.test {
+                var state = awaitLoadedBandalart(1L)
+                state.eventSink(HomeScreen.Event.OpenBandalartList)
+                state = awaitItem()
+                assertInstanceOf(HomeScreen.BottomSheetState.BandalartList::class.java, state.bottomSheet)
+
+                state.eventSink(HomeScreen.Event.AddBandalart)
+                do {
+                    state = awaitItem()
+                } while (
+                    state.bandalartData?.id != created.id ||
+                    state.effect != HomeScreen.Effect.ShowCreateSnackbar
+                )
+
+                assertEquals(1, repository.createCalls)
+                assertEquals(created.id, repository.recentBandalartId)
+                assertTrue(repository.completionUpdates.contains(created.id to false))
+                assertNull(state.bottomSheet)
+            }
+        }
+
+    @Test
+    fun sixthBandalartIsRejectedWithoutRepositoryCall() =
+        runTest {
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = List(5) { index -> bandalart(index + 1L) },
+                    recentBandalartId = 1L,
+                )
+            val presenter = HomePresenter(FakeNavigator(HomeScreen), repository)
+
+            presenter.test {
+                var state = awaitLoadedBandalart(1L)
+                state.eventSink(HomeScreen.Event.AddBandalart)
+                do {
+                    state = awaitItem()
+                } while (state.effect != HomeScreen.Effect.ShowLimitToast)
+
+                assertEquals(0, repository.createCalls)
+                state.eventSink(HomeScreen.Event.ConsumeEffect)
+                do {
+                    state = awaitItem()
+                } while (state.effect != null)
+                assertNull(state.effect)
+            }
+        }
+
+    @Test
+    fun mainCellDraftIsValidatedAndSaved() =
+        runTest {
+            val mainCell = cell(id = 10L, title = "기존 목표")
+            val repository = repositoryWithCells(mainCell = mainCell)
+            val presenter = HomePresenter(FakeNavigator(HomeScreen), repository)
+
+            presenter.test {
+                var state = awaitLoadedBandalart(1L)
+                state.eventSink(
+                    HomeScreen.Event.OpenCell(
+                        cellType = CellType.MAIN,
+                        isMainCellTitleEmpty = false,
+                        cellData = mainCell,
+                    ),
+                )
+                state = awaitCellSheet()
+
+                state.eventSink(HomeScreen.Event.UpdateCellTitle("가".repeat(16), Language.KOREAN))
+                expectNoEvents()
+                assertEquals("기존 목표", state.cellSheet().cellData.title)
+
+                state.eventSink(HomeScreen.Event.UpdateCellTitle("  새 목표  ", Language.KOREAN))
+                state.eventSink(HomeScreen.Event.UpdateDescription("새 설명"))
+                state.eventSink(HomeScreen.Event.OpenDatePicker)
+                state.eventSink(HomeScreen.Event.UpdateDueDate(""))
+                state.eventSink(HomeScreen.Event.OpenEmojiPicker)
+                state.eventSink(HomeScreen.Event.UpdateEmojiDraft("🚀"))
+                state.eventSink(HomeScreen.Event.UpdateThemeColor("#ABCDEF", "#123456"))
+                state.eventSink(HomeScreen.Event.SaveCell)
+                do {
+                    state = awaitItem()
+                } while (repository.mainCellUpdate == null || state.bottomSheet != null)
+
+                val update = requireNotNull(repository.mainCellUpdate)
+                assertEquals(1L, update.bandalartId)
+                assertEquals(mainCell.id, update.cellId)
+                assertEquals("새 목표", update.entity.title)
+                assertEquals("새 설명", update.entity.description)
+                assertNull(update.entity.dueDate)
+                assertEquals("🚀", update.entity.profileEmoji)
+                assertEquals("#ABCDEF", update.entity.mainColor)
+                assertEquals("#123456", update.entity.subColor)
+            }
+        }
+
+    @Test
+    fun subAndTaskCellDraftsUseTheirRepositoryPayloads() =
+        runTest {
+            val mainCell = cell(id = 10L, title = "메인")
+            val subCell = cell(id = 11L, title = "서브", parentId = mainCell.id)
+            val taskCell = cell(id = 12L, title = "태스크", parentId = subCell.id)
+            val repository =
+                repositoryWithCells(
+                    mainCell = mainCell,
+                    childCells =
+                        mapOf(
+                            mainCell.id to listOf(subCell),
+                            subCell.id to listOf(taskCell),
+                        ),
+                )
+            val presenter = HomePresenter(FakeNavigator(HomeScreen), repository)
+
+            presenter.test {
+                var state = awaitLoadedBandalart(1L)
+                state.eventSink(HomeScreen.Event.OpenCell(CellType.SUB, false, subCell))
+                state = awaitCellSheet()
+                state.eventSink(HomeScreen.Event.UpdateCellTitle("서브 수정", Language.KOREAN))
+                state.eventSink(HomeScreen.Event.UpdateDescription("서브 설명"))
+                state.eventSink(HomeScreen.Event.UpdateDueDate("2026-08-05"))
+                state.eventSink(HomeScreen.Event.SaveCell)
+                do {
+                    state = awaitItem()
+                } while (repository.subCellUpdate == null || state.bottomSheet != null)
+
+                val subUpdate = requireNotNull(repository.subCellUpdate)
+                assertEquals(subCell.id, subUpdate.cellId)
+                assertEquals("서브 수정", subUpdate.entity.title)
+                assertEquals("서브 설명", subUpdate.entity.description)
+                assertEquals("2026-08-05", subUpdate.entity.dueDate)
+
+                state.eventSink(HomeScreen.Event.OpenCell(CellType.TASK, false, taskCell))
+                state = awaitCellSheet()
+                state.eventSink(HomeScreen.Event.UpdateCompletion(true))
+                state.eventSink(HomeScreen.Event.UpdateDescription("태스크 설명"))
+                state.eventSink(HomeScreen.Event.SaveCell)
+                do {
+                    state = awaitItem()
+                } while (repository.taskCellUpdate == null || state.bottomSheet != null)
+
+                val taskUpdate = requireNotNull(repository.taskCellUpdate)
+                assertEquals(taskCell.id, taskUpdate.cellId)
+                assertEquals("태스크 설명", taskUpdate.entity.description)
+                assertTrue(taskUpdate.entity.isCompleted == true)
+            }
+        }
+
+    @Test
+    fun cellDeleteUsesDialogTargetAndClosesModal() =
+        runTest {
+            val mainCell = cell(id = 10L, title = "메인")
+            val taskCell = cell(id = 12L, title = "삭제 대상", parentId = mainCell.id)
+            val repository = repositoryWithCells(mainCell = mainCell)
+            val presenter = HomePresenter(FakeNavigator(HomeScreen), repository)
+
+            presenter.test {
+                var state = awaitLoadedBandalart(1L)
+                state.eventSink(HomeScreen.Event.OpenCell(CellType.TASK, false, taskCell))
+                state = awaitCellSheet()
+                state.eventSink(HomeScreen.Event.OpenCellDeleteDialog)
+                do {
+                    state = awaitItem()
+                } while (state.dialog !is HomeScreen.DialogState.CellDelete)
+
+                val dialog = state.dialog as HomeScreen.DialogState.CellDelete
+                assertEquals(taskCell.id, dialog.cellId)
+                assertEquals(CellType.TASK, dialog.cellType)
+                assertEquals(taskCell.title, dialog.cellTitle)
+
+                state.eventSink(HomeScreen.Event.DeleteCell(dialog.cellId))
+                do {
+                    state = awaitItem()
+                } while (repository.deletedCellIds.isEmpty() || state.dialog != null || state.bottomSheet != null)
+
+                assertEquals(listOf(taskCell.id), repository.deletedCellIds)
+            }
+        }
+
+    @Test
+    fun bandalartDeleteAlsoClearsCompletionSnapshotAndDropDown() =
+        runTest {
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1L), bandalart(2L)),
+                    recentBandalartId = 1L,
+                )
+            val presenter = HomePresenter(FakeNavigator(HomeScreen), repository)
+
+            presenter.test {
+                var state = awaitLoadedBandalart(1L)
+                state.eventSink(HomeScreen.Event.OpenDropDownMenu)
+                state = awaitItem()
+                assertTrue(state.isDropDownMenuOpened)
+                state.eventSink(HomeScreen.Event.OpenBandalartDeleteDialog)
+                state = awaitItem()
+                assertEquals(HomeScreen.DialogState.BandalartDelete, state.dialog)
+
+                state.eventSink(HomeScreen.Event.DeleteBandalart(1L))
+                do {
+                    state = awaitItem()
+                } while (
+                    repository.deletedBandalartIds.isEmpty() ||
+                    state.effect != HomeScreen.Effect.ShowDeleteSnackbar
+                )
+
+                assertEquals(listOf(1L), repository.deletedBandalartIds)
+                assertEquals(listOf(1L), repository.deletedCompletionIds)
+                assertFalse(state.isDropDownMenuOpened)
+                assertNull(state.dialog)
+                assertNull(state.bottomSheet)
+            }
+        }
+
+    @Test
+    fun invalidCellEntryAndQuickEmojiUpdateAreHandled() =
+        runTest {
+            val mainCell = cell(id = 10L, title = null)
+            val subCell = cell(id = 11L, title = "서브", parentId = mainCell.id)
+            val repository = repositoryWithCells(mainCell = mainCell)
+            val presenter = HomePresenter(FakeNavigator(HomeScreen), repository)
+
+            presenter.test {
+                var state = awaitLoadedBandalart(1L)
+                state.eventSink(HomeScreen.Event.OpenCell(CellType.SUB, true, subCell))
+                do {
+                    state = awaitItem()
+                } while (state.effect != HomeScreen.Effect.ShowMainGoalToast)
+                assertNull(state.bottomSheet)
+
+                state.eventSink(HomeScreen.Event.ConsumeEffect)
+                state.eventSink(HomeScreen.Event.OpenEmoji)
+                do {
+                    state = awaitItem()
+                } while (state.bottomSheet !is HomeScreen.BottomSheetState.Emoji)
+
+                state.eventSink(HomeScreen.Event.UpdateBandalartEmoji(1L, mainCell.id, "🌟"))
+                do {
+                    state = awaitItem()
+                } while (repository.emojiUpdates.isEmpty() || state.bottomSheet != null)
+
+                val update = repository.emojiUpdates.single()
+                assertEquals(1L, update.bandalartId)
+                assertEquals(mainCell.id, update.cellId)
+                assertEquals("🌟", update.entity.profileEmoji)
+            }
+        }
+
+    private fun repositoryWithCells(
+        mainCell: BandalartCellEntity,
+        childCells: Map<Long, List<BandalartCellEntity>> = emptyMap(),
+    ) = FakeBandalartRepository(
+        initialBandalarts = listOf(bandalart(1L)),
+        recentBandalartId = 1L,
+        mainCells = mapOf(1L to mainCell),
+        childCells = childCells,
+    )
+
+    private suspend fun ReceiveTurbine<HomeScreen.State>.awaitLoadedBandalart(bandalartId: Long,): HomeScreen.State {
+        var state = awaitItem()
+        while (state.bandalartData?.id != bandalartId || state.isLoading) {
+            state = awaitItem()
+        }
+        return state
+    }
+
+    private suspend fun ReceiveTurbine<HomeScreen.State>.awaitCellSheet(): HomeScreen.State {
+        var state = awaitItem()
+        while (state.bottomSheet !is HomeScreen.BottomSheetState.Cell) {
+            state = awaitItem()
+        }
+        return state
+    }
+
+    private fun HomeScreen.State.cellSheet(): HomeScreen.BottomSheetState.Cell = requireNotNull(bottomSheet as? HomeScreen.BottomSheetState.Cell)
+
+    private fun bandalart(id: Long) =
+        BandalartEntity(
+            id = id,
+            mainColor = "#3FFFBA",
+            subColor = "#111827",
+            profileEmoji = "🎯",
+            title = "반다라트 $id",
+            description = "설명 $id",
+            dueDate = null,
+            isCompleted = false,
+            completionRatio = 0,
+        )
+
+    private fun cell(
+        id: Long,
+        title: String?,
+        parentId: Long? = null,
+    ) = BandalartCellEntity(
+        id = id,
+        title = title,
+        description = null,
+        dueDate = null,
+        isCompleted = false,
+        parentId = parentId,
+    )
+}

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
@@ -16,9 +16,11 @@
 
 package com.nexters.bandalart.feature.home
 
+import com.nexters.bandalart.core.common.Language
 import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
 import com.nexters.bandalart.core.navigation.CommonParcelize
 import com.nexters.bandalart.feature.home.model.BandalartUiModel
+import com.nexters.bandalart.feature.home.model.CellType
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
 import com.slack.circuit.runtime.screen.ParcelableScreen
@@ -34,12 +36,130 @@ data object HomeScreen : ParcelableScreen, StaticScreen {
         val bandalartCellData: BandalartCellEntity? = null,
         val isLoading: Boolean = true,
         val isBandalartCompleted: Boolean = false,
+        val bottomSheet: BottomSheetState? = null,
+        val dialog: DialogState? = null,
+        val isDropDownMenuOpened: Boolean = false,
+        val effect: Effect? = null,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
+
+    sealed interface BottomSheetState {
+        data class Cell(
+            val cellType: CellType,
+            val initialCellData: BandalartCellEntity,
+            val cellData: BandalartCellEntity,
+            val initialBandalartData: BandalartUiModel,
+            val bandalartData: BandalartUiModel,
+            val isDatePickerOpened: Boolean = false,
+            val isEmojiPickerOpened: Boolean = false,
+        ) : BottomSheetState
+
+        data class BandalartList(
+            val currentBandalartId: Long,
+        ) : BottomSheetState
+
+        data class Emoji(
+            val bandalartId: Long,
+            val cellId: Long,
+            val currentEmoji: String?,
+        ) : BottomSheetState
+    }
+
+    sealed interface DialogState {
+        data object BandalartDelete : DialogState
+
+        data class CellDelete(
+            val cellId: Long,
+            val cellType: CellType,
+            val cellTitle: String?,
+        ) : DialogState
+    }
+
+    sealed interface Effect {
+        data object ShowCreateSnackbar : Effect
+
+        data object ShowDeleteSnackbar : Effect
+
+        data object ShowLimitToast : Effect
+
+        data object ShowMainGoalToast : Effect
+    }
 
     sealed interface Event : CircuitUiEvent {
         data class SelectBandalart(
             val bandalartId: Long,
         ) : Event
+
+        data object AddBandalart : Event
+
+        data object OpenBandalartList : Event
+
+        data object OpenEmoji : Event
+
+        data class OpenCell(
+            val cellType: CellType,
+            val isMainCellTitleEmpty: Boolean,
+            val cellData: BandalartCellEntity,
+        ) : Event
+
+        data object OpenBandalartDeleteDialog : Event
+
+        data object OpenCellDeleteDialog : Event
+
+        data object OpenDropDownMenu : Event
+
+        data object DismissDropDownMenu : Event
+
+        data object DismissBottomSheet : Event
+
+        data object DismissDialog : Event
+
+        data class UpdateCellTitle(
+            val title: String,
+            val language: Language,
+        ) : Event
+
+        data class UpdateDescription(
+            val description: String,
+        ) : Event
+
+        data class UpdateDueDate(
+            val dueDate: String,
+        ) : Event
+
+        data class UpdateCompletion(
+            val isCompleted: Boolean,
+        ) : Event
+
+        data class UpdateEmojiDraft(
+            val emoji: String,
+        ) : Event
+
+        data class UpdateThemeColor(
+            val mainColor: String,
+            val subColor: String,
+        ) : Event
+
+        data object OpenDatePicker : Event
+
+        data object OpenEmojiPicker : Event
+
+        data object SaveCell : Event
+
+        data class UpdateBandalartEmoji(
+            val bandalartId: Long,
+            val cellId: Long,
+            val emoji: String?,
+        ) : Event
+
+        data class DeleteBandalart(
+            val bandalartId: Long,
+        ) : Event
+
+        data class DeleteCell(
+            val cellId: Long,
+        ) : Event
+
+        data object ConsumeEffect : Event
     }
 }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -23,12 +23,19 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import com.nexters.bandalart.core.common.Language
 import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartEmojiEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
+import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
 import com.nexters.bandalart.core.domain.repository.BandalartRepository
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.nexters.bandalart.feature.home.mapper.toUiModel
 import com.nexters.bandalart.feature.home.model.BandalartUiModel
+import com.nexters.bandalart.feature.home.model.CellType
 import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.retained.rememberRetained
 import com.slack.circuit.runtime.Navigator
 import com.slack.circuit.runtime.presenter.Presenter
 import dev.zacsweers.metro.AppScope
@@ -53,6 +60,10 @@ class HomePresenter(
         var isLoading by remember { mutableStateOf(true) }
         var isBandalartCompleted by remember { mutableStateOf(false) }
         var isCreatingEmptyBandalart by remember { mutableStateOf(false) }
+        var bottomSheet by rememberRetained { mutableStateOf<HomeScreen.BottomSheetState?>(null) }
+        var dialog by rememberRetained { mutableStateOf<HomeScreen.DialogState?>(null) }
+        var isDropDownMenuOpened by remember { mutableStateOf(false) }
+        var effect by remember { mutableStateOf<HomeScreen.Effect?>(null) }
         val scope = rememberCoroutineScope()
 
         suspend fun loadBandalart(
@@ -114,6 +125,208 @@ class HomePresenter(
             }
         }
 
+        suspend fun createBandalart() {
+            if (bandalartList.size >= MAX_BANDALART_COUNT) {
+                effect = HomeScreen.Effect.ShowLimitToast
+                return
+            }
+
+            bandalartRepository.createBandalart()?.let { bandalart ->
+                bottomSheet = null
+                bandalartRepository.setRecentBandalartId(bandalart.id)
+                bandalartRepository.upsertBandalartId(bandalart.id, bandalart.isCompleted)
+                loadBandalart(bandalart.id)
+                effect = HomeScreen.Effect.ShowCreateSnackbar
+            }
+        }
+
+        fun openBandalartList() {
+            val currentBandalartId = bandalartData?.id ?: return
+            bottomSheet = HomeScreen.BottomSheetState.BandalartList(currentBandalartId)
+        }
+
+        fun openEmoji() {
+            val currentBandalart = bandalartData ?: return
+            val mainCellId = bandalartCellData?.id ?: return
+            bottomSheet =
+                HomeScreen.BottomSheetState.Emoji(
+                    bandalartId = currentBandalart.id,
+                    cellId = mainCellId,
+                    currentEmoji = currentBandalart.profileEmoji,
+                )
+        }
+
+        fun openCell(
+            cellType: CellType,
+            isMainCellTitleEmpty: Boolean,
+            cellData: BandalartCellEntity,
+        ) {
+            if (cellType != CellType.MAIN && isMainCellTitleEmpty) {
+                effect = HomeScreen.Effect.ShowMainGoalToast
+                return
+            }
+
+            val currentBandalart = bandalartData ?: return
+            bottomSheet =
+                HomeScreen.BottomSheetState.Cell(
+                    cellType = cellType,
+                    initialCellData = cellData,
+                    cellData = cellData,
+                    initialBandalartData = currentBandalart,
+                    bandalartData = currentBandalart,
+                )
+        }
+
+        fun updateCellTitle(
+            title: String,
+            language: Language,
+        ) {
+            val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.Cell ?: return
+            val maxLength =
+                when (language) {
+                    Language.KOREAN, Language.JAPANESE -> 15
+                    Language.ENGLISH -> 24
+                }
+            val validatedTitle =
+                title.takeIf { it.length <= maxLength } ?: currentSheet.cellData.title.orEmpty()
+            bottomSheet =
+                currentSheet.copy(
+                    cellData = currentSheet.cellData.copy(title = validatedTitle),
+                )
+        }
+
+        fun updateDescription(description: String) {
+            val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.Cell ?: return
+            val validatedDescription =
+                description.takeIf { it.length <= MAX_DESCRIPTION_LENGTH }
+                    ?: currentSheet.cellData.description
+            bottomSheet =
+                currentSheet.copy(
+                    cellData = currentSheet.cellData.copy(description = validatedDescription),
+                )
+        }
+
+        fun updateDueDate(dueDate: String) {
+            val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.Cell ?: return
+            bottomSheet =
+                currentSheet.copy(
+                    cellData = currentSheet.cellData.copy(dueDate = dueDate),
+                    isDatePickerOpened = false,
+                )
+        }
+
+        fun updateCompletion(isCompleted: Boolean) {
+            val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.Cell ?: return
+            bottomSheet =
+                currentSheet.copy(
+                    cellData = currentSheet.cellData.copy(isCompleted = isCompleted),
+                )
+        }
+
+        fun updateEmojiDraft(emoji: String) {
+            val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.Cell ?: return
+            bottomSheet =
+                currentSheet.copy(
+                    bandalartData = currentSheet.bandalartData.copy(profileEmoji = emoji),
+                    isEmojiPickerOpened = false,
+                )
+        }
+
+        fun updateThemeColor(
+            mainColor: String,
+            subColor: String,
+        ) {
+            val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.Cell ?: return
+            bottomSheet =
+                currentSheet.copy(
+                    bandalartData =
+                        currentSheet.bandalartData.copy(
+                            mainColor = mainColor,
+                            subColor = subColor,
+                        ),
+                )
+        }
+
+        suspend fun saveCell() {
+            val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.Cell ?: return
+            val currentBandalart = currentSheet.bandalartData
+            val currentCell = currentSheet.cellData
+            val title = currentCell.title?.trim()
+            val dueDate = currentCell.dueDate?.ifEmpty { null }
+
+            when (currentSheet.cellType) {
+                CellType.MAIN ->
+                    bandalartRepository.updateBandalartMainCell(
+                        bandalartId = currentBandalart.id,
+                        cellId = currentCell.id,
+                        updateBandalartMainCellEntity =
+                            UpdateBandalartMainCellEntity(
+                                title = title,
+                                description = currentCell.description,
+                                dueDate = dueDate,
+                                profileEmoji = currentBandalart.profileEmoji,
+                                mainColor = currentBandalart.mainColor,
+                                subColor = currentBandalart.subColor,
+                            ),
+                    )
+
+                CellType.SUB ->
+                    bandalartRepository.updateBandalartSubCell(
+                        bandalartId = currentBandalart.id,
+                        cellId = currentCell.id,
+                        updateBandalartSubCellEntity =
+                            UpdateBandalartSubCellEntity(
+                                title = title,
+                                description = currentCell.description,
+                                dueDate = dueDate,
+                            ),
+                    )
+
+                CellType.TASK ->
+                    bandalartRepository.updateBandalartTaskCell(
+                        bandalartId = currentBandalart.id,
+                        cellId = currentCell.id,
+                        updateBandalartTaskCellEntity =
+                            UpdateBandalartTaskCellEntity(
+                                title = title,
+                                description = currentCell.description,
+                                dueDate = dueDate,
+                                isCompleted = currentCell.isCompleted,
+                            ),
+                    )
+            }
+            bottomSheet = null
+        }
+
+        suspend fun updateBandalartEmoji(
+            bandalartId: Long,
+            cellId: Long,
+            emoji: String?,
+        ) {
+            bandalartRepository.updateBandalartEmoji(
+                bandalartId = bandalartId,
+                cellId = cellId,
+                updateBandalartEmojiEntity = UpdateBandalartEmojiEntity(profileEmoji = emoji),
+            )
+            bottomSheet = null
+        }
+
+        suspend fun deleteBandalart(bandalartId: Long) {
+            isLoading = true
+            bandalartRepository.deleteBandalart(bandalartId)
+            bandalartRepository.deleteCompletedBandalartId(bandalartId)
+            dialog = null
+            bottomSheet = null
+            isDropDownMenuOpened = false
+            effect = HomeScreen.Effect.ShowDeleteSnackbar
+        }
+
+        suspend fun deleteCell(cellId: Long) {
+            bandalartRepository.deleteBandalartCell(cellId)
+            dialog = null
+            bottomSheet = null
+        }
+
         LaunchedEffect(Unit) {
             bandalartRepository.getBandalartList().collect { entities ->
                 val currentList = entities.map { it.toUiModel() }
@@ -163,14 +376,93 @@ class HomePresenter(
             bandalartCellData = bandalartCellData,
             isLoading = isLoading,
             isBandalartCompleted = isBandalartCompleted,
+            bottomSheet = bottomSheet,
+            dialog = dialog,
+            isDropDownMenuOpened = isDropDownMenuOpened,
+            effect = effect,
         ) { event ->
             when (event) {
                 is HomeScreen.Event.SelectBandalart -> {
                     scope.launch {
                         bandalartRepository.setRecentBandalartId(event.bandalartId)
                         loadBandalart(event.bandalartId)
+                        bottomSheet = null
                     }
                 }
+
+                HomeScreen.Event.AddBandalart -> scope.launch { createBandalart() }
+                HomeScreen.Event.OpenBandalartList -> openBandalartList()
+                HomeScreen.Event.OpenEmoji -> openEmoji()
+                is HomeScreen.Event.OpenCell ->
+                    openCell(
+                        cellType = event.cellType,
+                        isMainCellTitleEmpty = event.isMainCellTitleEmpty,
+                        cellData = event.cellData,
+                    )
+
+                HomeScreen.Event.OpenBandalartDeleteDialog -> {
+                    dialog = HomeScreen.DialogState.BandalartDelete
+                }
+
+                HomeScreen.Event.OpenCellDeleteDialog -> {
+                    val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.Cell
+                    currentSheet?.let { sheet ->
+                        dialog =
+                            HomeScreen.DialogState.CellDelete(
+                                cellId = sheet.cellData.id,
+                                cellType = sheet.cellType,
+                                cellTitle = sheet.cellData.title,
+                            )
+                    }
+                }
+
+                HomeScreen.Event.OpenDropDownMenu -> isDropDownMenuOpened = true
+                HomeScreen.Event.DismissDropDownMenu -> isDropDownMenuOpened = false
+                HomeScreen.Event.DismissBottomSheet -> bottomSheet = null
+                HomeScreen.Event.DismissDialog -> dialog = null
+                is HomeScreen.Event.UpdateCellTitle ->
+                    updateCellTitle(
+                        title = event.title,
+                        language = event.language,
+                    )
+
+                is HomeScreen.Event.UpdateDescription -> updateDescription(event.description)
+                is HomeScreen.Event.UpdateDueDate -> updateDueDate(event.dueDate)
+                is HomeScreen.Event.UpdateCompletion -> updateCompletion(event.isCompleted)
+                is HomeScreen.Event.UpdateEmojiDraft -> updateEmojiDraft(event.emoji)
+                is HomeScreen.Event.UpdateThemeColor ->
+                    updateThemeColor(
+                        mainColor = event.mainColor,
+                        subColor = event.subColor,
+                    )
+
+                HomeScreen.Event.OpenDatePicker -> {
+                    val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.Cell
+                    currentSheet?.let { bottomSheet = it.copy(isDatePickerOpened = true) }
+                }
+
+                HomeScreen.Event.OpenEmojiPicker -> {
+                    val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.Cell
+                    currentSheet?.let { bottomSheet = it.copy(isEmojiPickerOpened = true) }
+                }
+
+                HomeScreen.Event.SaveCell -> scope.launch { saveCell() }
+                is HomeScreen.Event.UpdateBandalartEmoji -> {
+                    scope.launch {
+                        updateBandalartEmoji(
+                            bandalartId = event.bandalartId,
+                            cellId = event.cellId,
+                            emoji = event.emoji,
+                        )
+                    }
+                }
+
+                is HomeScreen.Event.DeleteBandalart -> {
+                    scope.launch { deleteBandalart(event.bandalartId) }
+                }
+
+                is HomeScreen.Event.DeleteCell -> scope.launch { deleteCell(event.cellId) }
+                HomeScreen.Event.ConsumeEffect -> effect = null
             }
         }
     }
@@ -181,5 +473,10 @@ class HomePresenter(
         fun create(
             @Assisted navigator: Navigator,
         ): HomePresenter
+    }
+
+    private companion object {
+        const val MAX_BANDALART_COUNT = 5
+        const val MAX_DESCRIPTION_LENGTH = 1000
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -160,6 +160,7 @@ koin-androidx-startup = { group = "io.insert-koin", name = "koin-androidx-startu
 
 # Circuit
 circuit-foundation = { group = "com.slack.circuit", name = "circuit-foundation", version.ref = "circuit" }
+circuit-retained = { group = "com.slack.circuit", name = "circuit-retained", version.ref = "circuit" }
 circuit-runtime = { group = "com.slack.circuit", name = "circuit-runtime", version.ref = "circuit" }
 circuit-runtime-presenter = { group = "com.slack.circuit", name = "circuit-runtime-presenter", version.ref = "circuit" }
 circuit-runtime-ui = { group = "com.slack.circuit", name = "circuit-runtime-ui", version.ref = "circuit" }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #182

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- Home 읽기 상태와 편집 draft의 수명을 분리하고 bottom sheet/dialog에만 `rememberRetained`를 적용했습니다.
- 생성 제한, modal/dropdown, cell draft validation, main/sub/task 수정, 반다라트/cell 삭제를 Circuit Event와 기존 KMP repository에 연결했습니다.
- 편집 Presenter test 7개를 별도 파일로 추가하고 기존 read/legacy/Metro graph 테스트를 유지했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `./gradlew :feature:home:testAndroidHostTest :composeApp:testAndroidHostTest`
- `./gradlew :feature:home:detekt :composeApp:detekt`
- 이번 변경 Kotlin 파일 Spotless IDE hook

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| UI 변경 없음 | - | runtime 미연결 | - |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 이 PR은 6-C shadow Presenter 단계입니다. repository에서 다시 읽을 수 있는 목록·상세·셀 트리는 일반 `remember`, 사용자 편집 draft가 들어 있는 bottom sheet/dialog만 retained 상태입니다.
- 공유·저장·capture, Complete 이동, 선택 업데이트와 실제 Home UI/runtime 교체는 다음 6-D에서 진행합니다.

## 💡 코드리뷰 Tip

Gemini Code Assist 리뷰 코멘트가 달리면 `resolve-gemini-review`를 실행하여 미해결 코멘트를 반영하거나 거절 사유를 남길 수 있습니다.
