### PR TITLE
fix: Android 저장 경로 및 Home 다크 테마 회귀 수정

### DIFF
--- a/core/common/src/commonMain/kotlin/com/nexters/bandalart/core/common/extension/Modifier.kt
+++ b/core/common/src/commonMain/kotlin/com/nexters/bandalart/core/common/extension/Modifier.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.focus.onFocusEvent
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.layout.LayoutModifier
@@ -172,3 +173,14 @@ fun Modifier.captureToGraphicsLayer(graphicsLayer: GraphicsLayer,) =
         graphicsLayer.record { this@drawWithContent.drawContent() }
         drawLayer(graphicsLayer)
     }
+
+fun Modifier.captureToGraphicsLayer(
+    graphicsLayer: GraphicsLayer,
+    captureBackgroundColor: Color,
+) = this.drawWithContent {
+    graphicsLayer.record {
+        drawRect(captureBackgroundColor)
+        this@drawWithContent.drawContent()
+    }
+    this@drawWithContent.drawContent()
+}

--- a/core/database/src/androidHostTest/kotlin/com/nexters/bandalart/core/database/BandalartDatabaseFactoryAndroidTest.kt
+++ b/core/database/src/androidHostTest/kotlin/com/nexters/bandalart/core/database/BandalartDatabaseFactoryAndroidTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 easyhooon
+ * Copyright 2026 easyhooon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,22 +16,14 @@
 
 package com.nexters.bandalart.core.database
 
