### PR TITLE
chore: KMP 통합 검증과 CI 병렬화

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -6,50 +6,190 @@ env:
 
 on:
     pull_request:
+        paths-ignore:
+            - "**/*.md"
 
 concurrency:
-    group: build-${{ github.ref }}
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
     cancel-in-progress: true
 
-jobs:
-    ci-build:
-        runs-on: macos-latest
+permissions:
+    contents: read
 
+jobs:
+    quality:
+        name: Code quality
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
+                with:
+                    fetch-depth: 0
 
             -   name: Setup JDK 21
-                uses: actions/setup-java@v3
+                uses: actions/setup-java@v4
                 with:
                     distribution: zulu
                     java-version: 21
 
             -   name: Setup Android SDK
-                uses: android-actions/setup-android@v2
+                uses: android-actions/setup-android@v3
 
             -   name: Setup Gradle
-                uses: gradle/gradle-build-action@v2
+                uses: gradle/actions/setup-gradle@v4
+
+            -   name: Generate build properties
+                env:
+                    SERVER_BASE_URL: ${{ secrets.SERVER_BASE_URL }}
+                    STORE_FILE: ${{ secrets.STORE_FILE }}
+                    STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
+                    KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+                    KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+                run: |
+                    printf 'SERVER_BASE_URL=%s\n' "$SERVER_BASE_URL" > secrets.properties
+                    printf 'STORE_FILE=%s\n' "$STORE_FILE" > keystore.properties
+                    printf 'STORE_PASSWORD=%s\n' "$STORE_PASSWORD" >> keystore.properties
+                    printf 'KEY_ALIAS=%s\n' "$KEY_ALIAS" >> keystore.properties
+                    printf 'KEY_PASSWORD=%s\n' "$KEY_PASSWORD" >> keystore.properties
+
+            -   name: Run static analysis
+                run: ./gradlew spotlessCheck detekt -PspotlessRatchetFrom=origin/main --stacktrace
+
+    unit_tests:
+        name: Unit tests
+        runs-on: macos-latest
+        timeout-minutes: 30
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   name: Setup JDK 21
+                uses: actions/setup-java@v4
                 with:
-                    gradle-home-cache-cleanup: true
+                    distribution: zulu
+                    java-version: 21
 
-            -   name: Generate secrets.properties
-                run: |
-                    echo "SERVER_BASE_URL=${{ secrets.SERVER_BASE_URL }}" >> secrets.properties
+            -   name: Setup Android SDK
+                uses: android-actions/setup-android@v3
 
-            -   name: Generate keystore.properties
+            -   name: Setup Gradle
+                uses: gradle/actions/setup-gradle@v4
+
+            -   name: Generate build properties
+                env:
+                    SERVER_BASE_URL: ${{ secrets.SERVER_BASE_URL }}
+                    STORE_FILE: ${{ secrets.STORE_FILE }}
+                    STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
+                    KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+                    KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
                 run: |
-                    echo "STORE_FILE=${{ secrets.STORE_FILE }}" >> keystore.properties
-                    echo "STORE_PASSWORD=${{ secrets.STORE_PASSWORD }}" >> keystore.properties
-                    echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> keystore.properties
-                    echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> keystore.properties
+                    printf 'SERVER_BASE_URL=%s\n' "$SERVER_BASE_URL" > secrets.properties
+                    printf 'STORE_FILE=%s\n' "$STORE_FILE" > keystore.properties
+                    printf 'STORE_PASSWORD=%s\n' "$STORE_PASSWORD" >> keystore.properties
+                    printf 'KEY_ALIAS=%s\n' "$KEY_ALIAS" >> keystore.properties
+                    printf 'KEY_PASSWORD=%s\n' "$KEY_PASSWORD" >> keystore.properties
 
             -   name: Run unit tests
                 run: ./gradlew allTests :androidApp:testDebugUnitTest --stacktrace
 
-            -   name: Run Android Lint
-                run: ./gradlew :androidApp:lintDebug --stacktrace
+    android:
+        name: Android lint and build
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
 
