### PR TITLE
fix: 다크 모드 UI 대비와 설정 폰트 보정

### DIFF
--- a/docs/HOTFIX_2_2_9_DARK_THEME_CONTRAST_STRATEGY.md
+++ b/docs/HOTFIX_2_2_9_DARK_THEME_CONTRAST_STRATEGY.md
@@ -1,0 +1,78 @@
+# 2.2.9 다크 테마 대비 회귀 핫픽스 전략
+
+## 1. 배경
+
+2.2.8 Internal Testing에서 Home 전체 다크 테마와 기존 Android 데이터 복구는 정상임을 확인했다. 다만 다크 테마에서 다섯 개의 세부 요소가 주변 화면과 일관되지 않거나 충분히 구분되지 않는다.
+
+- 더보기 메뉴의 저장 아이콘
+- 표 작성 modal bottom sheet의 입력 텍스트
+- 달성 여부 Switch의 미선택 thumb
+- 완료된 task cell과 6칸 task 영역의 바깥 배경
+- 설정 modal bottom sheet의 기본 시스템 폰트
+
+이번 핫픽스는 테마 팔레트나 화면 구조를 다시 설계하지 않는다. 라이트 모드 전용 색상 또는 잘못 연결된 semantic color만 바로잡는다.
+
+## 2. 확인된 원인
+
+| 증상 | 원인 |
+|---|---|
+| 저장 아이콘이 어두움 | `ic_gallery`가 `#1F2937` stroke/fill을 포함하고, `Icon`이 `Color.Unspecified`로 원본 색을 그대로 표시한다. |
+| 입력 문자가 검정색 | `BasicTextField`의 `BottomSheetContent()`가 `Gray900`을 고정 사용한다. |
+| 미선택 Switch thumb가 어두움 | thumb에 dark `surface`, track에 dark `surfaceVariant`를 사용해 두 색의 대비가 작다. |
+| 완료 task cell이 사라져 보임 | 완료 cell과 6칸 task 영역 wrapper가 모두 `outline`을 사용한다. |
+| 설정 화면 텍스트가 기존 화면과 이질적임 | 설정 화면의 모든 `Text`에 font family가 없고 전역 Material typography도 `FontFamily.Default`를 사용한다. |
+
+## 3. 수정 전략
+
+- 저장 아이콘 tint → `onSurface`
+- bottom sheet 입력 text와 cursor → `onSurface`
+- 미선택 Switch thumb → `onSurfaceVariant`
+- 완료 task cell → 기존 `outline` 유지
+- 6칸 task 영역 wrapper → `outlineVariant`
+- 설정 화면의 제목·섹션·테마 항목·버전 텍스트 → `pretendardFontFamily()`
+
+사용자 선택 main/sub 색상, 완료 check vector 원색, 삭제 아이콘의 error 색상은 변경하지 않는다.
+
+## 4. 검증 전략
+
+현재 프로젝트에는 Compose screenshot test 기반이 없고 semantics tree도 실제 paint color를 노출하지 않는다. 얕은 source-string 테스트나 hotfix를 위한 신규 screenshot framework 도입은 하지 않는다.
+
+자동 검증은 다음 범위로 한정한다.
+
+- Android/iOS에서 변경된 common Compose 코드 컴파일
+- Home의 기존 presenter 테스트
+- 변경 모듈의 정적 분석과 코드 스타일 검사
+
+최종 시각 판정은 2.2.9 Internal Testing에서 다음 항목을 라이트/다크 모드로 각각 확인한다.
+
+1. 저장 아이콘의 선과 면이 메뉴 배경에서 선명하게 보인다.
+2. modal bottom sheet의 입력 문자와 cursor가 보인다.
+3. 달성 여부를 끈 상태에서도 thumb와 track 경계가 보인다.
+4. 완료 task cell이 6칸 wrapper와 구분되고 완료 check도 유지된다.
+5. 라이트 모드에서 기존 의미와 조작 상태가 유지된다.
+6. 설정 화면의 제목·섹션·테마 항목·버전 정보가 기존 화면과 같은 Pretendard로 표시된다.
+
+## 5. 완료 조건
+
+- 다섯 요소가 Material color scheme의 의미색 또는 기존 제품 font family를 사용한다.
+- 새 hard-coded color를 추가하지 않는다.
+- Android/iOS common UI 컴파일과 기존 Home 테스트가 통과한다.
+- Internal Testing에서 다섯 시각 회귀 항목을 확인할 수 있도록 앱 버전을 2.2.9(20209)로 준비한다.
+
+## 6. 비범위
+
+- 디자인 시스템 팔레트 전면 조정
+- 사용자 지정 chart 색상 변경
+- 신규 screenshot test 도구 도입
+- Home 이외 화면의 디자인 변경
+- production 또는 iOS 배포
+
+## 7. 구현 후 자동 검증 결과
+
+- Home Android host test: 통과
+- Home detekt: 통과
+- Android 앱 debug Kotlin compile: 통과
+- iOS Simulator Arm64 KMP compile: 통과
+- 변경된 Kotlin 파일의 Spotless 포맷: 통과
+
+모듈 전체 `spotlessKotlinCheck`는 기준 브랜치부터 존재하는 `CellText.kt` 포맷 위반 한 건 때문에 실패한다. 이번 변경 파일에서는 위반이 검출되지 않으며, PR CI에서는 `origin/main` ratchet 기준으로 변경분을 다시 확인한다.

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartBottomSheet.kt
@@ -379,7 +379,7 @@ fun BandalartBottomSheet(
                                 },
                                 colors =
                                     SwitchDefaults.colors(
-                                        uncheckedThumbColor = MaterialTheme.colorScheme.surface,
+                                        uncheckedThumbColor = MaterialTheme.colorScheme.onSurfaceVariant,
                                         uncheckedTrackColor = MaterialTheme.colorScheme.surfaceVariant,
                                         uncheckedBorderColor = MaterialTheme.colorScheme.outline,
                                         checkedThumbColor = MaterialTheme.colorScheme.onPrimary,

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartChart.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartChart.kt
@@ -74,7 +74,7 @@ fun BandalartChart(
                             Modifier
                                 .layoutId(stringResource(Res.string.home_layout_id, index + 1))
                                 .clip(RoundedCornerShape(12.dp))
-                                .background(color = MaterialTheme.colorScheme.outline),
+                                .background(color = MaterialTheme.colorScheme.outlineVariant),
                     ) {
                         BandalartCellGrid(
                             bandalartData = bandalartData,

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartDropDownMenu.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartDropDownMenu.kt
@@ -88,7 +88,7 @@ fun BandalartDropDownMenu(
                             Modifier
                                 .size(24.dp)
                                 .align(CenterVertically),
-                        tint = Color.Unspecified,
+                        tint = MaterialTheme.colorScheme.onSurface,
                     )
                     Text(
                         text = stringResource(Res.string.dropdown_save),

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartTextField.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartTextField.kt
@@ -21,9 +21,11 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
@@ -44,14 +46,16 @@ internal fun BandalartTextField(
     BasicTextField(
         value = value,
         onValueChange = onValueChange,
-        modifier = modifier
-            .fillMaxWidth()
-            .height(24.dp)
-            .clearFocusOnKeyboardDismiss(),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(24.dp)
+                .clearFocusOnKeyboardDismiss(),
         keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
         keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
         maxLines = 1,
-        textStyle = BottomSheetContent(),
+        textStyle = BottomSheetContent().copy(color = MaterialTheme.colorScheme.onSurface),
+        cursorBrush = SolidColor(MaterialTheme.colorScheme.onSurface),
         decorationBox = { innerTextField ->
             if (value.text.isEmpty()) {
                 BottomSheetContentPlaceholder(text = placeholder)

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/settings/SettingsBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/settings/SettingsBottomSheet.kt
@@ -56,6 +56,7 @@ import bandalart.core.designsystem.generated.resources.settings_theme_system
 import bandalart.core.designsystem.generated.resources.settings_title
 import bandalart.core.designsystem.generated.resources.settings_version
 import bandalart.core.designsystem.generated.resources.settings_version_value
+import com.nexters.bandalart.core.designsystem.theme.pretendardFontFamily
 import com.nexters.bandalart.core.domain.entity.ThemeMode
 import com.nexters.bandalart.feature.home.HomeScreen
 import org.jetbrains.compose.resources.stringResource
@@ -115,6 +116,7 @@ internal fun SettingsBottomSheet(
                     text = stringResource(Res.string.settings_version),
                     color = MaterialTheme.colorScheme.onSurface,
                     fontSize = 15.sp,
+                    fontFamily = pretendardFontFamily(),
                     fontWeight = FontWeight.W600,
                 )
                 Spacer(modifier = Modifier.weight(1f))
@@ -122,6 +124,7 @@ internal fun SettingsBottomSheet(
                     text = stringResource(Res.string.settings_version_value, appVersion),
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     fontSize = 15.sp,
+                    fontFamily = pretendardFontFamily(),
                 )
             }
         }
@@ -142,6 +145,7 @@ private fun SettingsHeader(onCloseClick: () -> Unit) {
             text = stringResource(Res.string.settings_title),
             color = MaterialTheme.colorScheme.onSurface,
             fontSize = 20.sp,
+            fontFamily = pretendardFontFamily(),
             fontWeight = FontWeight.W700,
         )
         Spacer(modifier = Modifier.weight(1f))
@@ -161,6 +165,7 @@ private fun SettingsSectionTitle(text: String) {
         text = text,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         fontSize = 13.sp,
+        fontFamily = pretendardFontFamily(),
         fontWeight = FontWeight.W600,
         modifier = Modifier.padding(start = 24.dp, top = 12.dp, bottom = 10.dp),
     )
@@ -194,6 +199,7 @@ private fun ThemeModeRow(
             text = label,
             color = MaterialTheme.colorScheme.onSurface,
             fontSize = 16.sp,
+            fontFamily = pretendardFontFamily(),
             fontWeight = if (selected) FontWeight.W600 else FontWeight.W400,
         )
         Spacer(modifier = Modifier.weight(1f))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ targetSdk = "36"
 compileSdk = "37"
 majorVersion = "2"
 minorVersion = "2"
-patchVersion = "8"
+patchVersion = "9"
 packageName = "com.nexters.bandalart"
 
 # Gradle Plugin


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- 후속 작업: #203

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 다크 모드에서 저장 아이콘, 입력 텍스트·커서와 미선택 토글의 대비를 개선했습니다.
- 완료 task cell과 task 영역 wrapper의 배경색을 분리했습니다.
- 설정 modal bottom sheet의 모든 텍스트를 Pretendard로 통일했습니다.
- Internal Testing 재검증을 위해 앱 버전을 2.2.9(20209)로 올렸습니다.

## 🧪 테스트 내역 (선택)

- [x] Home Android host test 통과
- [x] Home detekt 통과
- [x] Android 앱 debug Kotlin compile 통과
- [x] iOS Simulator Arm64 KMP compile 통과
- [ ] 2.2.9 Internal Testing 실기기 시각 확인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

Internal Testing 설치 후 라이트·다크 모드를 비교할 예정입니다.

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- Compose screenshot test 기반이 없어 색상 대비와 Pretendard 적용의 최종 판정은 Internal Testing에서 진행합니다.
- 사용자 선택 chart 색상과 공유 이미지 배경은 변경하지 않았습니다.

## 💡 코드리뷰 Tip

Gemini Code Assist 리뷰 코멘트가 달리면 `resolve-gemini-review`를 실행하여 미해결 코멘트를 반영하거나 거절 사유를 남길 수 있습니다.