-import android.content.Context
-import androidx.room.Room
-import androidx.room.RoomDatabase
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-actual class BandalartDatabaseFactory(
-    private val context: Context
-) {
-    actual fun create(): RoomDatabase.Builder<BandalartDatabase> {
-        val appContext = context.applicationContext
-        val dbFile = appContext.getDatabasePath(ANDROID_BANDALART_DATABASE_NAME)
-
-        return Room.databaseBuilder(
-            context = appContext,
-            name = dbFile.absolutePath
-        )
+@DisplayName("Android Room 파일명 호환성")
+class BandalartDatabaseFactoryAndroidTest {
+    @Test
+    fun databaseUsesLegacyName() {
+        assertEquals("bandalart_database", ANDROID_BANDALART_DATABASE_NAME)
     }
 }
-
-internal const val ANDROID_BANDALART_DATABASE_NAME = "bandalart_database"

--- a/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreFactoryAndroidTest.kt
+++ b/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreFactoryAndroidTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.datastore
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Android DataStore 파일 경로 호환성")
+class BandalartDataStoreFactoryAndroidTest {
+    @Test
+    fun bandalartDataStoreUsesLegacyRelativePath() {
+        assertEquals(
+            "datastore/bandalart_datastore.preferences_pb",
+            ANDROID_BANDALART_DATA_STORE_RELATIVE_PATH,
+        )
+    }
+
+    @Test
+    fun inAppUpdateDataStoreUsesLegacyRelativePath() {
+        assertEquals(
+            "datastore/in_app_update_datastore.preferences_pb",
+            ANDROID_IN_APP_UPDATE_DATA_STORE_RELATIVE_PATH,
+        )
+    }
+}

--- a/core/datastore/src/androidMain/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreFactory.android.kt
+++ b/core/datastore/src/androidMain/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreFactory.android.kt
@@ -29,7 +29,7 @@ actual class BandalartDataStoreFactory(
         PreferenceDataStoreFactory.createWithPath(
             produceFile = {
                 context.filesDir
-                    .resolve(BANDALART_DATA_STORE_FILE_NAME)
+                    .resolve(ANDROID_BANDALART_DATA_STORE_RELATIVE_PATH)
                     .absolutePath
                     .toPath()
             }
@@ -39,9 +39,12 @@ actual class BandalartDataStoreFactory(
         PreferenceDataStoreFactory.createWithPath(
             produceFile = {
                 context.filesDir
-                    .resolve(IN_APP_UPDATE_DATA_STORE_FILE_NAME)
+                    .resolve(ANDROID_IN_APP_UPDATE_DATA_STORE_RELATIVE_PATH)
                     .absolutePath
                     .toPath()
             }
         )
 }
+
+internal const val ANDROID_BANDALART_DATA_STORE_RELATIVE_PATH = "datastore/bandalart_datastore.preferences_pb"
+internal const val ANDROID_IN_APP_UPDATE_DATA_STORE_RELATIVE_PATH = "datastore/in_app_update_datastore.preferences_pb"

--- a/docs/HOTFIX_2_2_8_STORAGE_THEME_STRATEGY.md
+++ b/docs/HOTFIX_2_2_8_STORAGE_THEME_STRATEGY.md
@@ -1,0 +1,152 @@
+# 2.2.8 저장 호환성 및 다크 테마 회귀 핫픽스 전략
+
+## 1. 배경
+
+GitHub Issue #203은 2.2.6 Play Internal 설치본을 2.2.7로 인앱 업데이트한 실제 Android 기기에서 발견한 출시 차단 회귀를 다룬다.
+
+- 온보딩이 다시 노출되고 기존 반다라트가 보이지 않는다.
+- 다크 모드가 system bar와 일부 app chrome에만 적용되고 Home의 바람개비형 차트, bottom sheet와 입력 UI는 밝은색으로 남는다.
+- Home top bar의 설정 아이콘과 `+추가`/목록 액션이 높이 기준으로 중앙 정렬되지 않는다.
+
+이번 핫픽스는 새 아키텍처를 추가하지 않는다. KMP 전환 과정에서 바뀐 Android 저장 경로와 semantic color 적용 누락을 복구하고 2.2.8 Internal Testing에서 동일 업데이트 경로를 다시 검증한다.
+
+## 2. 확인된 원인
+
+### Android 저장 경로
+
+2.2.6과 2.2.7은 key와 Room entity schema는 동일하지만 실제 파일 경로가 다르다.
+
+| 저장소 | 2.2.6 | 2.2.7 |
+|---|---|---|
+| Bandalart DataStore | `files/datastore/bandalart_datastore.preferences_pb` | `files/bandalart.preferences_pb` |
+| In-app update DataStore | `files/datastore/in_app_update_datastore.preferences_pb` | `files/in_app_update.preferences_pb` |
+| Room | `databases/bandalart_database` | `databases/bandalart.db` |
+
+기존 파일은 삭제되지 않았다. 2.2.7 Android factory가 새 빈 파일을 열어 onboarding status의 기본값 `false`와 빈 DB를 반환한다.
+
+### 다크 테마
+
+`BandalartTheme`에는 dark semantic palette가 있으나 Home 내부 컴포넌트가 `White`, `Gray100`, `Gray300`, `Gray900`을 직접 사용한다. 따라서 테마 전환이 화면 표면, 글자, 아이콘, border와 gradient에 전달되지 않는다.
+
+### Top bar 정렬
+
+설정 액션은 48dp `IconButton`, `+추가`/목록은 높이가 없는 `Box`다. 상위 `Row`에도 `verticalAlignment = Alignment.CenterVertically`가 없어 서로 다른 높이 기준으로 배치된다.
+
+## 3. 목표
+
+- Android에서 2.2.6의 실제 Room/DataStore 경로를 다시 사용한다.
+- 2.2.6 → 2.2.8 업데이트 후 onboarding, 최근 반다라트 ID, 목록과 Room 데이터가 그대로 보이게 한다.
+- Home의 실제 화면 표면 전체가 `MaterialTheme.colorScheme`을 사용하게 한다.
+- 사용자가 선택한 main/sub chart 색상과 emoji는 테마와 무관하게 유지한다.
+- 설정, `+추가`/목록 액션을 동일한 최소 48dp hit area와 수직 중앙 기준으로 맞춘다.
+- 앱 버전을 2.2.8(20208)로 올려 Internal Testing에서 재검증한다.
+
+## 4. 저장 호환성 구현
+
+### Android
+
+- DataStore factory는 기존 `preferencesDataStore(name = ...)`와 동일한 `files/datastore/` 경로를 직접 사용한다.
+- Bandalart: `bandalart_datastore.preferences_pb`
+- In-app update: `in_app_update_datastore.preferences_pb`
+- Room factory는 legacy database name `bandalart_database`를 사용한다.
+- Android 전용 상수와 경로 선택에 회귀 테스트를 추가한다.
+
+새 파일을 옛 파일 위에 복사하거나 DB를 삭제하지 않는다. 2.2.7은 Internal Testing에만 배포됐고 production의 사용자 데이터는 legacy 경로에 있으므로 Android의 source of truth를 legacy 경로로 복구하는 것이 가장 안전하다.
+
+### iOS
+
+iOS의 기존 `bandalart.preferences_pb`, `bandalart.db` 경로는 변경하지 않는다. Android 호환성 복구를 common filename 변경으로 구현하지 않는다.
+
+## 5. 다크 테마 구현 범위
+
+다음 의미를 Material color scheme에 연결한다.
+
+- page background → `background`
+- top bar, bottom sheet, dialog, menu, card → `surface`
+- 입력/선택/비활성 container → `surfaceVariant`
+- 기본 text/icon → `onSurface`
+- 보조 text/icon → `onSurfaceVariant`
+- divider/border/chart gap → `outline` 또는 `outlineVariant`
+- primary action → `primary` / `onPrimary`
+
+대상은 Home 차트와 cell, header, progress, skeleton, list/edit bottom sheet, emoji/color/date picker, dropdown, delete dialog, scroll gradient와 공통 bottom-sheet 구성요소다.
+
+다음은 직접 색상을 유지한다.
+
+- 사용자 선택 main/sub 색상
+- completion/error처럼 제품 의미가 있는 색상
+- 공유·저장 캡처 레이어의 `Gray50` 캔버스
+- emoji/vector 자체 색상과 `Color.Unspecified` tint
+
+캡처 전용 `Gray50` 배경과 실제 화면 배경은 draw 단계에서 분리한다. 저장되는 이미지는 기존 밝은 캔버스를 유지하고, 화면에는 캡처 배경을 다시 그리지 않아 상위 theme background가 보이게 한다.
+
+## 6. Top bar 정렬
+
+- 62dp top bar 높이는 유지한다.
+- 상위 `Row`를 top bar 높이에 맞추고 `verticalAlignment = Alignment.CenterVertically`를 적용한다.
+- 설정과 `+추가`/목록 모두 최소 48dp hit area를 갖는다.
+- 아이콘과 text row를 중앙 정렬하고 기존 좌우 padding과 시각적 간격은 유지한다.
+
+## 7. 회귀 테스트
+
+### 자동
+
+- Android legacy DataStore file name과 `datastore/` 상대 경로
+- Android legacy Room database name
+- 기존 DataStore key 읽기/쓰기 테스트 유지
+- 기존 Room DAO schema/CRUD 테스트 유지
+- ThemeMode와 Home Presenter 테스트 유지
+- Android/iOS 컴파일과 정적 분석 통과
+
+Compose screenshot test 기반이 현재 없으므로 다크 테마 전체 색상과 top bar 시각 정렬은 코드 수준 semantic color 감사와 Internal Testing 실기기 비교를 완료 조건으로 둔다. 얕은 source-string 테스트는 잘못된 안정감을 주므로 추가하지 않는다.
+
+### Internal Testing
+
+1. 기존 2.2.6 설치본과 데이터가 있는 상태를 준비한다.
+2. 2.2.8 선택 업데이트를 수행한다.
+3. 온보딩이 생략되고 기존 Home 데이터가 표시되는지 확인한다.
+4. 생성·편집·삭제, 목록, 완료, 공유·저장을 확인한다.
+5. 시스템/라이트/다크 전환 후 Home 차트, modal과 입력 UI를 확인한다.
+6. 앱 재시작 후 데이터와 테마 설정을 확인한다.
+
+## 8. 검증 명령
+
+```bash
+./gradlew :core:datastore:testAndroidHostTest \
+  :core:database:testAndroidHostTest \
+  :feature:home:testAndroidHostTest \
+  :androidApp:compileDebugKotlin \
+  :composeApp:compileKotlinIosSimulatorArm64
+
+./gradlew spotlessCheck detekt -PspotlessRatchetFrom=origin/main
+```
+
+전체 APK/AAB와 실제 Play 업로드는 PR CI 통과·merge 후 `deploy-android-playstore` 절차에서 실행한다.
+
+## 9. 완료 조건
+
+- Android가 legacy Room/DataStore 파일을 열고 기존 데이터가 유지된다.
+- iOS 저장 경로와 사용자 선택 차트/공유 이미지 색상에 영향이 없다.
+- Home의 바람개비형 차트와 modal까지 다크 테마가 일관되게 적용된다.
+- top bar 액션이 동일 높이 기준으로 중앙 정렬된다.
+- 2.2.8(20208) 자동 검증과 Internal Testing 업데이트 검증이 통과한다.
+- 결과를 #203과 umbrella #182에 기록한다.
+
+## 10. 비범위
+
+- 새로운 테마 팔레트 또는 디자인 시스템 전면 개편
+- Room schema/version 변경
+- 2.2.7 새 빈 저장소와 legacy 저장소의 양방향 merge
+- iOS 배포
+- production 배포
+- foreground 강제 업데이트 정책 #186
+
+## 11. 구현 후 자동 검증 결과
+
+- Android legacy DataStore/Room 경로 회귀 테스트: 통과
+- 기존 Home Presenter Android host test: 통과
+- `core:common`, `core:database`, `core:datastore`, `feature:home` detekt: 통과
+- Android 앱 debug Kotlin compile: 통과
+- iOS Simulator Arm64 KMP compile: 통과
+
+실제 2.2.6 → 2.2.8 데이터 복구와 다크 테마 시각 확인은 PR merge 후 Internal Testing에서 수행한다.

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
@@ -228,8 +228,10 @@ internal fun HomeContent(
                 Column(
                     modifier =
                         Modifier
-                            .captureToGraphicsLayer(homeGraphicsLayer)
-                            .background(Gray50),
+                            .captureToGraphicsLayer(
+                                graphicsLayer = homeGraphicsLayer,
+                                captureBackgroundColor = Gray50,
+                            ),
                 ) {
                     if (state.bandalartCellData != null && state.bandalartData != null) {
                         HomeHeader(
@@ -244,8 +246,10 @@ internal fun HomeContent(
                             onHomeUiAction = state.eventSink,
                             modifier =
                                 Modifier
-                                    .captureToGraphicsLayer(completeGraphicsLayer)
-                                    .background(Gray50),
+                                    .captureToGraphicsLayer(
+                                        graphicsLayer = completeGraphicsLayer,
+                                        captureBackgroundColor = Gray50,
+                                    ),
                         )
                     }
                     Spacer(modifier = Modifier.height(64.dp))

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/CompletionRatioProgressBar.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/CompletionRatioProgressBar.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -40,7 +41,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray200
 import com.nexters.bandalart.core.designsystem.theme.MainColor
 import androidx.compose.ui.tooling.preview.Preview
 
@@ -66,31 +66,35 @@ fun CompletionRatioProgressBar(
     }
 
     Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .wrapContentSize(),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .wrapContentSize(),
     ) {
         // Progress Bar
         Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(8.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(8.dp),
         ) {
             // for the background of the ProgressBar
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clip(RoundedCornerShape(5.dp))
-                    .background(Gray200),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .clip(RoundedCornerShape(5.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
             )
             // for the progress of the ProgressBar
             Box(
-                modifier = Modifier
-                    .fillMaxWidth(size)
-                    .fillMaxHeight()
-                    .clip(RoundedCornerShape(5.dp))
-                    .background(progressColor)
-                    .animateContentSize(),
+                modifier =
+                    Modifier
+                        .fillMaxWidth(size)
+                        .fillMaxHeight()
+                        .clip(RoundedCornerShape(5.dp))
+                        .background(progressColor)
+                        .animateContentSize(),
             )
         }
     }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/HomeHeader.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/HomeHeader.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
@@ -61,9 +62,6 @@ import com.nexters.bandalart.core.common.extension.toColor
 import com.nexters.bandalart.core.common.extension.toFormatDate
 import com.nexters.bandalart.core.common.getLocale
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray100
-import com.nexters.bandalart.core.designsystem.theme.Gray300
-import com.nexters.bandalart.core.designsystem.theme.Gray600
 import com.nexters.bandalart.core.designsystem.theme.Gray900
 import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
 import com.nexters.bandalart.feature.home.model.BandalartUiModel
@@ -97,7 +95,7 @@ fun HomeHeader(
                             Modifier
                                 .width(52.dp)
                                 .aspectRatio(1f)
-                                .background(Gray100)
+                                .background(MaterialTheme.colorScheme.surfaceVariant)
                                 .clickable {
                                     onHomeUiAction(HomeScreen.Event.OpenEmoji)
                                 },
@@ -138,7 +136,12 @@ fun HomeHeader(
             ) {
                 Text(
                     text = bandalartData.titleText.ifEmpty { stringResource(Res.string.home_empty_title) },
-                    color = if (bandalartData.titleText.isEmpty()) Gray300 else Gray900,
+                    color =
+                        if (bandalartData.titleText.isEmpty()) {
+                            MaterialTheme.colorScheme.outline
+                        } else {
+                            MaterialTheme.colorScheme.onBackground
+                        },
                     fontSize = 20.sp,
                     fontWeight = FontWeight.W700,
                     modifier =
@@ -156,7 +159,7 @@ fun HomeHeader(
                         Modifier
                             .align(Alignment.CenterEnd)
                             .clickable { onHomeUiAction(HomeScreen.Event.OpenDropDownMenu) },
-                    tint = Color.Unspecified,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 BandalartDropDownMenu(
                     isDropDownMenuOpened = isDropDownMenuOpened,
@@ -171,7 +174,7 @@ fun HomeHeader(
         ) {
             Text(
                 text = stringResource(Res.string.home_complete_ratio, bandalartData.completionRatio),
-                color = Gray600,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
                 fontSize = 12.sp,
                 fontWeight = FontWeight.W500,
                 letterSpacing = (-0.24).sp,
@@ -183,11 +186,11 @@ fun HomeHeader(
                             .height(8.dp)
                             .padding(start = 6.dp),
                     thickness = 1.dp,
-                    color = Gray300,
+                    color = MaterialTheme.colorScheme.outlineVariant,
                 )
                 Text(
                     text = bandalartData.dueDate.toFormatDate(getLocale()),
-                    color = Gray600,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     fontSize = 12.sp,
                     fontWeight = FontWeight.W500,
                     modifier = Modifier.padding(start = 6.dp),

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/HomeTopBar.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/HomeTopBar.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Icon
@@ -67,7 +68,10 @@ internal fun HomeTopBar(
                 .background(MaterialTheme.colorScheme.surface),
         contentAlignment = Alignment.CenterStart,
     ) {
-        Row(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().height(62.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             AppTitle(
                 modifier =
                     Modifier
@@ -90,6 +94,8 @@ internal fun HomeTopBar(
                 modifier =
                     Modifier
                         .padding(end = 20.dp)
+                        .height(48.dp)
+                        .widthIn(min = 48.dp)
                         .clickable(
                             onClick = {
                                 if (bandalartCount > 1) {
@@ -99,6 +105,7 @@ internal fun HomeTopBar(
                                 }
                             },
                         ),
+                contentAlignment = Alignment.Center,
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     if (bandalartCount > 1) {

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartBottomSheet.kt
@@ -49,6 +49,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -61,7 +62,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
@@ -88,10 +88,6 @@ import com.nexters.bandalart.core.common.extension.toLocalDateTime
 import com.nexters.bandalart.core.common.extension.toStringLocalDateTime
 import com.nexters.bandalart.core.common.getLocale
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray100
-import com.nexters.bandalart.core.designsystem.theme.Gray300
-import com.nexters.bandalart.core.designsystem.theme.Gray400
-import com.nexters.bandalart.core.designsystem.theme.Gray700
 import com.nexters.bandalart.core.ui.NavigationBarHeightDp
 import com.nexters.bandalart.core.ui.ThemeColor
 import com.nexters.bandalart.core.ui.getNavigationBarPadding
@@ -165,7 +161,7 @@ fun BandalartBottomSheet(
         Column(
             modifier =
                 Modifier
-                    .background(White)
+                    .background(MaterialTheme.colorScheme.surface)
                     .navigationBarsPadding()
                     .noRippleClickable { focusManager.clearFocus() },
         ) {
@@ -205,7 +201,7 @@ fun BandalartBottomSheet(
                                             Modifier
                                                 .width(52.dp)
                                                 .aspectRatio(1f)
-                                                .background(Gray100)
+                                                .background(MaterialTheme.colorScheme.surfaceVariant)
                                                 .clickable {
                                                     onHomeUiAction(HomeScreen.Event.OpenEmojiPicker)
                                                 },
@@ -254,7 +250,7 @@ fun BandalartBottomSheet(
                             HorizontalDivider(
                                 modifier = Modifier.fillMaxWidth(),
                                 thickness = 1.dp,
-                                color = Gray300,
+                                color = MaterialTheme.colorScheme.outline,
                             )
                         }
                     }
@@ -326,14 +322,14 @@ fun BandalartBottomSheet(
                                     Modifier
                                         .align(Alignment.CenterEnd)
                                         .size(24.dp),
-                                tint = Gray400,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
                         Spacer(modifier = Modifier.height(10.dp))
                         HorizontalDivider(
                             modifier = Modifier.fillMaxWidth(),
                             thickness = 1.dp,
-                            color = Gray300,
+                            color = MaterialTheme.colorScheme.outline,
                         )
                     }
                     AnimatedVisibility(visible = bottomSheetData.isDatePickerOpened) {
@@ -360,7 +356,7 @@ fun BandalartBottomSheet(
                         HorizontalDivider(
                             modifier = Modifier.fillMaxWidth(),
                             thickness = 1.dp,
-                            color = Gray300,
+                            color = MaterialTheme.colorScheme.outline,
                         )
                     }
                     if (cellType == CellType.TASK) {
@@ -383,12 +379,12 @@ fun BandalartBottomSheet(
                                 },
                                 colors =
                                     SwitchDefaults.colors(
-                                        uncheckedThumbColor = White,
-                                        uncheckedTrackColor = Gray300,
-                                        uncheckedBorderColor = Gray300,
-                                        checkedThumbColor = White,
-                                        checkedTrackColor = Gray700,
-                                        checkedBorderColor = Gray700,
+                                        uncheckedThumbColor = MaterialTheme.colorScheme.surface,
+                                        uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant,
+                                        uncheckedBorderColor = MaterialTheme.colorScheme.outline,
+                                        checkedThumbColor = MaterialTheme.colorScheme.onPrimary,
+                                        checkedTrackColor = MaterialTheme.colorScheme.primary,
+                                        checkedBorderColor = MaterialTheme.colorScheme.primary,
                                     ),
                                 modifier =
                                     Modifier

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartCell.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartCell.kt
@@ -29,12 +29,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -46,10 +46,6 @@ import bandalart.core.designsystem.generated.resources.home_sub_cell
 import bandalart.core.designsystem.generated.resources.ic_cell_check
 import com.nexters.bandalart.core.common.extension.toColor
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray400
-import com.nexters.bandalart.core.designsystem.theme.Gray500
-import com.nexters.bandalart.core.designsystem.theme.Gray600
-import com.nexters.bandalart.core.designsystem.theme.Gray900
 import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
 import com.nexters.bandalart.feature.home.model.BandalartUiModel
 import com.nexters.bandalart.feature.home.model.CellType
@@ -193,7 +189,12 @@ private fun SubCellContent(
 
 @Composable
 private fun TaskCellContent(cellData: BandalartCellEntity) {
-    val cellTextColor = if (cellData.isCompleted) Gray600 else Gray900
+    val cellTextColor =
+        if (cellData.isCompleted) {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        } else {
+            MaterialTheme.colorScheme.onSurface
+        }
 
     if (cellData.title.isNullOrEmpty()) {
         EmptyTaskContent()
@@ -256,7 +257,7 @@ private fun EmptyTaskContent() {
     Icon(
         imageVector = Icons.Default.Add,
         contentDescription = stringResource(Res.string.add_description),
-        tint = Gray500,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
         modifier = Modifier.size(20.dp),
     )
 }
@@ -293,6 +294,7 @@ private fun FilledCellContent(
     }
 }
 
+@Composable
 private fun getCellBackgroundColor(
     bandalartData: BandalartUiModel,
     cellType: CellType,
@@ -308,8 +310,8 @@ private fun getCellBackgroundColor(
         // 서브 목표 미달성
         cellType == CellType.SUB -> bandalartData.subColor.toColor()
         // 태스크 목표 달성
-        cellData.isCompleted -> Gray400
-        else -> White
+        cellData.isCompleted -> MaterialTheme.colorScheme.outline
+        else -> MaterialTheme.colorScheme.surface
     }
 
 // @ComponentPreview

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartChart.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartChart.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -34,7 +35,6 @@ import bandalart.core.designsystem.generated.resources.home_layout_id
 import bandalart.core.designsystem.generated.resources.home_main_id
 import com.nexters.bandalart.core.common.extension.toColor
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray300
 import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
 import com.nexters.bandalart.feature.home.model.BandalartUiModel
 import com.nexters.bandalart.feature.home.model.CellType
@@ -74,7 +74,7 @@ fun BandalartChart(
                             Modifier
                                 .layoutId(stringResource(Res.string.home_layout_id, index + 1))
                                 .clip(RoundedCornerShape(12.dp))
-                                .background(color = Gray300),
+                                .background(color = MaterialTheme.colorScheme.outline),
                     ) {
                         BandalartCellGrid(
                             bandalartData = bandalartData,

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartColorPicker.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartColorPicker.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,12 +34,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.unit.dp
 import com.nexters.bandalart.core.common.extension.noRippleClickable
 import com.nexters.bandalart.core.common.extension.toColor
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray900
 import com.nexters.bandalart.core.ui.ThemeColor
 import com.nexters.bandalart.core.ui.allColor
 import androidx.compose.ui.tooling.preview.Preview
@@ -50,9 +49,10 @@ fun BandalartColorPicker(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(45.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(45.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceEvenly,
     ) {
@@ -65,22 +65,24 @@ fun BandalartColorPicker(
             ) {
                 if (it.mainColor == initSelected.mainColor) {
                     Card(
-                        border = BorderStroke(width = 1.5.dp, color = Gray900),
-                        modifier = Modifier
-                            .height(45.dp)
-                            .aspectRatio(1f),
+                        border = BorderStroke(width = 1.5.dp, color = MaterialTheme.colorScheme.onSurface),
+                        modifier =
+                            Modifier
+                                .height(45.dp)
+                                .aspectRatio(1f),
                         shape = RoundedCornerShape(90.dp),
-                        colors = CardDefaults.cardColors(White),
+                        colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surface),
                     ) { }
                 }
                 Card(
-                    modifier = Modifier
-                        .height(36.dp)
-                        .aspectRatio(1f)
-                        .noRippleClickable {
-                            initSelected = it
-                            onColorSelect(initSelected)
-                        },
+                    modifier =
+                        Modifier
+                            .height(36.dp)
+                            .aspectRatio(1f)
+                            .noRippleClickable {
+                                initSelected = it
+                                onColorSelect(initSelected)
+                            },
                     shape = RoundedCornerShape(90.dp),
                     colors = CardDefaults.cardColors(containerColor = it.mainColor.toColor()),
                 ) { }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartDatePicker.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartDatePicker.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
@@ -52,8 +53,6 @@ import bandalart.core.designsystem.generated.resources.datepicker_year
 import com.nexters.bandalart.core.common.extension.LocalDateTime
 import com.nexters.bandalart.core.common.extension.toLocalDateTime
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray200
-import com.nexters.bandalart.core.designsystem.theme.Gray900
 import com.nexters.bandalart.core.designsystem.theme.pretendardFontFamily
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -79,35 +78,38 @@ fun BandalartDatePicker(
         val chosenDay = remember { mutableStateOf(currentDueDate.dayOfMonth.toString()) }
 
         Row(
-            modifier = Modifier
-                .align(Alignment.End)
-                .padding(
-                    top = 14.dp,
-                    end = 20.dp,
-                    bottom = 14.dp,
-                ),
+            modifier =
+                Modifier
+                    .align(Alignment.End)
+                    .padding(
+                        top = 14.dp,
+                        end = 20.dp,
+                        bottom = 14.dp,
+                    ),
         ) {
             Text(
                 text = stringResource(Res.string.bottomsheet_reset),
-                color = Gray900,
+                color = MaterialTheme.colorScheme.onSurface,
                 fontSize = 16.sp,
                 fontWeight = FontWeight.W700,
-                modifier = Modifier
-                    .clickable {
-                        onDueDateSelect(LocalDateTime.now())
-                    },
+                modifier =
+                    Modifier
+                        .clickable {
+                            onDueDateSelect(LocalDateTime.now())
+                        },
                 fontFamily = pretendardFontFamily(),
             )
             Text(
                 text = stringResource(Res.string.bottomsheet_done),
-                color = Gray900,
+                color = MaterialTheme.colorScheme.onSurface,
                 fontSize = 16.sp,
                 fontWeight = FontWeight.W700,
-                modifier = Modifier
-                    .padding(start = 16.dp)
-                    .clickable {
-                        onDueDateSelect(selectedDateWithValidate(chosenYear.value, chosenMonth.value, chosenDay.value))
-                    },
+                modifier =
+                    Modifier
+                        .padding(start = 16.dp)
+                        .clickable {
+                            onDueDateSelect(selectedDateWithValidate(chosenYear.value, chosenMonth.value, chosenDay.value))
+                        },
                 fontFamily = pretendardFontFamily(),
             )
         }
@@ -133,9 +135,10 @@ fun DateSelectionSection(
     modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(180.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(180.dp),
         contentAlignment = Alignment.Center,
     ) {
         val yearOffset = Int.MAX_VALUE / 2 - ((Int.MAX_VALUE / 2) % years.size) + years.indexOf(currentYear)
@@ -143,18 +146,20 @@ fun DateSelectionSection(
         val dayOffset = Int.MAX_VALUE / 2 - ((Int.MAX_VALUE / 2) % days.size) + (currentDay - 1)
 
         Box(
-            modifier = Modifier
-                .height(40.dp)
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(10.dp))
-                .background(Gray200)
-                .align(Alignment.Center),
+            modifier =
+                Modifier
+                    .height(40.dp)
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(10.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .align(Alignment.Center),
         )
         Row(
             horizontalArrangement = Arrangement.SpaceAround,
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(180.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(180.dp),
         ) {
             InfiniteItemsPicker(
                 modifier = Modifier.weight(1f),
@@ -225,15 +230,17 @@ fun InfiniteItemsPicker(
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
-                        text = when {
-                            isYear -> stringResource(Res.string.datepicker_year, items[itemIndex].toString())
-                            isMonth -> stringResource(Res.string.datepicker_month, items[itemIndex].toString())
-                            else -> stringResource(Res.string.datepicker_day, items[itemIndex].toString())
-                        },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .alpha(if (isMiddleItem) 1f else 0.6f),
-                        color = Gray900,
+                        text =
+                            when {
+                                isYear -> stringResource(Res.string.datepicker_year, items[itemIndex].toString())
+                                isMonth -> stringResource(Res.string.datepicker_month, items[itemIndex].toString())
+                                else -> stringResource(Res.string.datepicker_day, items[itemIndex].toString())
+                            },
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .alpha(if (isMiddleItem) 1f else 0.6f),
+                        color = MaterialTheme.colorScheme.onSurface,
                         fontSize = if (isMiddleItem) 20.sp else 17.sp,
                         fontWeight = if (isMiddleItem) FontWeight.W500 else FontWeight.W400,
                         textAlign = TextAlign.Center,
@@ -245,17 +252,22 @@ fun InfiniteItemsPicker(
     }
 }
 
-fun selectedDateWithValidate(year: String, month: String, day: String): LocalDateTime {
+fun selectedDateWithValidate(
+    year: String,
+    month: String,
+    day: String
+): LocalDateTime {
     val yearNum = year.filter { it.isDigit() }.toInt()
     val monthNum = month.filter { it.isDigit() }.toInt()
     val dayNum = day.filter { it.isDigit() }.toInt()
 
     // 각 월의 최대 일수 계산
-    val maxDaysInMonth = when (monthNum) {
-        2 -> if (isLeapYear(yearNum)) 29 else 28 // 2월: 윤년 고려
-        4, 6, 9, 11 -> 30 // 30일까지 있는 달
-        else -> 31 // 그 외 달은 31일
-    }
+    val maxDaysInMonth =
+        when (monthNum) {
+            2 -> if (isLeapYear(yearNum)) 29 else 28 // 2월: 윤년 고려
+            4, 6, 9, 11 -> 30 // 30일까지 있는 달
+            else -> 31 // 그 외 달은 31일
+        }
 
     // 일자 유효성 검사 및 보정
     val validatedDay = dayNum.coerceAtMost(maxDaysInMonth)
@@ -264,9 +276,7 @@ fun selectedDateWithValidate(year: String, month: String, day: String): LocalDat
 }
 
 // 윤년 계산 함수
-private fun isLeapYear(year: Int): Boolean {
-    return year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
-}
+private fun isLeapYear(year: Int): Boolean = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
 
 // @ComponentPreview
 @Preview

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartDeleteAlertDialog.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartDeleteAlertDialog.kt
@@ -28,13 +28,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -46,9 +46,6 @@ import bandalart.core.designsystem.generated.resources.delete_bandalart_delete
 import bandalart.core.designsystem.generated.resources.delete_description
 import bandalart.core.designsystem.generated.resources.ic_delete
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray200
-import com.nexters.bandalart.core.designsystem.theme.Gray400
-import com.nexters.bandalart.core.designsystem.theme.Gray900
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -64,25 +61,27 @@ fun BandalartDeleteAlertDialog(
     Dialog(onDismissRequest = { onCancelClick() }) {
         Surface(
             shape = RoundedCornerShape(16.dp),
-            color = White,
+            color = MaterialTheme.colorScheme.surface,
         ) {
             Column(
-                modifier = modifier
-                    .fillMaxWidth()
-                    .padding(top = 24.dp),
+                modifier =
+                    modifier
+                        .fillMaxWidth()
+                        .padding(top = 24.dp),
             ) {
                 Icon(
                     imageVector = vectorResource(Res.drawable.ic_delete),
                     contentDescription = stringResource(Res.string.delete_description),
-                    modifier = Modifier
-                        .height(28.dp)
-                        .align(Alignment.CenterHorizontally),
+                    modifier =
+                        Modifier
+                            .height(28.dp)
+                            .align(Alignment.CenterHorizontally),
                     tint = Color.Unspecified,
                 )
                 Spacer(modifier = Modifier.height(18.dp))
                 Text(
                     text = title,
-                    color = Gray900,
+                    color = MaterialTheme.colorScheme.onSurface,
                     fontSize = 20.sp,
                     fontWeight = FontWeight.W700,
                     modifier = Modifier.align(Alignment.CenterHorizontally),
@@ -94,7 +93,7 @@ fun BandalartDeleteAlertDialog(
                     Spacer(modifier = Modifier.height(8.dp))
                     Text(
                         text = message,
-                        color = Gray400,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                         fontSize = 14.sp,
                         fontWeight = FontWeight.W500,
                         modifier = Modifier.align(Alignment.CenterHorizontally),
@@ -104,48 +103,53 @@ fun BandalartDeleteAlertDialog(
                 }
                 Spacer(modifier = Modifier.height(30.dp))
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 24.dp)
-                        .align(Alignment.CenterHorizontally),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp)
+                            .align(Alignment.CenterHorizontally),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Button(
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(56.dp),
+                        modifier =
+                            Modifier
+                                .weight(1f)
+                                .height(56.dp),
                         onClick = onCancelClick,
-                        colors = ButtonColors(
-                            containerColor = Gray200,
-                            contentColor = Gray900,
-                            disabledContainerColor = Gray200,
-                            disabledContentColor = Gray900,
-                        ),
+                        colors =
+                            ButtonColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            ),
                     ) {
                         Text(
                             text = stringResource(Res.string.delete_bandalart_cancel),
                             fontSize = 16.sp,
                             fontWeight = FontWeight.W600,
-                            color = Gray900,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                     Spacer(modifier = Modifier.width(9.dp))
                     Button(
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(56.dp),
+                        modifier =
+                            Modifier
+                                .weight(1f)
+                                .height(56.dp),
                         onClick = onDeleteClick,
-                        colors = ButtonColors(
-                            containerColor = Gray900,
-                            contentColor = White,
-                            disabledContainerColor = Gray900,
-                            disabledContentColor = White,
-                        ),
+                        colors =
+                            ButtonColors(
+                                containerColor = MaterialTheme.colorScheme.primary,
+                                contentColor = MaterialTheme.colorScheme.onPrimary,
+                                disabledContainerColor = MaterialTheme.colorScheme.primary,
+                                disabledContentColor = MaterialTheme.colorScheme.onPrimary,
+                            ),
                     ) {
                         Text(
                             text = stringResource(Res.string.delete_bandalart_delete),
-                            color = White,
+                            color = MaterialTheme.colorScheme.onPrimary,
                             fontSize = 16.sp,
                             fontWeight = FontWeight.W600,
                         )

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartDropDownMenu.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartDropDownMenu.kt
@@ -28,12 +28,12 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
@@ -46,7 +46,6 @@ import bandalart.core.designsystem.generated.resources.ic_gallery
 import bandalart.core.designsystem.generated.resources.ic_trash
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
 import com.nexters.bandalart.core.designsystem.theme.Error
-import com.nexters.bandalart.core.designsystem.theme.Gray800
 import com.nexters.bandalart.core.designsystem.theme.pretendardFontFamily
 import com.nexters.bandalart.feature.home.HomeScreen
 import org.jetbrains.compose.resources.stringResource
@@ -63,7 +62,7 @@ fun BandalartDropDownMenu(
         modifier =
             modifier
                 .wrapContentSize()
-                .background(White),
+                .background(MaterialTheme.colorScheme.surface),
         expanded = isDropDownMenuOpened,
         onDismissRequest = {
             onAction(HomeScreen.Event.DismissDropDownMenu)
@@ -93,7 +92,7 @@ fun BandalartDropDownMenu(
                     )
                     Text(
                         text = stringResource(Res.string.dropdown_save),
-                        color = Gray800,
+                        color = MaterialTheme.colorScheme.onSurface,
                         fontSize = 14.sp,
                         fontWeight = FontWeight.W500,
                         modifier =

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartEmojiPicker.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartEmojiPicker.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -39,22 +40,20 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray100
-import com.nexters.bandalart.core.designsystem.theme.Gray400
 import com.nexters.bandalart.core.ui.NavigationBarHeightDp
 import kotlinx.collections.immutable.persistentListOf
 import androidx.compose.ui.tooling.preview.Preview
 
-private val emojiList = persistentListOf(
-    "🔥", "😀", "😃", "😄", "😆", "🥹",
-    "🥰", "😍", "😂", "🥲", "☺️", "😎",
-    "🥳", "🤩", "⭐", "🌟", "✨", "💥",
-    "❤️", "🧡", "💛", "💚", "💙", "❤️‍🔥",
-)
+private val emojiList =
+    persistentListOf(
+        "🔥", "😀", "😃", "😄", "😆", "🥹",
+        "🥰", "😍", "😂", "🥲", "☺️", "😎",
+        "🥳", "🤩", "⭐", "🌟", "✨", "💥",
+        "❤️", "🧡", "💛", "💚", "💙", "❤️‍🔥",
+    )
 
 @Composable
 fun BandalartEmojiPicker(
@@ -67,73 +66,79 @@ fun BandalartEmojiPicker(
     var prevSelectedEmoji by remember { mutableStateOf(currentEmoji) }
 
     Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(White)
-            .padding(
-                top = if (isBottomSheet) 16.dp else 0.dp,
-            ),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(
+                    top = if (isBottomSheet) 16.dp else 0.dp,
+                ),
     ) {
         var emojiIndex = 0
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    top = if (isBottomSheet) 15.dp else 0.dp,
-                    start = if (isBottomSheet) 15.dp else 0.dp,
-                    end = if (isBottomSheet) 23.dp else 8.dp,
-                    bottom = if (isBottomSheet) 26.dp else 0.dp,
-                ),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        top = if (isBottomSheet) 15.dp else 0.dp,
+                        start = if (isBottomSheet) 15.dp else 0.dp,
+                        end = if (isBottomSheet) 23.dp else 8.dp,
+                        bottom = if (isBottomSheet) 26.dp else 0.dp,
+                    ),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.SpaceEvenly,
         ) {
             repeat(4) {
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 8.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceEvenly,
                 ) {
                     repeat(6) {
                         val emojiItem = emojiList[emojiIndex++]
                         Card(
-                            modifier = Modifier
-                                .padding(start = 8.dp)
-                                .weight(1f),
+                            modifier =
+                                Modifier
+                                    .padding(start = 8.dp)
+                                    .weight(1f),
                             shape = RoundedCornerShape(12.dp),
-                            border = when (emojiItem) {
-                                selectedEmoji -> {
-                                    BorderStroke(
-                                        width = 1.dp,
-                                        color = Gray400,
-                                    )
-                                }
+                            border =
+                                when (emojiItem) {
+                                    selectedEmoji -> {
+                                        BorderStroke(
+                                            width = 1.dp,
+                                            color = MaterialTheme.colorScheme.outline,
+                                        )
+                                    }
 
-                                prevSelectedEmoji -> {
-                                    BorderStroke(
-                                        width = 1.dp,
-                                        color = Color.Transparent,
-                                    )
-                                }
+                                    prevSelectedEmoji -> {
+                                        BorderStroke(
+                                            width = 1.dp,
+                                            color = Color.Transparent,
+                                        )
+                                    }
 
-                                else -> null
-                            },
+                                    else -> null
+                                },
                         ) {
                             Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .aspectRatio(1f)
-                                    .background(color = Gray100)
-                                    .clickable {
-                                        if (selectedEmoji == emojiItem) {
-                                            return@clickable
-                                        } else {
-                                            prevSelectedEmoji = selectedEmoji
-                                            selectedEmoji = emojiItem
-                                            onEmojiSelect(emojiItem)
-                                        }
-                                    },
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .aspectRatio(1f)
+                                        .background(color = MaterialTheme.colorScheme.surfaceVariant)
+                                        .clickable {
+                                            if (selectedEmoji == emojiItem) {
+                                                return@clickable
+                                            } else {
+                                                prevSelectedEmoji = selectedEmoji
+                                                selectedEmoji = emojiItem
+                                                onEmojiSelect(emojiItem)
+                                            }
+                                        },
                                 contentAlignment = Alignment.Center,
                             ) {
                                 Text(

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartListBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartListBottomSheet.kt
@@ -40,13 +40,13 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -57,10 +57,6 @@ import bandalart.core.designsystem.generated.resources.bandalart_list_add
 import bandalart.core.designsystem.generated.resources.bandalart_list_title
 import bandalart.core.designsystem.generated.resources.clear_description
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray200
-import com.nexters.bandalart.core.designsystem.theme.Gray600
-import com.nexters.bandalart.core.designsystem.theme.Gray800
-import com.nexters.bandalart.core.designsystem.theme.Gray900
 import com.nexters.bandalart.core.ui.NavigationBarHeightDp
 import com.nexters.bandalart.core.ui.getNavigationBarPadding
 import com.nexters.bandalart.feature.home.model.BandalartUiModel
@@ -95,7 +91,7 @@ fun BandalartListBottomSheet(
         Column(
             modifier =
                 Modifier
-                    .background(White)
+                    .background(MaterialTheme.colorScheme.surface)
                     .navigationBarsPadding(),
         ) {
             Spacer(modifier = Modifier.height(20.dp))
@@ -107,7 +103,7 @@ fun BandalartListBottomSheet(
             ) {
                 Text(
                     text = stringResource(Res.string.bandalart_list_title),
-                    color = Gray900,
+                    color = MaterialTheme.colorScheme.onSurface,
                     fontSize = 16.sp,
                     fontWeight = FontWeight.W700,
                     modifier = modifier.fillMaxWidth(),
@@ -126,7 +122,7 @@ fun BandalartListBottomSheet(
                     Icon(
                         imageVector = Icons.Default.Clear,
                         contentDescription = stringResource(Res.string.clear_description),
-                        tint = Gray900,
+                        tint = MaterialTheme.colorScheme.onSurface,
                     )
                 }
             }
@@ -162,19 +158,23 @@ fun BandalartListBottomSheet(
                             onClick = {
                                 onHomeUiAction(HomeScreen.Event.AddBandalart)
                             },
-                            colors = ButtonDefaults.buttonColors(containerColor = Gray200),
+                            colors =
+                                ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                ),
                         ) {
                             Row {
                                 Icon(
                                     imageVector = Icons.Default.Add,
                                     contentDescription = stringResource(Res.string.add_description),
-                                    tint = Gray600,
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                     modifier = Modifier.size(20.dp),
                                 )
                                 Spacer(modifier = Modifier.padding(start = 4.dp))
                                 Text(
                                     text = stringResource(Res.string.bandalart_list_add),
-                                    color = Gray800,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                                     fontSize = 16.sp,
                                     fontWeight = FontWeight.W600,
                                 )

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartListItem.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartListItem.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -54,9 +55,6 @@ import bandalart.core.designsystem.generated.resources.home_complete_ratio
 import bandalart.core.designsystem.generated.resources.ic_empty_emoji
 import com.nexters.bandalart.core.common.extension.toColor
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray100
-import com.nexters.bandalart.core.designsystem.theme.Gray300
-import com.nexters.bandalart.core.designsystem.theme.Gray400
 import com.nexters.bandalart.core.designsystem.theme.Gray900
 import com.nexters.bandalart.feature.home.model.BandalartUiModel
 import com.nexters.bandalart.feature.home.model.dummy.dummyBandalartData
@@ -72,28 +70,33 @@ fun BandalartListItem(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
-            .border(
-                width = 1.5.dp,
-                color = if (currentBandalartId != bandalartItem.id) Gray100 else Gray300,
-                shape = RoundedCornerShape(12.dp),
-            )
-            .clickable {
-                if (currentBandalartId != bandalartItem.id) {
-                    onClick(bandalartItem.id)
-                }
-            }
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(12.dp))
+                .border(
+                    width = 1.5.dp,
+                    color =
+                        if (currentBandalartId != bandalartItem.id) {
+                            MaterialTheme.colorScheme.outlineVariant
+                        } else {
+                            MaterialTheme.colorScheme.outline
+                        },
+                    shape = RoundedCornerShape(12.dp),
+                ).clickable {
+                    if (currentBandalartId != bandalartItem.id) {
+                        onClick(bandalartItem.id)
+                    }
+                }.padding(horizontal = 16.dp, vertical = 12.dp),
     ) {
         Box(modifier = Modifier.align(Alignment.CenterVertically)) {
             Card(shape = RoundedCornerShape(16.dp)) {
                 Box(
-                    modifier = Modifier
-                        .width(48.dp)
-                        .aspectRatio(1f)
-                        .background(Gray100),
+                    modifier =
+                        Modifier
+                            .width(48.dp)
+                            .aspectRatio(1f)
+                            .background(MaterialTheme.colorScheme.surfaceVariant),
                     contentAlignment = Alignment.Center,
                 ) {
                     if (bandalartItem.profileEmoji.isNullOrEmpty()) {
@@ -112,15 +115,17 @@ fun BandalartListItem(
             }
         }
         Column(
-            modifier = Modifier
-                .weight(1f)
-                .padding(start = 8.dp),
+            modifier =
+                Modifier
+                    .weight(1f)
+                    .padding(start = 8.dp),
         ) {
             if (bandalartItem.isCompleted) {
                 Box(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(24.dp))
-                        .background(color = bandalartItem.mainColor.toColor()),
+                    modifier =
+                        Modifier
+                            .clip(RoundedCornerShape(24.dp))
+                            .background(color = bandalartItem.mainColor.toColor()),
                 ) {
                     Row(
                         modifier = Modifier.padding(horizontal = 9.dp),
@@ -144,19 +149,21 @@ fun BandalartListItem(
                 }
             } else {
                 Box(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(24.dp))
-                        .background(color = bandalartItem.mainColor.toColor()),
+                    modifier =
+                        Modifier
+                            .clip(RoundedCornerShape(24.dp))
+                            .background(color = bandalartItem.mainColor.toColor()),
                 ) {
                     Row(
                         modifier = Modifier.padding(start = 8.dp, end = 8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
-                            text = stringResource(
-                                Res.string.home_complete_ratio,
-                                bandalartItem.completionRatio,
-                            ),
+                            text =
+                                stringResource(
+                                    Res.string.home_complete_ratio,
+                                    bandalartItem.completionRatio,
+                                ),
                             color = Gray900,
                             fontSize = 9.sp,
                             fontWeight = FontWeight.W600,
@@ -167,7 +174,12 @@ fun BandalartListItem(
             }
             Text(
                 text = bandalartItem.titleText,
-                color = if (bandalartItem.isGeneratedTitle) Gray300 else Gray900,
+                color =
+                    if (bandalartItem.isGeneratedTitle) {
+                        MaterialTheme.colorScheme.outline
+                    } else {
+                        MaterialTheme.colorScheme.onSurface
+                    },
                 fontSize = 16.sp,
                 fontWeight = FontWeight.W700,
                 letterSpacing = (-0.32).sp,
@@ -178,7 +190,7 @@ fun BandalartListItem(
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.ArrowForward,
                     contentDescription = stringResource(Res.string.arrow_forward_description),
-                    tint = Gray400,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.size(16.dp),
                 )
             }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartSkeleton.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartSkeleton.kt
@@ -22,71 +22,58 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color.Companion.White
 import bandalart.core.designsystem.generated.resources.Res
 import bandalart.core.designsystem.generated.resources.skeleton_trans_animate_label
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray100
-import com.nexters.bandalart.core.designsystem.theme.Gray200
-import com.nexters.bandalart.core.designsystem.theme.Gray300
-import com.nexters.bandalart.core.designsystem.theme.Gray400
-import com.nexters.bandalart.core.designsystem.theme.Gray50
 import org.jetbrains.compose.resources.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 
-private val shimmerMainColors = listOf(
-    Gray200,
-    Gray300,
-    Gray400,
-)
-
-private val shimmerSubColors = listOf(
-    Gray100,
-    Gray200,
-    Gray300,
-)
-
-private val shimmerTaskColors = listOf(
-    White,
-    Gray50,
-)
-
 @Composable
-fun BandalartSkeleton(
-    modifier: Modifier = Modifier,
-) {
+fun BandalartSkeleton(modifier: Modifier = Modifier,) {
+    val colorScheme = MaterialTheme.colorScheme
+    val shimmerMainColors = listOf(colorScheme.surfaceVariant, colorScheme.outlineVariant, colorScheme.outline)
+    val shimmerSubColors = listOf(colorScheme.surface, colorScheme.surfaceVariant, colorScheme.outlineVariant)
+    val shimmerTaskColors = listOf(colorScheme.background, colorScheme.surface)
+
     val transition = rememberInfiniteTransition(label = "Skeleton transition")
-    val translateAnim = transition.animateFloat(
-        initialValue = 0f,
-        targetValue = 800f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(
-                durationMillis = 600,
-                easing = FastOutLinearInEasing,
-            ),
-            repeatMode = RepeatMode.Reverse,
-        ),
-        label = stringResource(Res.string.skeleton_trans_animate_label),
-    )
-    val mainBrush = Brush.linearGradient(
-        colors = shimmerMainColors,
-        start = Offset.Zero,
-        end = Offset(x = translateAnim.value, y = translateAnim.value),
-    )
-    val subBrush = Brush.linearGradient(
-        colors = shimmerSubColors,
-        start = Offset.Zero,
-        end = Offset(x = translateAnim.value, y = translateAnim.value),
-    )
-    val taskBrush = Brush.linearGradient(
-        colors = shimmerTaskColors,
-        start = Offset.Zero,
-        end = Offset(x = translateAnim.value, y = translateAnim.value),
-    )
+    val translateAnim =
+        transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 800f,
+            animationSpec =
+                infiniteRepeatable(
+                    animation =
+                        tween(
+                            durationMillis = 600,
+                            easing = FastOutLinearInEasing,
+                        ),
+                    repeatMode = RepeatMode.Reverse,
+                ),
+            label = stringResource(Res.string.skeleton_trans_animate_label),
+        )
+    val mainBrush =
+        Brush.linearGradient(
+            colors = shimmerMainColors,
+            start = Offset.Zero,
+            end = Offset(x = translateAnim.value, y = translateAnim.value),
+        )
+    val subBrush =
+        Brush.linearGradient(
+            colors = shimmerSubColors,
+            start = Offset.Zero,
+            end = Offset(x = translateAnim.value, y = translateAnim.value),
+        )
+    val taskBrush =
+        Brush.linearGradient(
+            colors = shimmerTaskColors,
+            start = Offset.Zero,
+            end = Offset(x = translateAnim.value, y = translateAnim.value),
+        )
 
     BandalartSkeletonScreen(
         taskBrush = taskBrush,

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartSkeletonScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartSkeletonScreen.kt
@@ -16,12 +16,6 @@
 
 package com.nexters.bandalart.feature.home.ui.bandalart
 
-import androidx.compose.animation.core.FastOutLinearInEasing
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -43,6 +37,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -50,10 +45,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.text.font.FontWeight
@@ -76,15 +69,7 @@ import bandalart.core.designsystem.generated.resources.option_description
 import bandalart.core.designsystem.generated.resources.share_description
 import bandalart.core.designsystem.generated.resources.skeleton_complete_ratio
 import bandalart.core.designsystem.generated.resources.skeleton_title
-import bandalart.core.designsystem.generated.resources.skeleton_trans_animate_label
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray100
-import com.nexters.bandalart.core.designsystem.theme.Gray200
-import com.nexters.bandalart.core.designsystem.theme.Gray300
-import com.nexters.bandalart.core.designsystem.theme.Gray400
-import com.nexters.bandalart.core.designsystem.theme.Gray50
-import com.nexters.bandalart.core.designsystem.theme.Gray600
-import com.nexters.bandalart.core.designsystem.theme.Gray900
 import com.nexters.bandalart.core.designsystem.theme.neurimboGothicRegularFontFamily
 import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
 import com.nexters.bandalart.feature.home.ui.CompletionRatioProgressBar
@@ -112,30 +97,33 @@ fun BandalartSkeletonScreen(
 ) {
     Surface(
         modifier = modifier.fillMaxSize(),
-        color = Gray50,
+        color = MaterialTheme.colorScheme.background,
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(bottom = 32.dp),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(bottom = 32.dp),
             ) {
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(62.dp)
-                        .background(White),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(62.dp)
+                            .background(MaterialTheme.colorScheme.surface),
                     contentAlignment = Alignment.CenterStart,
                 ) {
                     Row(modifier = Modifier.fillMaxWidth()) {
                         Text(
                             text = stringResource(Res.string.bandalart),
-                            color = Gray900,
+                            color = MaterialTheme.colorScheme.onBackground,
                             fontSize = 28.sp,
                             fontWeight = FontWeight.W400,
-                            modifier = Modifier
-                                .align(Alignment.CenterVertically)
-                                .padding(start = 20.dp, top = 2.dp),
+                            modifier =
+                                Modifier
+                                    .align(Alignment.CenterVertically)
+                                    .padding(start = 20.dp, top = 2.dp),
                             fontFamily = neurimboGothicRegularFontFamily(),
                             lineHeight = 20.sp,
                             letterSpacing = (-0.56).sp,
@@ -144,7 +132,7 @@ fun BandalartSkeletonScreen(
                 }
                 HorizontalDivider(
                     thickness = 1.dp,
-                    color = Gray100,
+                    color = MaterialTheme.colorScheme.outlineVariant,
                 )
                 Column(modifier.padding(horizontal = 16.dp)) {
                     Spacer(modifier = Modifier.height(24.dp))
@@ -156,10 +144,11 @@ fun BandalartSkeletonScreen(
                                     elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
                                 ) {
                                     Box(
-                                        modifier = Modifier
-                                            .width(52.dp)
-                                            .aspectRatio(1f)
-                                            .background(Gray100),
+                                        modifier =
+                                            Modifier
+                                                .width(52.dp)
+                                                .aspectRatio(1f)
+                                                .background(MaterialTheme.colorScheme.surfaceVariant),
                                         contentAlignment = Alignment.Center,
                                     ) {
                                         Icon(
@@ -172,26 +161,29 @@ fun BandalartSkeletonScreen(
                                 Icon(
                                     imageVector = vectorResource(Res.drawable.ic_edit),
                                     contentDescription = stringResource(Res.string.edit_description),
-                                    modifier = Modifier
-                                        .align(Alignment.BottomEnd)
-                                        .offset(x = 4.dp, y = 4.dp),
+                                    modifier =
+                                        Modifier
+                                            .align(Alignment.BottomEnd)
+                                            .offset(x = 4.dp, y = 4.dp),
                                     tint = Color.Unspecified,
                                 )
                             }
                             Spacer(modifier = Modifier.height(12.dp))
                             Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .wrapContentHeight(),
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .wrapContentHeight(),
                             ) {
                                 Text(
                                     text = stringResource(Res.string.skeleton_title),
-                                    color = Gray900,
+                                    color = MaterialTheme.colorScheme.onBackground,
                                     fontSize = 20.sp,
                                     fontWeight = FontWeight.W700,
-                                    modifier = Modifier
-                                        .align(Alignment.Center)
-                                        .background(subBrush),
+                                    modifier =
+                                        Modifier
+                                            .align(Alignment.Center)
+                                            .background(subBrush),
                                     letterSpacing = (-0.4).sp,
                                 )
                                 Icon(
@@ -210,7 +202,7 @@ fun BandalartSkeletonScreen(
                     ) {
                         Text(
                             text = stringResource(Res.string.skeleton_complete_ratio),
-                            color = Gray600,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                             fontSize = 12.sp,
                             fontWeight = FontWeight.W500,
                             letterSpacing = (-0.24).sp,
@@ -222,7 +214,7 @@ fun BandalartSkeletonScreen(
                 Box(modifier = Modifier.padding(horizontal = 16.dp)) {
                     CompletionRatioProgressBar(
                         completionRatio = 0,
-                        progressColor = Gray300,
+                        progressColor = MaterialTheme.colorScheme.outline,
                     )
                 }
                 Spacer(modifier = Modifier.height(18.dp))
@@ -233,11 +225,12 @@ fun BandalartSkeletonScreen(
                 )
                 Spacer(modifier = Modifier.weight(1f))
                 Box(
-                    modifier = Modifier
-                        .wrapContentSize()
-                        .clip(RoundedCornerShape(18.dp))
-                        .background(Gray100)
-                        .align(Alignment.CenterHorizontally),
+                    modifier =
+                        Modifier
+                            .wrapContentSize()
+                            .clip(RoundedCornerShape(18.dp))
+                            .background(MaterialTheme.colorScheme.surfaceVariant)
+                            .align(Alignment.CenterHorizontally),
                     contentAlignment = Alignment.Center,
                 ) {
                     Row(
@@ -251,7 +244,7 @@ fun BandalartSkeletonScreen(
                         )
                         Text(
                             text = stringResource(Res.string.home_share),
-                            color = Gray900,
+                            color = MaterialTheme.colorScheme.onSurface,
                             fontSize = 12.sp,
                             fontWeight = FontWeight.W700,
                             modifier = Modifier.padding(start = 4.dp),
@@ -273,24 +266,26 @@ fun BandalartSkeletonChart(
     BoxWithConstraints {
         val paddedMaxWidth = remember(maxWidth) { maxWidth - (15.dp * 2) }
 
-        val subCellList = persistentListOf(
-            SkeletonSubCell(2, 3, 1, 1, null),
-            SkeletonSubCell(3, 2, 1, 0, null),
-            SkeletonSubCell(3, 2, 1, 1, null),
-            SkeletonSubCell(2, 3, 0, 1, null),
-        )
+        val subCellList =
+            persistentListOf(
+                SkeletonSubCell(2, 3, 1, 1, null),
+                SkeletonSubCell(3, 2, 1, 0, null),
+                SkeletonSubCell(3, 2, 1, 1, null),
+                SkeletonSubCell(2, 3, 0, 1, null),
+            )
 
         Layout(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clip(RoundedCornerShape(8.dp)),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(8.dp)),
             content = {
                 for (index in subCellList.indices) {
                     Box(
                         modifier
                             .layoutId(stringResource(Res.string.home_layout_id, index + 1))
                             .clip(RoundedCornerShape(12.dp))
-                            .background(color = Gray200),
+                            .background(color = MaterialTheme.colorScheme.surfaceVariant),
                     ) {
                         SkeletonCellGrid(
                             rows = subCellList[index].rowCnt,
@@ -375,13 +370,14 @@ fun SkeletonCellGrid(
                     val isSubCell = rowIndex == subCell.subCellRowIndex && colIndex == subCell.subCellColIndex
                     SkeletonCell(
                         cellType = if (isSubCell) CellType.SUB else CellType.TASK,
-                        skeletonCellInfo = SkeletonCellInfo(
-                            isSubCell = isSubCell,
-                            colIndex = colIndex,
-                            rowIndex = rowIndex,
-                            colCnt = cols,
-                            rowCnt = rows,
-                        ),
+                        skeletonCellInfo =
+                            SkeletonCellInfo(
+                                isSubCell = isSubCell,
+                                colIndex = colIndex,
+                                rowIndex = rowIndex,
+                                colCnt = cols,
+                                rowCnt = rows,
+                            ),
                         modifier = Modifier.weight(1f),
                         taskBrush = taskBrush,
                         subBrush = subBrush,
@@ -414,24 +410,47 @@ fun SkeletonCell(
     mainCellPadding: Dp = 1.dp,
 ) {
     Box(
-        modifier = modifier
-            .padding(
-                start = if (cellType == CellType.MAIN) mainCellPadding
-                else if (skeletonCellInfo.colIndex == 0) outerPadding
-                else innerPadding,
-                end = if (cellType == CellType.MAIN) mainCellPadding
-                else if (skeletonCellInfo.colIndex == skeletonCellInfo.colCnt - 1) outerPadding
-                else innerPadding,
-                top = if (cellType == CellType.MAIN) mainCellPadding
-                else if (skeletonCellInfo.rowIndex == 0) outerPadding
-                else innerPadding,
-                bottom = if (cellType == CellType.MAIN) mainCellPadding
-                else if (skeletonCellInfo.rowIndex == skeletonCellInfo.rowCnt - 1) outerPadding
-                else innerPadding,
-            )
-            .aspectRatio(1f)
-            .clip(RoundedCornerShape(10.dp))
-            .background(if (cellType == CellType.MAIN) mainBrush else if (skeletonCellInfo.isSubCell) subBrush else taskBrush),
+        modifier =
+            modifier
+                .padding(
+                    start =
+                        if (cellType == CellType.MAIN)
+                            mainCellPadding
+                        else if (skeletonCellInfo.colIndex == 0)
+                            outerPadding
+                        else
+                            innerPadding,
+                    end =
+                        if (cellType == CellType.MAIN)
+                            mainCellPadding
+                        else if (skeletonCellInfo.colIndex == skeletonCellInfo.colCnt - 1)
+                            outerPadding
+                        else
+                            innerPadding,
+                    top =
+                        if (cellType == CellType.MAIN)
+                            mainCellPadding
+                        else if (skeletonCellInfo.rowIndex == 0)
+                            outerPadding
+                        else
+                            innerPadding,
+                    bottom =
+                        if (cellType == CellType.MAIN)
+                            mainCellPadding
+                        else if (skeletonCellInfo.rowIndex == skeletonCellInfo.rowCnt - 1)
+                            outerPadding
+                        else
+                            innerPadding,
+                ).aspectRatio(1f)
+                .clip(RoundedCornerShape(10.dp))
+                .background(
+                    if (cellType == CellType.MAIN)
+                        mainBrush
+                    else if (skeletonCellInfo.isSubCell)
+                        subBrush
+                    else
+                        taskBrush
+                ),
         contentAlignment = Alignment.Center,
     ) { }
 }
@@ -440,56 +459,7 @@ fun SkeletonCell(
 @Preview
 @Composable
 private fun BandalartSkeletonScreenPreview() {
-    val shimmerMainColors = listOf(
-        Gray200,
-        Gray300,
-        Gray400,
-    )
-    val shimmerSubColors = listOf(
-        Gray100,
-        Gray200,
-        Gray300,
-    )
-    val shimmerTaskColors = listOf(
-        White,
-        Gray50,
-    )
-
-    val transition = rememberInfiniteTransition(label = "Skeleton transition")
-    val translateAnim = transition.animateFloat(
-        initialValue = 0f,
-        targetValue = 800f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(
-                durationMillis = 600,
-                easing = FastOutLinearInEasing,
-            ),
-            repeatMode = RepeatMode.Reverse,
-        ),
-        label = stringResource(Res.string.skeleton_trans_animate_label),
-    )
-
-    val mainBrush = Brush.linearGradient(
-        colors = shimmerMainColors,
-        start = Offset.Zero,
-        end = Offset(x = translateAnim.value, y = translateAnim.value),
-    )
-    val subBrush = Brush.linearGradient(
-        colors = shimmerSubColors,
-        start = Offset.Zero,
-        end = Offset(x = translateAnim.value, y = translateAnim.value),
-    )
-    val taskBrush = Brush.linearGradient(
-        colors = shimmerTaskColors,
-        start = Offset.Zero,
-        end = Offset(x = translateAnim.value, y = translateAnim.value),
-    )
-
     BandalartTheme {
-        BandalartSkeletonScreen(
-            taskBrush = mainBrush,
-            subBrush = subBrush,
-            mainBrush = taskBrush,
-        )
+        BandalartSkeleton()
     }
 }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BottomSheetButton.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BottomSheetButton.kt
@@ -21,17 +21,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.unit.dp
 import bandalart.core.designsystem.generated.resources.Res
 import bandalart.core.designsystem.generated.resources.bottomsheet_delete
 import bandalart.core.designsystem.generated.resources.bottomsheet_done
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray200
-import com.nexters.bandalart.core.designsystem.theme.Gray400
-import com.nexters.bandalart.core.designsystem.theme.Gray900
 import org.jetbrains.compose.resources.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 
@@ -43,11 +40,17 @@ fun BottomSheetDeleteButton(
     FilledIconButton(
         onClick = onClick,
         modifier = modifier.height(56.dp),
-        colors = IconButtonColors(Gray200, Gray900, Gray200, Gray900),
+        colors =
+            IconButtonColors(
+                MaterialTheme.colorScheme.surfaceVariant,
+                MaterialTheme.colorScheme.onSurface,
+                MaterialTheme.colorScheme.surfaceVariant,
+                MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
     ) {
         BottomSheetButtonText(
             text = stringResource(Res.string.bottomsheet_delete),
-            color = Gray900,
+            color = MaterialTheme.colorScheme.onSurface,
         )
     }
 }
@@ -61,12 +64,23 @@ fun BottomSheetCompleteButton(
     FilledIconButton(
         onClick = onClick,
         modifier = modifier.height(56.dp),
-        colors = IconButtonColors(Gray900, White, Gray200, Gray400),
+        colors =
+            IconButtonColors(
+                MaterialTheme.colorScheme.primary,
+                MaterialTheme.colorScheme.onPrimary,
+                MaterialTheme.colorScheme.surfaceVariant,
+                MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
         enabled = isEnabled,
     ) {
         BottomSheetButtonText(
             text = stringResource(Res.string.bottomsheet_done),
-            color = if (isEnabled) White else Gray400,
+            color =
+                if (isEnabled) {
+                    MaterialTheme.colorScheme.onPrimary
+                } else {
+                    MaterialTheme.colorScheme.onSurfaceVariant
+                },
         )
     }
 }
@@ -78,9 +92,10 @@ private fun BottomSheetDeleteButtonPreview() {
     BandalartTheme {
         BottomSheetDeleteButton(
             onClick = {},
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
         )
     }
 }
@@ -93,9 +108,10 @@ private fun BottomSheetCompleteButtonPreview() {
         BottomSheetCompleteButton(
             isEnabled = false,
             onClick = {},
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
         )
     }
 }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BottomSheetText.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BottomSheetText.kt
@@ -18,6 +18,7 @@ package com.nexters.bandalart.feature.home.ui.bandalart
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Text
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -36,9 +37,6 @@ import bandalart.core.designsystem.generated.resources.bottomsheet_header_taskce
 import bandalart.core.designsystem.generated.resources.bottomsheet_title
 import bandalart.core.designsystem.generated.resources.bottomsheet_title_placeholder
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray400
-import com.nexters.bandalart.core.designsystem.theme.Gray600
-import com.nexters.bandalart.core.designsystem.theme.Gray900
 import com.nexters.bandalart.feature.home.model.CellType
 import org.jetbrains.compose.resources.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -50,22 +48,25 @@ fun BottomSheetTitleText(
     isBlankCell: Boolean,
     modifier: Modifier = Modifier,
 ) {
-    val titleResId = when {
-        isBlankCell -> when (cellType) {
-            CellType.MAIN -> Res.string.bottomsheet_header_maincell_enter_title
-            CellType.SUB -> Res.string.bottomsheet_header_subcell_enter_title
-            CellType.TASK -> Res.string.bottomsheet_header_taskcell_enter_title
+    val titleResId =
+        when {
+            isBlankCell ->
+                when (cellType) {
+                    CellType.MAIN -> Res.string.bottomsheet_header_maincell_enter_title
+                    CellType.SUB -> Res.string.bottomsheet_header_subcell_enter_title
+                    CellType.TASK -> Res.string.bottomsheet_header_taskcell_enter_title
+                }
+            else ->
+                when (cellType) {
+                    CellType.MAIN -> Res.string.bottomsheet_header_maincell_edit_title
+                    CellType.SUB -> Res.string.bottomsheet_header_subcell_edit_title
+                    CellType.TASK -> Res.string.bottomsheet_header_taskcell_edit_title
+                }
         }
-        else -> when (cellType) {
-            CellType.MAIN -> Res.string.bottomsheet_header_maincell_edit_title
-            CellType.SUB -> Res.string.bottomsheet_header_subcell_edit_title
-            CellType.TASK -> Res.string.bottomsheet_header_taskcell_edit_title
-        }
-    }
 
     Text(
         text = stringResource(titleResId),
-        color = Gray900,
+        color = MaterialTheme.colorScheme.onSurface,
         fontSize = 16.sp,
         fontWeight = FontWeight.W700,
         modifier = modifier.fillMaxWidth(),
@@ -82,7 +83,7 @@ fun BottomSheetSubTitleText(
 ) {
     Text(
         text = text,
-        color = Gray600,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
         fontSize = 12.sp,
         fontWeight = FontWeight.W700,
         modifier = modifier,
@@ -99,7 +100,7 @@ fun BottomSheetContentPlaceholder(
 ) {
     Text(
         text = text,
-        color = Gray400,
+        color = MaterialTheme.colorScheme.outline,
         fontSize = 16.sp,
         fontWeight = FontWeight.W400,
         modifier = modifier,
@@ -117,7 +118,7 @@ fun BottomSheetContentText(
     Text(
         text = text,
         textAlign = TextAlign.Start,
-        color = Gray600,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
         fontSize = 16.sp,
         fontWeight = FontWeight.W600,
         modifier = modifier,
@@ -214,7 +215,7 @@ private fun BottomSheetButtonTextPreview() {
     BandalartTheme {
         BottomSheetButtonText(
             text = stringResource(Res.string.bottomsheet_done),
-            color = Gray400,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BottomSheetTopBar.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BottomSheetTopBar.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,7 +36,6 @@ import androidx.compose.ui.unit.dp
 import bandalart.core.designsystem.generated.resources.Res
 import bandalart.core.designsystem.generated.resources.clear_description
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.designsystem.theme.Gray900
 import com.nexters.bandalart.feature.home.model.CellType
 import org.jetbrains.compose.resources.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -48,22 +48,24 @@ fun BottomSheetTopBar(
     modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
     ) {
         BottomSheetTitleText(cellType = cellType, isBlankCell = isBlankCell)
         IconButton(
-            modifier = Modifier
-                .align(Alignment.CenterEnd)
-                .height(21.dp)
-                .aspectRatio(1f),
+            modifier =
+                Modifier
+                    .align(Alignment.CenterEnd)
+                    .height(21.dp)
+                    .aspectRatio(1f),
             onClick = onCloseClick,
         ) {
             Icon(
                 imageVector = Icons.Default.Clear,
                 contentDescription = stringResource(Res.string.clear_description),
-                tint = Gray900,
+                tint = MaterialTheme.colorScheme.onSurface,
             )
         }
     }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/ScrollGradientOverlay.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/ScrollGradientOverlay.kt
@@ -20,11 +20,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color.Companion.Transparent
-import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
 
@@ -33,15 +33,23 @@ internal fun ScrollGradientOverlay(
     isTop: Boolean,
     modifier: Modifier = Modifier,
 ) {
+    val surfaceColor = MaterialTheme.colorScheme.surface
+
     Spacer(
-        modifier = modifier
-            .background(
-                brush = Brush.verticalGradient(
-                    colors = if (isTop) listOf(White, Transparent) else listOf(Transparent, White),
-                ),
-                shape = RectangleShape,
-            )
-            .height(77.dp)
-            .fillMaxWidth(),
+        modifier =
+            modifier
+                .background(
+                    brush =
+                        Brush.verticalGradient(
+                            colors =
+                                if (isTop) {
+                                    listOf(surfaceColor, Transparent)
+                                } else {
+                                    listOf(Transparent, surfaceColor)
+                                },
+                        ),
+                    shape = RectangleShape,
+                ).height(77.dp)
+                .fillMaxWidth(),
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ targetSdk = "36"
 compileSdk = "37"
 majorVersion = "2"
 minorVersion = "2"
-patchVersion = "7"
+patchVersion = "8"
 packageName = "com.nexters.bandalart"
 
 # Gradle Plugin


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #203
- #182

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- Android가 KMP 전환 전 Room 데이터베이스와 DataStore 파일 경로를 다시 사용하도록 복구했습니다.
- Home 차트, 셀, 바텀시트, 목록, 다이얼로그와 스켈레톤에 다크 테마 semantic color를 적용했습니다.
- 화면 배경과 공유·저장 이미지의 캡처 전용 배경을 분리하고 Home top bar 액션을 중앙 정렬했습니다.
- 앱 버전을 2.2.8(20208)로 올리고 저장 호환성 회귀 테스트와 핫픽스 전략 문서를 추가했습니다.

## 🧪 테스트 내역 (선택)

- [x] Room/DataStore Android legacy 경로 회귀 테스트 통과
- [x] Home Android host test 통과
- [x] 관련 모듈 detekt 통과
- [x] Android debug Kotlin 및 iOS Simulator Arm64 KMP 컴파일 통과
- [ ] Internal Testing에서 기존 설치 데이터와 다크 테마 실기기 확인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

Internal Testing 배포 후 2.2.7 설치 기기에서 확인합니다.

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- 2.2.7에서 새로 생성된 빈 저장소와 legacy 저장소의 양방향 병합은 범위에 포함하지 않았습니다.
- 공유·저장 이미지에는 기존 `Gray50` 캔버스를 기록하고 실제 Home 화면에는 현재 테마 배경이 보이도록 draw 경로를 분리했습니다.

## 💡 코드리뷰 Tip

Gemini Code Assist 리뷰 코멘트가 달리면 `resolve-gemini-review`를 실행하여 미해결 코멘트를 반영하거나 거절 사유를 남길 수 있습니다.