-            -   name: Run Android and iOS builds
-                run: ./gradlew :androidApp:assembleDebug :composeApp:linkDebugFrameworkIosSimulatorArm64 --stacktrace
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   name: Setup JDK 21
+                uses: actions/setup-java@v4
+                with:
+                    distribution: zulu
+                    java-version: 21
+
+            -   name: Setup Android SDK
+                uses: android-actions/setup-android@v3
+
+            -   name: Setup Gradle
+                uses: gradle/actions/setup-gradle@v4
+
+            -   name: Generate build properties
+                env:
+                    SERVER_BASE_URL: ${{ secrets.SERVER_BASE_URL }}
+                    STORE_FILE: ${{ secrets.STORE_FILE }}
+                    STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
+                    KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+                    KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+                run: |
+                    printf 'SERVER_BASE_URL=%s\n' "$SERVER_BASE_URL" > secrets.properties
+                    printf 'STORE_FILE=%s\n' "$STORE_FILE" > keystore.properties
+                    printf 'STORE_PASSWORD=%s\n' "$STORE_PASSWORD" >> keystore.properties
+                    printf 'KEY_ALIAS=%s\n' "$KEY_ALIAS" >> keystore.properties
+                    printf 'KEY_PASSWORD=%s\n' "$KEY_PASSWORD" >> keystore.properties
+
+            -   name: Run Android lint and build
+                run: ./gradlew :androidApp:lintDebug :androidApp:assembleDebug --stacktrace
+
+    ios:
+        name: iOS framework build
+        runs-on: macos-latest
+        timeout-minutes: 30
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   name: Setup JDK 21
+                uses: actions/setup-java@v4
+                with:
+                    distribution: zulu
+                    java-version: 21
+
+            -   name: Setup Android SDK
+                uses: android-actions/setup-android@v3
+
+            -   name: Setup Gradle
+                uses: gradle/actions/setup-gradle@v4
+
+            -   name: Generate build properties
+                env:
+                    SERVER_BASE_URL: ${{ secrets.SERVER_BASE_URL }}
+                    STORE_FILE: ${{ secrets.STORE_FILE }}
+                    STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
+                    KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+                    KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+                run: |
+                    printf 'SERVER_BASE_URL=%s\n' "$SERVER_BASE_URL" > secrets.properties
+                    printf 'STORE_FILE=%s\n' "$STORE_FILE" > keystore.properties
+                    printf 'STORE_PASSWORD=%s\n' "$STORE_PASSWORD" >> keystore.properties
+                    printf 'KEY_ALIAS=%s\n' "$KEY_ALIAS" >> keystore.properties
+                    printf 'KEY_PASSWORD=%s\n' "$KEY_PASSWORD" >> keystore.properties
+
+            -   name: Run iOS framework build
+                run: ./gradlew :composeApp:linkDebugFrameworkIosSimulatorArm64 --stacktrace
+
+    ci-build:
+        name: ci-build
+        runs-on: ubuntu-latest
+        if: ${{ always() && !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+        needs:
+            - quality
+            - unit_tests
+            - android
+            - ios
+
+        steps:
+            -   name: Verify required jobs
+                env:
+                    QUALITY_RESULT: ${{ needs.quality.result }}
+                    UNIT_TESTS_RESULT: ${{ needs.unit_tests.result }}
+                    ANDROID_RESULT: ${{ needs.android.result }}
+                    IOS_RESULT: ${{ needs.ios.result }}
+                run: |
+                    test "$QUALITY_RESULT" = "success"
+                    test "$UNIT_TESTS_RESULT" = "success"
+                    test "$ANDROID_RESULT" = "success"
+                    test "$IOS_RESULT" = "success"

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -1,6 +1,7 @@
 import java.util.Properties
 
 plugins {
+    id("bandalart.lint")
     id("bandalart.android.application")
     id("bandalart.android.application.compose")
     alias(libs.plugins.google.service)
@@ -27,9 +28,10 @@ android {
         getByName("debug") {
             isDebuggable = true
             applicationIdSuffix = ".dev"
-            manifestPlaceholders += mapOf(
-                "appName" to "@string/app_name_dev",
-            )
+            manifestPlaceholders +=
+                mapOf(
+                    "appName" to "@string/app_name_dev",
+                )
         }
 
         getByName("release") {
@@ -37,9 +39,10 @@ android {
             isMinifyEnabled = true
             isShrinkResources = true
             signingConfig = signingConfigs.getByName("release")
-            manifestPlaceholders += mapOf(
-                "appName" to "@string/app_name",
-            )
+            manifestPlaceholders +=
+                mapOf(
+                    "appName" to "@string/app_name",
+                )
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",

--- a/build-logic/src/main/kotlin/com/nexters/bandalart/buildlogic/DetektPlugin.kt
+++ b/build-logic/src/main/kotlin/com/nexters/bandalart/buildlogic/DetektPlugin.kt
@@ -56,7 +56,9 @@ fun Project.configureDetekt(extension: DetektExtension) {
 
             jvmTarget = JavaVersion.VERSION_17.toString()
 
-            source = project.files("./").asFileTree
+            if (name == "detekt") {
+                source = project.files("./").asFileTree
+            }
 
             include("**/*.kt")
             include("**/*.kts")
@@ -65,8 +67,6 @@ fun Project.configureDetekt(extension: DetektExtension) {
 
             reportMerge.configure {
                 input.from(this@detekt.xmlReportFile)
-                input.from(this@detekt.htmlReportFile)
-                input.from(this@detekt.sarifReportFile)
             }
         }
     }

--- a/build-logic/src/main/kotlin/com/nexters/bandalart/buildlogic/SpotlessPlugin.kt
+++ b/build-logic/src/main/kotlin/com/nexters/bandalart/buildlogic/SpotlessPlugin.kt
@@ -11,59 +11,18 @@ class SpotlessPlugin : BuildLogicPlugin(
         val editorConfigFile = rootProject.file(".editorconfig")
 
         extensions.configure<SpotlessExtension> {
+            providers.gradleProperty("spotlessRatchetFrom").orNull?.let(::ratchetFrom)
+
             kotlin {
                 target("**/*.kt")
                 targetExclude("**/build/**/*.kt")
-                licenseHeader(licenseHeaderKotlin)
                 ktlint(libs.versions.ktlint.get()).setEditorConfigPath(editorConfigFile)
             }
-            format("kts") {
-                target("**/*.kts")
-                targetExclude("**/build/**/*.kts")
-                licenseHeader(licenseHeaderKotlin, "(^(?![\\/ ]\\*).*$)")
-            }
-            format("xml") {
-                target("**/*.xml")
-                targetExclude("**/build/**/*.xml")
-                licenseHeader(licenseHeaderXml, "(^(?![\\/ ]\\*).*$)")
+            kotlinGradle {
+                target("**/*.gradle.kts")
+                targetExclude("**/build/**/*.gradle.kts")
+                ktlint(libs.versions.ktlint.get()).setEditorConfigPath(editorConfigFile)
             }
         }
     },
 )
-
-private val licenseHeaderKotlin =
-    buildString {
-        append("/*\n")
-        append(" * Copyright \$YEAR easyhooon\n")
-        append(" *\n")
-        append(" * Licensed under the Apache License, Version 2.0 (the \"License\");\n")
-        append(" * you may not use this file except in compliance with the License.\n")
-        append(" * You may obtain a copy of the License at\n")
-        append(" *\n")
-        append(" *     http://www.apache.org/licenses/LICENSE-2.0\n")
-        append(" *\n")
-        append(" * Unless required by applicable law or agreed to in writing, software\n")
-        append(" * distributed under the License is distributed on an \"AS IS\" BASIS,\n")
-        append(" * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n")
-        append(" * See the License for the specific language governing permissions and\n")
-        append(" * limitations under the License.\n")
-        append(" */\n")
-        append("\n")
-    }
-
-private val licenseHeaderXml =
-    buildString {
-        append("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n")
-        append("<!--\n")
-        append("     Copyright \$YEAR easyhooon\n")
-        append("     Licensed under the Apache License, Version 2.0 (the \"License\");\n")
-        append("     you may not use this file except in compliance with the License.\n")
-        append("     You may obtain a copy of the License at\n")
-        append("          http://www.apache.org/licenses/LICENSE-2.0\n")
-        append("     Unless required by applicable law or agreed to in writing, software\n")
-        append("     distributed under the License is distributed on an \"AS IS\" BASIS,\n")
-        append("     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n")
-        append("     See the License for the specific language governing permissions and\n")
-        append("     limitations under the License.\n")
-        append("-->")
-    }

--- a/core/common/src/androidHostTest/kotlin/com/nexters/bandalart/core/common/extension/ColorExtensionsTest.kt
+++ b/core/common/src/androidHostTest/kotlin/com/nexters/bandalart/core/common/extension/ColorExtensionsTest.kt
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.ValueSource
 import android.graphics.Color as AndroidColor
 
 @DisplayName("String 확장 함수 테스트")
+@Suppress("FunctionNaming")
 class ColorExtensionsTest {
     @BeforeEach
     fun setUp() {

--- a/core/common/src/androidMain/kotlin/com/nexters/bandalart/core/common/AppVersionProvider.android.kt
+++ b/core/common/src/androidMain/kotlin/com/nexters/bandalart/core/common/AppVersionProvider.android.kt
@@ -17,6 +17,8 @@
 package com.nexters.bandalart.core.common
 
 import android.content.Context
+import android.content.pm.PackageManager
+import io.github.aakira.napier.Napier
 
 actual class AppVersionProvider(
     private val context: Context
@@ -24,7 +26,8 @@ actual class AppVersionProvider(
     actual fun getAppVersion(): String =
         try {
             context.packageManager.getPackageInfo(context.packageName, 0).versionName ?: "Unknown"
-        } catch (e: Exception) {
+        } catch (e: PackageManager.NameNotFoundException) {
+            Napier.e("Failed to get app version", e, tag = "AppVersion")
             "Unknown"
         }
 }

--- a/core/common/src/iosMain/kotlin/com/nexters/bandalart/core/common/AppVersionProvider.ios.kt
+++ b/core/common/src/iosMain/kotlin/com/nexters/bandalart/core/common/AppVersionProvider.ios.kt
@@ -16,16 +16,10 @@
 
 package com.nexters.bandalart.core.common
 
-import io.github.aakira.napier.Napier
 import platform.Foundation.NSBundle
 
 actual class AppVersionProvider {
     actual fun getAppVersion(): String =
-        try {
-            NSBundle.mainBundle.infoDictionary?.get("CFBundleShortVersionString") as? String
-                ?: "Unknown"
-        } catch (e: Exception) {
-            Napier.e("Failed to get app version", e, tag = "AppVersion")
-            "Unknown"
-        }
+        NSBundle.mainBundle.infoDictionary?.get("CFBundleShortVersionString") as? String
+            ?: "Unknown"
 }

--- a/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/repository/InAppUpdateRepositoryTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/repository/InAppUpdateRepositoryTest.kt
@@ -21,6 +21,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -84,6 +85,8 @@ class InAppUpdateRepositoryImplTest {
             patch: Int,
             currentVersionCode: Int
         ) = runTest {
+            assertEquals(currentVersionCode, calculateVersionCode(major, minor, patch))
+
             // scenario 1: 현재 버전이 거절된 버전과 동일한 경우
             val sameVersionCode = currentVersionCode
             coEvery { mockInAppUpdateDataStore.getLastRejectedUpdateVersion() } returns sameVersionCode

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -16,7 +16,6 @@ kotlin {
             implementation(libs.robolectric.junit5.extension)
             implementation(libs.turbine)
         }
-
     }
 
     compilerOptions.freeCompilerArgs.add("-Xexpect-actual-classes")

--- a/core/designsystem/src/commonMain/kotlin/com/nexters/bandalart/core/designsystem/theme/Type.kt
+++ b/core/designsystem/src/commonMain/kotlin/com/nexters/bandalart/core/designsystem/theme/Type.kt
@@ -7,15 +7,17 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
 // Set of Material typography styles to start with
-val Typography = Typography(
-    bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
-        lineHeight = 24.sp,
-        letterSpacing = 0.5.sp,
-    ),
-//  // Other default text styles to override
+val Typography =
+    Typography(
+        bodyLarge =
+            TextStyle(
+                fontFamily = FontFamily.Default,
+                fontWeight = FontWeight.Normal,
+                fontSize = 16.sp,
+                lineHeight = 24.sp,
+                letterSpacing = 0.5.sp,
+            ),
+        //  // Other default text styles to override
 //  titleLarge = TextStyle(
 //      fontFamily = FontFamily.Default,
 //      fontWeight = FontWeight.Normal,
@@ -30,5 +32,4 @@ val Typography = Typography(
 //      lineHeight = 16.sp,
 //      letterSpacing = 0.5.sp
 //  )
-)
-
+    )

--- a/core/ui/src/commonMain/kotlin/com/nexters/bandalart/core/ui/component/BandalartButton.kt
+++ b/core/ui/src/commonMain/kotlin/com/nexters/bandalart/core/ui/component/BandalartButton.kt
@@ -10,13 +10,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.nexters.bandalart.core.common.extension.clickableSingle
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
 import com.nexters.bandalart.core.designsystem.theme.pretendardFontFamily
-import org.jetbrains.compose.resources.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
 fun BandalartButton(
@@ -25,9 +24,10 @@ fun BandalartButton(
     modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = modifier
-            .height(56.dp)
-            .clickableSingle(onClick = onClick),
+        modifier =
+            modifier
+                .height(56.dp)
+                .clickableSingle(onClick = onClick),
         contentAlignment = Alignment.Center,
     ) {
         Text(

--- a/docs/CIRCUIT_METRO_KMP_MIGRATION_MAP.md
+++ b/docs/CIRCUIT_METRO_KMP_MIGRATION_MAP.md
@@ -377,12 +377,14 @@ Presenter 테스트는 Circuit 공식 `Presenter.test`/Turbine 패턴을 유지�
 - [x] Android/iOS entry point에서 플랫폼별 단일 AppGraph를 명시적으로 전달
 - [x] graph test, Android/iOS compile, Detekt와 변경 모듈 Spotless 통과
 - [x] Android debug runtime dependency graph의 Koin artifact 0건
-- [ ] PR CI의 전체 unit test, Android Lint/build와 iOS framework link 통과
+- [x] PR #199 CI의 전체 unit test, Android Lint/build와 iOS framework link 통과
 - [ ] 양 플랫폼 기동과 기존 로컬 데이터 수동 검증
 
 ### 8. 통합 검증 및 main 일원화
 
-- 전체 Android/iOS build/test/static check
+- [x] 정적 분석 적용 범위와 기존 baseline 정비
+- [x] CI의 quality/unit/Android/iOS 병렬 job 구성
+- [ ] PR CI에서 전체 Android/iOS build/test/static check 및 wall time 확인
 - 기존 로컬 데이터 upgrade/restart 확인
 - 내부 테스트 배포
 - `main` merge 및 `develop` 역할 종료

--- a/docs/KMP_INTEGRATION_VALIDATION_STRATEGY.md
+++ b/docs/KMP_INTEGRATION_VALIDATION_STRATEGY.md
@@ -1,0 +1,131 @@
+# KMP 통합 검증 및 main 일원화 전략
+
+## 1. 목적
+
+Circuit 화면과 Metro 의존성 그래프가 Android/iOS composition root까지 연결된 현재 `main`을 양 플랫폼의 단일 기준선으로 확정한다.
+
+이 단계는 새로운 기능을 추가하는 작업이 아니다. 자동 검증 범위를 완성하고 CI 병목을 줄인 뒤, 기존 로컬 데이터와 실제 앱 흐름을 양 플랫폼에서 확인하고 내부 테스트 배포를 거쳐 `develop`의 역할을 종료할 수 있는 근거를 만드는 작업이다.
+
+## 2. 현재 기준선
+
+- PR #199까지 `main`에 반영됐다.
+- Android와 iOS는 플랫폼별 Metro `AppGraph`를 한 번 생성해 공통 `BandalartApp`에 명시적으로 전달한다.
+- 직접 및 전이 Koin runtime 의존성은 Android debug runtime graph에서 제거됐다.
+- Circuit 0.35.1, Metro 1.1.1, compileSdk 37, targetSdk 36을 유지한다.
+- 현재 CI는 unit test, Android Lint, Android/iOS build를 단일 job에서 순차 실행한다.
+- PR #199의 최신 CI는 약 19분 55초가 걸렸다.
+- Spotless/Detekt는 KMP 모듈에서 사용할 수 있지만 적용 범위와 기존 baseline 정비가 끝나지 않아 CI 필수 gate에 포함되지 않았다.
+- `feature:splash`에는 이미 `bandalart.lint`가 적용돼 있었다. 실제 누락은 `androidApp`과 `baselineprofile`이며, `composeApp`의 Spotless task는 형제 모듈인 `androidApp` 소스를 검사하지 않는다.
+
+## 3. 이번 브랜치의 범위
+
+### 3.1 자동 통합 검증
+
+- 전체 Android/iOS unit test와 대상 Circuit Presenter test를 실행한다.
+- Android debug APK와 signed release AAB를 생성한다.
+- iOS Simulator Arm64 framework를 link한다.
+- Android Lint를 실행한다.
+- 최종 Android runtime dependency graph에 Koin artifact가 없는지 확인한다.
+- Metro graph test로 동일 DB, DataStore, repository가 앱 graph 안에서 중복 생성되지 않는지 확인한다.
+
+### 3.2 정적 분석 범위 정비
+
+- `androidApp`, `feature:splash`, `baselineprofile`을 포함한 모듈별 적용 정책을 먼저 확정한다.
+- 앱과 프로덕션 KMP 소스에는 Spotless/Detekt를 적용한다.
+- 생성 코드와 benchmark/profile 전용 소스처럼 도구 적용 이득이 낮거나 오탐이 큰 범위는 이유를 문서화하고 명시적으로 제외한다.
+- 기존 위반은 일괄 포맷 변경으로 섞지 않는다. 변경 파일 수정, 의도적인 baseline, 별도 부채 작업 중 하나로 분류한다.
+- Detekt convention이 KMP compilation별 source를 덮어쓰지 않도록 task 범위를 검토한다.
+- 정비가 끝난 뒤 `spotlessCheck`와 `detekt`를 CI의 빠른 선행 gate로 추가한다.
+
+### 3.3 CI 병목 해소
+
+- 현재 workflow의 단계별 시간을 기록해 기준선을 남긴다.
+- 동일 runner에서 여러 Gradle invocation이 반복하는 configuration/compile 비용을 확인한다.
+- 빠른 정적 분석, unit test, Android 검증, iOS 검증을 독립 job으로 나눠 병렬 실행하는 구성을 우선 검토한다.
+- 동일 브랜치의 새 push가 이전 run을 취소하는 현재 concurrency 동작은 유지한다.
+- 문서만 변경된 PR의 경량 검증은 required check가 영구 pending되지 않는 구조에서만 적용한다.
+- 브랜치 보호가 참조하는 최종 required check 이름은 안정적으로 유지한다.
+- 검증 항목을 삭제하기보다 중복 실행과 순차 대기를 줄인다.
+
+## 4. 후속 수동 gate
+
+자동 검증 PR이 merge된 뒤 다음을 실제 설치 앱에서 확인한다.
+
+### Android
+
+- 기존 스토어 또는 내부 테스트 버전 위에 업그레이드 설치한다.
+- 기존 Room 데이터와 DataStore 설정이 유지되는지 확인한다.
+- cold start, process 재생성, background 복귀와 재시작을 확인한다.
+- 온보딩, Home 조회/편집, 완료 이미지 생성·공유 흐름을 확인한다.
+- 선택 업데이트와 강제 업데이트 정책이 기존 동작을 유지하는지 확인한다.
+- Internal track 배포와 기존 설치 앱의 업데이트를 확인한다.
+
+### iOS
+
+- 기존 앱 데이터가 있는 설치 상태에서 새 framework/app을 실행한다.
+- cold start, background 복귀, Home 조회/편집, 완료 이미지 생성·공유 흐름을 확인한다.
+- Android 전용 업데이트 effect가 iOS graph와 UI 계약을 오염시키지 않는지 확인한다.
+
+수동 결과는 체크리스트와 기기/OS 정보를 PR 또는 후속 이슈에 기록한다.
+
+## 5. main 일원화 기준
+
+다음 조건을 모두 충족한 뒤 `main`을 Android/iOS 공통 개발 기준선으로 선언한다.
+
+- 자동 통합 검증과 CI gate가 통과한다.
+- 양 플랫폼의 기존 로컬 데이터 upgrade/restart가 통과한다.
+- Android 내부 테스트 배포와 업데이트 설치가 통과한다.
+- `develop`에만 남은 미병합 커밋, workflow, secret 참조가 없는지 감사한다.
+- 기본 브랜치, PR base, 배포 workflow와 작업 문서가 `main`을 가리킨다.
+- `develop` 역할 종료와 보호 규칙 변경은 감사 결과를 제시한 뒤 수행한다.
+
+`develop`은 즉시 삭제하지 않는다. 먼저 freeze/read-only 기준을 적용하고, 필요한 이력이 없음을 확인한 뒤 보관 또는 삭제를 결정한다.
+
+## 6. 제외 범위
+
+- 설정 화면과 다크 모드 같은 신규 기능
+- BackStack에서 NavStack으로의 전환
+- Circuit, Metro, Kotlin, AGP의 추가 버전 업그레이드
+- DB schema 또는 DataStore key 변경
+- 앱 버전 및 versionCode 변경
+- Play production 배포와 App Store 재출시
+
+## 7. 실행 순서
+
+1. 현재 CI workflow와 정적 분석 convention의 실제 task 범위를 확인한다.
+2. 모듈별 Spotless/Detekt 적용·제외 정책을 확정한다.
+3. 기존 baseline을 최소 변경으로 정리하고 로컬 정적 분석을 통과시킨다.
+4. CI를 빠른 선행 gate와 Android/iOS 병렬 검증으로 재구성한다.
+5. 전체 자동 검증을 로컬과 PR CI에서 통과시킨다.
+6. 양 플랫폼 수동 회귀와 기존 데이터 upgrade/restart를 수행한다.
+7. Android internal track에 배포해 기존 설치 앱 업데이트를 확인한다.
+8. `develop` 차이를 감사하고 `main` 일원화 변경을 별도 승인 가능한 단위로 적용한다.
+
+## 8. 성공 기준
+
+- 자동 검증 항목을 줄이지 않고 PR CI wall time이 기존 약 20분보다 유의미하게 감소한다.
+- 정적 분석 대상과 제외 대상이 문서와 Gradle 설정에서 일치한다.
+- `androidApp`이 Spotless/Detekt 대상인지 여부가 암묵적 누락이 아니라 명시적 정책으로 결정된다.
+- Android/iOS build, test, static check가 모두 통과한다.
+- 기존 Room schema와 DataStore key가 바뀌지 않는다.
+- 양 플랫폼 실제 앱 흐름과 기존 데이터가 유지된다.
+- 내부 배포 및 branch 운영 변경 전후에 되돌릴 기준점이 남는다.
+
+## 9. 롤백 원칙
+
+- CI 재구성은 기존 검증 명령을 기준으로 결과 동등성을 먼저 확인한다. 누락이 발견되면 병렬 workflow만 되돌리고 검증 명령은 유지한다.
+- 정적 분석 적용이 대규모 무관 포맷 diff를 요구하면 baseline 또는 별도 부채 작업으로 분리한다.
+- 수동 회귀에서 데이터 또는 기능 문제가 발견되면 internal 배포를 중단하고 `main` 일원화와 `develop` 역할 변경을 진행하지 않는다.
+- 브랜치 보호와 기본 브랜치 변경은 코드 merge와 분리해 복구 가능한 순서로 수행한다.
+
+## 10. 구현 결과
+
+- `androidApp`에 `bandalart.lint`를 적용해 application 진입점도 Spotless/Detekt 대상에 포함했다.
+- `baselineprofile`은 생성·계측 전용 Android test 모듈이므로 필수 정적 분석에서 명시적으로 제외했다.
+- Spotless는 Kotlin과 Gradle Kotlin DSL에 ktlint 1.5.0을 적용한다. 기존 파일의 저작권 연도를 갱신하지 못하고 non-convergent 결과를 만들던 license header 및 XML step은 제거했다.
+- CI는 `origin/main` ratchet을 전달해 현재 PR에서 변경된 파일만 Spotless gate로 검사한다.
+- Detekt 일반 task만 모듈 전체 소스를 검사하며, target/compilation별 task의 source와 classpath는 더 이상 덮어쓰지 않는다.
+- 기존 Detekt 위반 11건은 단순 포맷, 미사용 import/parameter, 정확한 예외 처리와 test naming suppression으로 정리했다.
+- CI는 code quality, unit test, Android lint/build, iOS framework build를 병렬 실행하고 마지막 `ci-build`가 결과를 집계한다.
+- Markdown-only PR은 무거운 KMP build workflow를 실행하지 않는다.
+- PR #199 기준 약 19분 55초였던 단일 순차 job과 새 병렬 CI의 wall time은 이번 PR 결과로 비교한다.

--- a/docs/KMP_METRO_MIGRATION_TROUBLESHOOTING.md
+++ b/docs/KMP_METRO_MIGRATION_TROUBLESHOOTING.md
@@ -494,6 +494,25 @@ Home 모듈에는 현재 formatter 규칙과 맞지 않는 기존 파일이 남�
 
 DI runtime 제거는 소스 import 0건뿐 아니라 최종 앱 runtime classpath까지 확인한다.
 
+## 25. Spotless ratchet이 linked worktree에서 저장소를 찾지 못함
+
+### 증상
+
+`ratchetFrom("origin/main")`을 convention에 항상 적용한 뒤 linked worktree에서 Spotless task를 생성하면 `Cannot find git repository in any parent directory`로 실패했다.
+
+### 원인
+
+일반 clone의 `.git`은 디렉터리지만 `git worktree`로 만든 작업 디렉터리의 `.git`은 공통 git directory를 가리키는 파일이다. Spotless의 JGit ratchet 탐색이 이 구조를 repository directory로 인식하지 못했다.
+
+### 해결
+
+- convention은 `spotlessRatchetFrom` Gradle property가 있을 때만 ratchet을 활성화한다.
+- GitHub Actions quality job은 full fetch 후 `-PspotlessRatchetFrom=origin/main`을 전달한다.
+- linked worktree의 로컬 변경 파일은 absolute path를 전달하는 `spotlessIdeHook`으로 포맷한다.
+- 기존 baseline 전체에 `spotlessApply`를 실행하지 않는다.
+
+CI clone과 로컬 linked worktree의 Git metadata 형태가 다르므로 ratchet 활성화를 명시적인 실행 입력으로 둔다.
+
 ## 참고 문서
 
 - [KMP AGP 9 마이그레이션 전략](KMP_AGP_9_MIGRATION_STRATEGY.md)

--- a/docs/KMP_STATIC_ANALYSIS_SUPPORT.md
+++ b/docs/KMP_STATIC_ANALYSIS_SUPPORT.md
@@ -1,13 +1,14 @@
 # KMP ktlint / Detekt 지원 범위
 
-작성 기준: 2026-08-05, `refactor/metro-repository-graph`
+작성 기준: 2026-08-05, `chore/kmp-integration-validation`
 
 ## 결론
 
 - **ktlint는 KMP 소스의 스타일 검사와 포맷에 사용할 수 있다.** ktlint 자체는 `.kt`/`.kts` 파일을 검사하며 KMP target을 컴파일하거나 타입을 해석하지 않는다. 이 저장소에서는 ktlint Gradle plugin이 아니라 **Spotless 7.0.1이 ktlint 1.5.0을 formatter/linter 엔진으로 호출**한다.
 - **Detekt 1.23.8은 KMP Gradle plugin과 함께 target/compilation별 task를 생성한다.** 다만 실제 type resolution은 JVM/Android target에만 연결되고 Kotlin/Native(iOS)는 타입 정보 없이 분석된다.
 - 따라서 “KMP에서 지원된다”는 답은 둘 다 `Yes`이지만 범위가 다르다. ktlint/Spotless는 source set과 무관한 파일 기반 스타일 검사이고, Detekt는 KMP task를 제공하되 모든 플랫폼에서 동일한 의미 분석을 제공하지 않는다.
-- 현재 저장소는 12개 KMP 모듈에 도구가 적용되어 있으나 `feature:splash`, `androidApp`, `baselineprofile`에는 적용되지 않는다. 또한 Detekt convention이 KMP task별 source 입력을 모듈 전체로 덮어써 source set 분리가 무효화된다. 현재 상태를 그대로 CI 필수 gate로 승격하면 안 된다.
+- 현재 저장소는 프로덕션 KMP 모듈과 `androidApp`에 도구를 적용한다. `baselineprofile`은 생성·계측 전용 Android test 모듈이므로 필수 정적 분석에서 명시적으로 제외한다.
+- Detekt의 일반 `detekt` task는 모듈 전체 소스를 검사하되 target/compilation별 task의 source 입력은 덮어쓰지 않는다. Android target의 type resolution과 KMP source set 경계를 보존한다.
 
 ## 공식 지원 근거
 
@@ -25,9 +26,7 @@ Spotless는 format마다 `target`/`targetExclude`로 파일 집합을 정하고 
 - [Spotless Gradle: Kotlin/ktlint 설정](https://github.com/diffplug/spotless/blob/main/plugin-gradle/README.md#ktlint)
 - [Spotless Gradle: `spotlessCheck`와 `check` 연결](https://github.com/diffplug/spotless/blob/main/plugin-gradle/README.md#disabling-warnings-and-error-messages)
 
-Spotless의 `$YEAR`는 헤더가 없는 파일에 현재 연도를 넣지만, 이미 유효한 연도가 있는 헤더는 기본 설정에서 갱신하지 않는다. 즉 2026년에 새 파일에 기존 `2025` 헤더를 복사하면 Spotless가 자동으로 `2026`으로 바꾸지 않는다. `ratchetFrom`을 사용해야 변경 파일의 연도 갱신 동작을 활성화할 수 있다.
-
-- [Spotless license header 연도 동작](https://github.com/diffplug/spotless/blob/main/plugin-gradle/README.md#license-header)
+저작권 헤더는 코드 포맷과 별도 관심사로 둔다. Spotless의 license header step은 기존 유효 연도를 갱신하지 않고 KTS/XML 일부 파일에서 non-convergent 결과를 만들었기 때문에 자동 주입하지 않는다.
 
 ### Detekt
 
@@ -55,11 +54,13 @@ KMP의 `commonMain`, 플랫폼별 source set, 중간 source set은 서로 다른
 
 | Format | 대상 | 제외 | 적용 step |
 | --- | --- | --- | --- |
-| Kotlin | `**/*.kt` | `**/build/**/*.kt` | license header, ktlint 1.5.0 |
-| Gradle Kotlin DSL | `**/*.kts` | `**/build/**/*.kts` | license header |
-| XML | `**/*.xml` | `**/build/**/*.xml` | XML용 license header |
+| Kotlin | `**/*.kt` | `**/build/**/*.kt` | ktlint 1.5.0 |
+| Gradle Kotlin DSL | `**/*.gradle.kts` | `**/build/**/*.gradle.kts` | ktlint 1.5.0 |
+| XML | 필수 gate 제외 | - | Android Lint와 리소스 빌드로 검증 |
 
 Kotlin target이 source set별로 나뉘지 않으므로 plugin이 적용된 모듈에서는 `commonMain`, `androidMain`, `androidHostTest`, `iosMain` 등 디렉터리 이름과 관계없이 모든 `.kt`가 같은 `spotlessKotlinCheck`에서 검사된다. generated source가 `build/` 밖에 생성되면 현재 exclude로는 걸러지지 않는다.
+
+CI는 `-PspotlessRatchetFrom=origin/main`을 전달해 현재 PR에서 변경된 파일만 검사한다. 기존 포맷 부채를 대량 변경하지 않으면서 새 위반 유입을 막는다. linked worktree에서는 Spotless가 `.git` 파일을 repository directory로 인식하지 못하므로 변경 파일에 absolute-path `spotlessIdeHook`을 사용한다.
 
 현재 `.editorconfig`는 ktlint의 filename, import ordering, wrapping, argument list wrapping, multiline if/else, trailing comma 등의 일부 표준 규칙을 비활성화한다. 따라서 “ktlint 지원”이 “모든 ktlint 표준 규칙 활성화”를 뜻하지는 않는다.
 
@@ -71,18 +72,18 @@ Kotlin target이 source set별로 나뉘지 않으므로 plugin이 적용된 모
 - `buildUponDefaultConfig = true`, `ignoreFailures = false`, `autoCorrect = false`, parallel 실행
 - `detekt-formatting` ruleset 추가
 - 모든 `Detekt` task에 `jvmTarget = 17`
-- 모든 `Detekt` task의 source를 각 모듈의 `./` 전체로 다시 설정하고 `**/*.kt`, `**/*.kts`를 포함하며 `resources/`, `build/`를 제외
-
-마지막 source 재설정이 핵심 한계다. Detekt plugin이 만든 `detektAndroidMain`, `detektMetadataCommonMain`, `detektIosArm64Main` 등의 원래 compilation별 입력이 모두 같은 모듈 전체 파일 트리로 바뀐다. task 이름과 classpath는 target별이어도 실제 입력은 source set별로 분리되지 않는다. 특히 Android type-resolution task가 iOS/common 파일과 모듈의 `build.gradle.kts`까지 함께 받으므로 정확한 의미 분석을 보장하기 어렵고 같은 파일이 여러 task에서 중복 검사될 수 있다.
+- 일반 `detekt` task만 각 모듈의 `./` 전체에서 `.kt`/`.kts`를 검사하고 `resources/`, `build/`를 제외
+- target/compilation별 Detekt task는 plugin이 계산한 source와 classpath를 보존
+- report merge에는 XML report만 입력
 
 `./gradlew :composeApp:tasks --all --offline`로 확인한 대표 task는 다음과 같다.
 
 | Task 종류 | 예시 | Type resolution | 현재 실제 source 입력 |
 | --- | --- | --- | --- |
 | 일반 | `detekt` | 없음 | 모듈 전체 `.kt`/`.kts` |
-| Android | `detektAndroidMain`, `detektAndroidHostTest` | 있음 | 모듈 전체 `.kt`/`.kts`로 덮어씀 |
-| metadata/common/intermediate | `detektMetadataCommonMain`, `detektMetadataIosMain`, `detektMetadataAppleMain` | 없음 | 모듈 전체 `.kt`/`.kts`로 덮어씀 |
-| Kotlin/Native | `detektIosArm64Main`, `detektIosSimulatorArm64Main`, `detektIosX64Main` 및 test task | 없음 | 모듈 전체 `.kt`/`.kts`로 덮어씀 |
+| Android | `detektAndroidMain`, `detektAndroidHostTest` | 있음 | plugin이 계산한 Android source set |
+| metadata/common/intermediate | `detektMetadataCommonMain`, `detektMetadataIosMain`, `detektMetadataAppleMain` | 없음 | plugin이 계산한 source set |
+| Kotlin/Native | `detektIosArm64Main`, `detektIosSimulatorArm64Main`, `detektIosX64Main` 및 test task | 없음 | plugin이 계산한 Native source set |
 
 ## 모듈 및 source set별 적용 여부
 
@@ -91,9 +92,9 @@ Kotlin target이 source set별로 나뉘지 않으므로 plugin이 적용된 모
 | `composeApp` | 적용 | 적용 | `commonMain`, `androidMain`, `androidHostTest`, `androidRelease`, `iosMain`의 실제 파일 포함 |
 | `core:common`, `core:data`, `core:database`, `core:datastore`, `core:designsystem`, `core:domain`, `core:navigation`, `core:ui` | 적용 | 적용 | 각 모듈의 존재하는 common/Android/iOS/test 파일 포함 |
 | `feature:complete`, `feature:home`, `feature:onboarding` | 적용 | 적용 | `bandalart.kmp.feature`가 `bandalart.lint`를 적용 |
-| `feature:splash` | **미적용** | **미적용** | KMP 모듈이지만 `bandalart.lint`/`bandalart.detekt`가 없음 |
-| `androidApp` | 미적용 | 미적용 | Android application module |
-| `baselineprofile` | 미적용 | 미적용 | Android test module |
+| `feature:splash` | 적용 | 적용 | `bandalart.lint` 직접 적용 |
+| `androidApp` | 적용 | 적용 | Android application 진입점도 동일 gate 적용 |
+| `baselineprofile` | 제외 | 제외 | 생성·계측 전용 Android test 모듈 |
 
 `bandalart.kmp.feature`는 `bandalart.lint`를 통해 Detekt를 이미 적용한 뒤 `bandalart.detekt`를 다시 요청한다. Gradle plugin idempotency 때문에 task가 두 벌 생성되지는 않지만 중복 선언은 불필요하다.
 
@@ -101,46 +102,26 @@ Kotlin target이 source set별로 나뉘지 않으므로 plugin이 적용된 모
 
 기존 `docs/KMP_AGP_9_MIGRATION_STRATEGY.md`와 `docs/KMP_METRO_MIGRATION_TROUBLESHOOTING.md`에는 “KMP에서 task가 생성되지만 규칙/source 범위 정비가 필요하며 CI gate에서 제외했다”는 요약만 있다. 지원 범위, 누락 모듈, type resolution 한계, Detekt source 덮어쓰기는 기록되어 있지 않았다.
 
-현재 PR branch에서 실제 실행한 결과는 다음과 같다.
+`chore/kmp-integration-validation`에서 실제 실행한 결과는 다음과 같다.
 
-- `composeApp` Spotless 검사는 처음에 `RepositoryBindings.kt`의 formatting 2건을 발견했고 이번 PR에서 수정했다. 이후 검사에서는 기존 `BandalartApp`, `BandalartNavHost`, `BandalartSnackbar`, `MainViewController`의 function naming 4건이 남았다.
-- `composeApp`의 일반 `detekt` task는 기존 `MainViewController` naming 1건으로 실패했다.
-- 현재 `.github/workflows/android-ci.yml`은 단위 테스트, `:androidApp:lintDebug`, Android/iOS build만 실행하며 Spotless/Detekt를 실행하지 않는다.
-
-이는 도구가 KMP에서 실행되지 않는 문제가 아니라, **지원되지만 기존 baseline/규칙/적용 범위 정비가 끝나지 않은 상태**라는 뜻이다.
+- `androidApp`을 포함한 일반 `detekt`가 통과했다.
+- 변경 Kotlin/KTS 파일은 absolute-path `spotlessIdeHook`으로 포맷했다.
+- CI는 Spotless ratchet과 Detekt를 빠른 quality job에서 실행한다.
+- unit test, Android Lint/build와 iOS framework build는 독립 job에서 병렬 실행한다.
+- 마지막 `ci-build` job이 네 결과를 집계해 기존 check 이름을 유지한다.
 
 ## CI 권장 task와 도입 순서
 
-### 지금
-
-현재 CI 명령은 유지한다. Spotless/Detekt는 실패 원인과 누락 범위를 정리하는 별도 작업에서 먼저 통과시킨다. `ktlintCheck`는 이 저장소에 생성되지 않는 task이므로 사용하지 않는다.
-
-로컬 현황 확인에는 아래 selector를 사용한다.
+### CI gate
 
 ```bash
-./gradlew spotlessCheck detekt
+./gradlew spotlessCheck detekt -PspotlessRatchetFrom=origin/main
 ```
 
-현재 이 명령은 적용된 12개 모듈의 `spotlessCheck`와 type resolution 없는 일반 `detekt`를 선택한다. `feature:splash`, `androidApp`, `baselineprofile`은 포함하지 않는다.
-
-### CI gate로 올리기 전 필수 정비
-
-1. 정적 분석 대상 모듈 정책을 확정하고 최소한 누락된 KMP 모듈 `feature:splash`에 동일 convention을 적용한다.
-2. 기존 Spotless/Detekt 위반을 수정하거나 의도적인 baseline으로 동결한다.
-3. Detekt의 `tasks.withType<Detekt> { source = ... }` 전역 덮어쓰기를 제거한다. 일반 `detekt`만 별도 범위로 설정하거나 KMP plugin이 제공한 compilation별 source를 보존한다.
-4. Native task에는 type resolution이 없다는 전제하에 규칙 결과를 해석한다. 플랫폼별 타입 규칙의 완전한 대체재로 사용하지 않는다.
-5. report merge가 필요한 형식과 산출물 경로를 분리해 검증한다.
-
-### 정비 후 권장 gate
-
-```bash
-./gradlew spotlessCheck detekt
-```
-
-- `spotlessCheck`: 모든 적용 모듈의 ktlint/헤더/Gradle Kotlin DSL/XML 검사
+- `spotlessCheck`: 현재 PR에서 변경된 Kotlin과 Gradle Kotlin DSL의 ktlint 검사
 - `detekt`: KMP 전체 파일의 공통 syntax/구조 규칙 검사, type resolution 없음
 
-Android/JVM 의미 분석 규칙도 gate로 삼으려면 compilation별 source 입력을 복구한 후 생성된 Android task를 별도 실행한다.
+Android/JVM 의미 분석 규칙도 추가 gate로 삼으려면 source 입력이 복구된 compilation별 Android task를 별도 실행한다.
 
 ```bash
 ./gradlew detektAndroidMain
@@ -152,7 +133,6 @@ Android/JVM 의미 분석 규칙도 gate로 삼으려면 compilation별 source �
 
 - ktlint/Spotless는 KMP compiler 검증이 아니다. `expect`/`actual` 연결, source set dependency, 플랫폼 API 사용 가능 여부는 Kotlin compilation이 검증한다.
 - Detekt 1.23.8의 Native/iOS 분석에는 type resolution이 없다. 타입이 필요한 규칙은 실행되지 않거나 제한된 동작만 한다.
-- 현재 Detekt source 덮어쓰기로 compilation별 task의 장점이 훼손되어 있다.
 - Spotless와 일반 `detekt`는 모두 파일 기반 범위를 넓게 잡으므로 build 밖의 generated Kotlin은 별도 exclude가 필요하다.
-- Spotless의 `$YEAR`는 기존의 유효한 연도를 자동 갱신하지 않는다.
+- Spotless JGit ratchet은 linked worktree를 인식하지 못하므로 로컬에서는 absolute-path IDE hook을 사용한다.
 - Detekt 1.23.8은 공식 페이지에서도 더 이상 actively maintained 버전이 아니며 Kotlin 2.0.21로 빌드되었다. 현재 프로젝트 Kotlin/Gradle/AGP 조합에서 task 생성은 확인했지만, version upgrade는 규칙/baseline과 함께 별도 검증해야 한다.


### PR DESCRIPTION
## 🔗 관련 이슈

- #182

## 📙 작업 설명

- 순차 실행하던 단일 CI job을 code quality, unit test, Android, iOS 병렬 job과 최종 `ci-build` 집계 job으로 재구성했습니다.
- `androidApp`에 `bandalart.lint`를 적용하고 Spotless를 변경 파일 ratchet 방식의 Kotlin/Kotlin DSL 검사로 정리했습니다.
- Detekt 일반 task와 KMP target별 task의 source 책임을 분리해 Android type resolution과 source set 경계를 보존했습니다.
- 기존 Detekt 위반 11건을 최소 수정하고 정적 분석 지원 범위·통합 검증 전략·트러블슈팅 문서를 갱신했습니다.
- Markdown-only PR은 무거운 Android/iOS CI를 실행하지 않도록 했습니다.

## 🧪 테스트 내역 (선택)

- [x] `detekt`
- [x] `:core:common:testAndroidHostTest`
- [x] `:core:data:testAndroidHostTest`
- [x] `:androidApp:compileDebugKotlin`
- [x] `:composeApp:compileKotlinIosSimulatorArm64`
- [x] 변경 Kotlin/KTS 파일 Spotless IDE hook
- [x] `androidApp` Spotless/Detekt task 생성 확인
- [x] CI YAML 구문과 job 구조 확인
- [ ] 실제 Android/iOS 기기 회귀 테스트

## 📸 스크린샷 또는 시연 영상 (선택)

- UI 변경 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)

- CI quality job은 full fetch 후 `-PspotlessRatchetFrom=origin/main`을 전달합니다.
- linked worktree에서는 Spotless JGit ratchet 대신 absolute-path IDE hook을 사용합니다.
- `baselineprofile`은 생성·계측 전용 모듈이라 필수 정적 분석에서 명시적으로 제외했습니다.
- 기존 연도를 갱신하지 못하고 non-convergent 결과를 만들던 저작권 헤더 자동 주입과 XML Spotless step은 제거했습니다.
- 병렬 CI 최장 job은 iOS 10분 10초로, 기존 순차 CI 19분 55초 대비 약 49% 단축됐습니다.
- #182는 실제 기기 검증·내부 배포·main 일원화까지 완료한 뒤 닫습니다.

## 💡 코드리뷰 Tip

Gemini Code Assist 리뷰 코멘트가 달리면 `resolve-gemini-review`를 실행하여 미해결 코멘트를 반영하거나 거절 사유를 남길 수 있습니다.
