### PR TITLE
fix: foreground 복귀 시 강제 업데이트 검사

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -69,11 +69,13 @@ play {
 
 dependencies {
     implementation(projects.composeApp)
+    implementation(projects.core.common)
     implementation(projects.core.designsystem)
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.splash)
     implementation(libs.androidx.profileinstaller)
+    implementation(libs.app.update)
 
     implementation(libs.firebase.common)
 

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/MainActivity.kt
@@ -16,16 +16,44 @@
 
 package com.nexters.bandalart
 
+import android.app.Activity
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.Lifecycle
+import com.google.android.play.core.appupdate.AppUpdateInfo
+import com.google.android.play.core.appupdate.AppUpdateManager
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import com.google.android.play.core.appupdate.AppUpdateOptions
+import com.google.android.play.core.install.model.AppUpdateType
+import com.google.android.play.core.install.model.UpdateAvailability
+import com.nexters.bandalart.core.common.utils.isImmediateUpdate
+import io.github.aakira.napier.Napier
 
 class MainActivity : ComponentActivity() {
+    private lateinit var appUpdateManager: AppUpdateManager
+    private lateinit var updateResultLauncher: ActivityResultLauncher<IntentSenderRequest>
+    private var skipNextResumeForSplash = false
+    private var isUpdateCheckInProgress = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
+        appUpdateManager = AppUpdateManagerFactory.create(this)
+        skipNextResumeForSplash = savedInstanceState == null
+        updateResultLauncher =
+            registerForActivityResult(
+                ActivityResultContracts.StartIntentSenderForResult(),
+            ) { result ->
+                if (result.resultCode == Activity.RESULT_CANCELED) {
+                    finish()
+                }
+            }
         enableEdgeToEdge()
         setContent {
             BandalartApp(
@@ -33,4 +61,75 @@ class MainActivity : ComponentActivity() {
             )
         }
     }
+
+    override fun onResume() {
+        super.onResume()
+        if (skipNextResumeForSplash) {
+            skipNextResumeForSplash = false
+            return
+        }
+        checkForImmediateUpdate()
+    }
+
+    private fun checkForImmediateUpdate() {
+        if (isUpdateCheckInProgress) return
+        isUpdateCheckInProgress = true
+
+        appUpdateManager.appUpdateInfo
+            .addOnSuccessListener { appUpdateInfo ->
+                isUpdateCheckInProgress = false
+                if (!lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+                    return@addOnSuccessListener
+                }
+                when {
+                    appUpdateInfo.updateAvailability() ==
+                        UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS -> {
+                        startImmediateUpdate(appUpdateInfo)
+                    }
+
+                    appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
+                        appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE) &&
+                        isImmediateUpdate(
+                            currentVersionCode = currentVersionCode(),
+                            availableVersionCode = appUpdateInfo.availableVersionCode(),
+                        ) -> {
+                        startImmediateUpdate(appUpdateInfo)
+                    }
+                }
+            }.addOnFailureListener { exception ->
+                isUpdateCheckInProgress = false
+                Napier.e(
+                    "Failed to check immediate update on foreground",
+                    exception,
+                    tag = "InAppUpdate",
+                )
+            }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun startImmediateUpdate(appUpdateInfo: AppUpdateInfo) {
+        try {
+            val started =
+                appUpdateManager.startUpdateFlowForResult(
+                    appUpdateInfo,
+                    updateResultLauncher,
+                    AppUpdateOptions.newBuilder(AppUpdateType.IMMEDIATE).build(),
+                )
+            if (!started) {
+                Napier.w("Immediate update flow was not started", tag = "InAppUpdate")
+            }
+        } catch (exception: Exception) {
+            Napier.e(
+                "Failed to start immediate update on foreground",
+                exception,
+                tag = "InAppUpdate",
+            )
+        }
+    }
+
+    private fun currentVersionCode(): Int =
+        packageManager
+            .getPackageInfo(packageName, 0)
+            .longVersionCode
+            .toInt()
 }

--- a/core/common/src/androidHostTest/kotlin/com/nexters/bandalart/core/common/utils/InAppUpdatePolicyTest.kt
+++ b/core/common/src/androidHostTest/kotlin/com/nexters/bandalart/core/common/utils/InAppUpdatePolicyTest.kt
@@ -14,25 +14,25 @@
  * limitations under the License.
  */
 
-package com.nexters.bandalart.feature.home
+package com.nexters.bandalart.core.common.utils
 
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
-class FlexibleUpdatePolicyTest {
+class InAppUpdatePolicyTest {
     @Test
     fun patchUpdateUsesFlexibleFlow() {
         assertFalse(
             isImmediateUpdate(
                 currentVersionCode = 20206,
-                availableVersionCode = 20207,
+                availableVersionCode = 20299,
             ),
         )
     }
 
     @Test
-    fun minorAndMajorUpdatesRemainImmediate() {
+    fun minorAndMajorUpdatesUseImmediateFlow() {
         assertTrue(
             isImmediateUpdate(
                 currentVersionCode = 20206,
@@ -43,6 +43,22 @@ class FlexibleUpdatePolicyTest {
             isImmediateUpdate(
                 currentVersionCode = 20206,
                 availableVersionCode = 30000,
+            ),
+        )
+    }
+
+    @Test
+    fun sameOrOlderVersionDoesNotStartImmediateFlow() {
+        assertFalse(
+            isImmediateUpdate(
+                currentVersionCode = 20206,
+                availableVersionCode = 20206,
+            ),
+        )
+        assertFalse(
+            isImmediateUpdate(
+                currentVersionCode = 20206,
+                availableVersionCode = 20199,
             ),
         )
     }

--- a/core/common/src/commonMain/kotlin/com/nexters/bandalart/core/common/utils/InAppUpdate.kt
+++ b/core/common/src/commonMain/kotlin/com/nexters/bandalart/core/common/utils/InAppUpdate.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 easyhooon
+ * Copyright 2026 easyhooon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@
 
 package com.nexters.bandalart.core.common.utils
 
-// fun isValidImmediateAppUpdate(updateVersion: Int): Boolean {
-//     val updateMajor = updateVersion / 10000
-//     val updateMinor = (updateVersion % 10000) / 100
-//
-//     val currentMajor = BuildConfig.VERSION_CODE / 10000
-//     val currentMinor = (BuildConfig.VERSION_CODE % 10000) / 100
-//
-//     return updateMajor > currentMajor || updateMinor > currentMinor
-// }
+fun isImmediateUpdate(
+    currentVersionCode: Int,
+    availableVersionCode: Int,
+): Boolean {
+    val availableMajor = availableVersionCode / 10_000
+    val availableMinor = (availableVersionCode % 10_000) / 100
+    val currentMajor = currentVersionCode / 10_000
+    val currentMinor = (currentVersionCode % 10_000) / 100
+
+    return availableMajor > currentMajor || availableMinor > currentMinor
+}

--- a/docs/IN_APP_UPDATE_FOREGROUND_STRATEGY.md
+++ b/docs/IN_APP_UPDATE_FOREGROUND_STRATEGY.md
@@ -1,0 +1,165 @@
+# In-App Update foreground 보강 전략
+
+- 관련 이슈: #186
+- 기준 브랜치: `main`
+- 대상 플랫폼: Android
+
+## 문제
+
+현재 업데이트 책임은 화면별로 나뉘어 있다.
+
+- `Splash`: cold start에서 minor/major 변경을 Immediate Update로 검사한다.
+- `Home`: `RESUMED`마다 patch 변경을 Flexible Update로 검사하고 다운로드 완료 Snackbar를 처리한다.
+
+앱 프로세스가 살아 있는 상태에서 사용자가 다른 앱으로 이동했다가 돌아왔을 때 새 minor/major 업데이트가 배포되면, `Splash`는 이미 back stack에서 제거돼 Immediate Update를 다시 검사하지 않는다. `Home`의 검사는 해당 버전을 의도적으로 Flexible 대상에서 제외하므로 아무 flow도 시작하지 않는다.
+
+## 성공 기준
+
+- 새 프로세스의 cold start에서는 기존 Splash Immediate Update UX를 유지한다.
+- 프로세스가 살아 있는 앱이 foreground로 복귀할 때 화면 위치와 관계없이 Immediate Update를 검사한다.
+- 진행 중인 Immediate Update가 있으면 공식 가이드대로 복귀 시 재개한다.
+- patch Flexible Update의 안내 bottom sheet, 다운로드, 설치 Snackbar 동작은 변경하지 않는다.
+- 동일 resume에서 update flow를 중복 실행하지 않는다.
+
+## 결정
+
+전체 Flexible UI까지 앱 root로 옮기지 않고, Android `MainActivity`가 **foreground Immediate Update coordinator** 역할만 맡는다.
+
+이유:
+
+- foreground/background lifecycle은 화면보다 Activity가 안정적으로 소유한다.
+- Onboarding, Home, Complete 중 어떤 화면에 있어도 검사할 수 있다.
+- 이미 Internal Testing으로 검증한 Home Flexible Update UI와 거절 이력 저장 경로를 변경하지 않는다.
+- Splash의 최초 차단 UX를 유지하면서 관측된 누락만 작게 보강한다.
+
+## 상태 우선순위
+
+`MainActivity.onResume()`에서 최초 fresh launch를 제외하고 새 `AppUpdateInfo`를 조회한 뒤 다음 순서를 적용한다.
+
+1. `DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS`
+   - Immediate Update flow를 재개한다.
+2. `UPDATE_AVAILABLE`
+   - 현재/신규 versionCode의 major 또는 minor가 달라지고 Immediate가 허용되면 flow를 시작한다.
+3. 그 외
+   - 아무 작업도 하지 않는다. patch Flexible Update는 Home의 기존 effect가 담당한다.
+
+fresh launch의 첫 `onResume`은 Splash가 이미 최초 검사를 담당하므로 Activity 검사를 생략한다. saved instance state가 있는 복원 진입은 Splash가 현재 화면이라는 보장이 없으므로 첫 resume부터 검사한다.
+
+## PR용 전체 시퀀스
+
+```mermaid
+sequenceDiagram
+    actor User as 사용자
+    participant Activity as MainActivity
+    participant Splash as Splash Immediate Effect
+    participant Home as Home Flexible Effect
+    participant Play as Play AppUpdateManager
+
+    User->>Activity: 앱 실행
+    Activity->>Activity: fresh launch의 첫 onResume 검사 생략
+    Activity->>Splash: Circuit Splash 표시
+    Splash->>Play: 최신 AppUpdateInfo 조회
+    Play-->>Splash: availability, versionCode, allowed type
+
+    alt minor/major 업데이트이며 Immediate 허용
+        Splash->>Play: Immediate Update 시작
+        alt 사용자가 취소
+            Play-->>Splash: RESULT_CANCELED
+            Splash->>Activity: finish()
+        else 업데이트 완료
+            Play-->>Activity: 설치 후 앱 재시작
+        end
+    else 강제 업데이트 대상 아님
+        Splash->>Home: 온보딩 상태 확인 후 화면 이동
+        Home->>Play: Home RESUMED 시 AppUpdateInfo 조회
+        alt patch 업데이트이며 Flexible 허용
+            Play-->>Home: 선택 업데이트 가능
+            Home-->>User: 업데이트 안내 bottom sheet
+            alt 사용자가 업데이트 진행 선택
+                User->>Home: 업데이트
+                Home->>Play: Flexible Update 시작
+                Play-->>Home: InstallStatus.DOWNLOADED
+                Home-->>User: 재시작 Snackbar
+                User->>Home: 재시작
+                Home->>Play: completeUpdate()
+                Play-->>Activity: 설치 후 앱 재시작
+            else 나중에 선택 또는 취소
+                Home->>Home: 거절한 versionCode 저장
+            end
+        else 업데이트 없음 또는 Immediate 대상
+            Home->>Home: Flexible flow를 시작하지 않음
+        end
+    end
+
+    User->>Activity: 앱을 background로 보낸 뒤 foreground 복귀
+    Activity->>Play: 새로운 AppUpdateInfo 조회
+    Play-->>Activity: 현재 업데이트 상태
+
+    alt Immediate Update 진행 중
+        Activity->>Play: Immediate Update flow 재개
+    else 새 minor/major 업데이트이며 Immediate 허용
+        Activity->>Play: Immediate Update 시작
+        alt 사용자가 취소
+            Play-->>Activity: RESULT_CANCELED
+            Activity->>Activity: finish()
+        else 업데이트 완료
+            Play-->>Activity: 설치 후 앱 재시작
+        end
+    else patch 업데이트 또는 업데이트 없음
+        Activity->>Activity: Immediate coordinator는 no-op
+        opt Home이 현재 화면
+            Home->>Play: 기존 Flexible Update 검사
+            Play-->>Home: patch면 선택 업데이트 안내
+        end
+    end
+```
+
+핵심은 cold start의 차단 책임은 Splash, 실행 중 foreground 복귀의 강제 업데이트 책임은 Activity, patch 선택 업데이트와 설치 완료 UI는 Home이 갖는 것이다.
+
+## 중복·실패 정책
+
+- update 정보 조회 중에는 추가 조회를 막는다.
+- update flow 시작 전마다 새 `AppUpdateInfo`를 사용한다.
+- Immediate 동의 화면을 사용자가 취소하면 기존 정책과 동일하게 Activity를 종료한다.
+- 조회 또는 flow 시작 실패는 기록하고 다음 foreground 복귀에서 재시도한다.
+- Remote Config kill switch, Play update priority/staleness 정책은 이번 범위에 추가하지 않는다.
+
+## 코드 변경
+
+- `MainActivity`
+  - `AppUpdateManager`와 Activity Result launcher 소유
+  - fresh launch 구분 및 foreground resume 검사
+  - 진행 중/new Immediate Update 시작
+- `core/common/utils/InAppUpdate.kt`
+  - Splash/Home/Activity가 공유하는 versionCode 기반 Immediate 정책으로 정리
+- `ImmediateUpdateEffect.android.kt`
+  - cold start 최초 검사만 유지
+  - 진행 중 update 재개 책임은 Activity로 이동
+- Gradle
+  - `androidApp`에 `core:common`, Play app-update 의존성 명시
+- 테스트
+  - 공통 versionCode 정책의 patch/minor/major/same/downgrade 경계값 검증
+
+## 검증
+
+### 자동
+
+- 공통 업데이트 정책 단위 테스트
+- 기존 Home Presenter rejection 테스트
+- 기존 Splash Presenter 중복 navigation 테스트
+- Android 컴파일과 CI는 commit/push 단계에서 실행
+
+### Internal Testing
+
+1. patch 버전: 기존 선택 업데이트 bottom sheet와 설치 Snackbar 유지
+2. minor 버전: cold start에서 Immediate Update 표시
+3. minor 버전 배포 전 앱 실행 → background → 배포 전파 후 foreground: Immediate Update 표시
+4. Immediate Update 진행 중 background/foreground: flow 재개
+5. Immediate Update 취소: 앱 종료
+6. Home 외 Onboarding/Complete 화면에서 foreground 복귀: Immediate Update 표시
+
+## 공식 참고
+
+- https://developer.android.com/guide/playcore/in-app-updates/kotlin-java
+- `AppUpdateInfo`는 update flow 시작마다 새 인스턴스를 조회해야 한다.
+- Immediate Update가 진행 중이면 앱이 foreground로 돌아올 때 flow를 재개해야 한다.

--- a/feature/home/src/androidMain/kotlin/com/nexters/bandalart/feature/home/FlexibleUpdateEffect.android.kt
+++ b/feature/home/src/androidMain/kotlin/com/nexters/bandalart/feature/home/FlexibleUpdateEffect.android.kt
@@ -47,6 +47,7 @@ import com.google.android.play.core.install.InstallStateUpdatedListener
 import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
+import com.nexters.bandalart.core.common.utils.isImmediateUpdate
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -175,18 +176,6 @@ private fun isImmediateUpdate(
         currentVersionCode = currentVersionCode,
         availableVersionCode = availableVersionCode,
     )
-}
-
-internal fun isImmediateUpdate(
-    currentVersionCode: Int,
-    availableVersionCode: Int,
-): Boolean {
-    val availableMajor = availableVersionCode / 10_000
-    val availableMinor = (availableVersionCode % 10_000) / 100
-    val currentMajor = currentVersionCode / 10_000
-    val currentMinor = (currentVersionCode % 10_000) / 100
-
-    return availableMajor > currentMajor || availableMinor > currentMinor
 }
 
 @Suppress("TooGenericExceptionCaught")

--- a/feature/splash/src/androidMain/kotlin/com/nexters/bandalart/feature/splash/ImmediateUpdateEffect.android.kt
+++ b/feature/splash/src/androidMain/kotlin/com/nexters/bandalart/feature/splash/ImmediateUpdateEffect.android.kt
@@ -29,9 +29,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.android.gms.tasks.Task
 import com.google.android.play.core.appupdate.AppUpdateInfo
 import com.google.android.play.core.appupdate.AppUpdateManager
@@ -39,6 +36,7 @@ import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.appupdate.AppUpdateOptions
 import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.UpdateAvailability
+import com.nexters.bandalart.core.common.utils.isImmediateUpdate
 import io.github.aakira.napier.Napier
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -50,8 +48,6 @@ internal actual fun ImmediateUpdateEffect(onComplete: () -> Unit) {
     val context = LocalContext.current
     val activity = LocalActivity.current
     val appUpdateManager = remember(context) { AppUpdateManagerFactory.create(context) }
-    val lifecycle = LocalLifecycleOwner.current.lifecycle
-    val lifecycleState by lifecycle.currentStateFlow.collectAsStateWithLifecycle()
     val currentOnComplete by rememberUpdatedState(onComplete)
 
     val updateResultLauncher =
@@ -81,19 +77,6 @@ internal actual fun ImmediateUpdateEffect(onComplete: () -> Unit) {
             currentOnComplete()
         }
     }
-
-    LaunchedEffect(lifecycleState, appUpdateManager) {
-        if (lifecycleState == Lifecycle.State.RESUMED) {
-            try {
-                val appUpdateInfo = appUpdateManager.appUpdateInfo.await()
-                if (appUpdateInfo.updateAvailability() == UpdateAvailability.DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS) {
-                    appUpdateManager.startImmediateUpdate(appUpdateInfo, updateResultLauncher)
-                }
-            } catch (exception: Exception) {
-                Napier.e("Failed to resume immediate update", exception, tag = "InAppUpdate")
-            }
-        }
-    }
 }
 
 private fun isValidImmediateUpdate(
@@ -105,12 +88,10 @@ private fun isValidImmediateUpdate(
             .getPackageInfo(context.packageName, 0)
             .longVersionCode
             .toInt()
-    val availableMajor = availableVersionCode / 10_000
-    val availableMinor = (availableVersionCode % 10_000) / 100
-    val currentMajor = currentVersionCode / 10_000
-    val currentMinor = (currentVersionCode % 10_000) / 100
-
-    return availableMajor > currentMajor || availableMinor > currentMinor
+    return isImmediateUpdate(
+        currentVersionCode = currentVersionCode,
+        availableVersionCode = availableVersionCode,
+    )
 }
 
 private fun AppUpdateManager.startImmediateUpdate(


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #186

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- `MainActivity.onResume()`에서 fresh launch 이후 foreground 복귀마다 새로운 `AppUpdateInfo`를 조회합니다.
- 진행 중인 Immediate Update는 재개하고, 새 minor/major 버전은 현재 화면과 관계없이 Immediate Update로 시작합니다.
- cold start 검사는 기존 Splash가 유지하고, patch Flexible Update와 설치 완료 Snackbar는 기존 Home flow가 유지합니다.
- Splash/Home/Activity가 같은 versionCode 정책을 사용하도록 `core:common`으로 통합하고 patch/minor/major/same/downgrade 경계값 테스트를 추가했습니다.
- 전체 결정과 Internal Testing 항목을 `IN_APP_UPDATE_FOREGROUND_STRATEGY.md`에 기록했습니다.

### 업데이트 시퀀스

```mermaid
sequenceDiagram
    actor User as 사용자
    participant Activity as MainActivity
    participant Splash as Splash Immediate Effect
    participant Home as Home Flexible Effect
    participant Play as Play AppUpdateManager

    User->>Activity: 앱 실행
    Activity->>Activity: fresh launch의 첫 onResume 검사 생략
    Activity->>Splash: Circuit Splash 표시
    Splash->>Play: 최신 AppUpdateInfo 조회
    Play-->>Splash: availability, versionCode, allowed type

    alt minor/major 업데이트이며 Immediate 허용
        Splash->>Play: Immediate Update 시작
        alt 사용자가 취소
            Play-->>Splash: RESULT_CANCELED
            Splash->>Activity: finish()
        else 업데이트 완료
            Play-->>Activity: 설치 후 앱 재시작
        end
    else 강제 업데이트 대상 아님
        Splash->>Home: 온보딩 상태 확인 후 화면 이동
        Home->>Play: Home RESUMED 시 AppUpdateInfo 조회
        alt patch 업데이트이며 Flexible 허용
            Play-->>Home: 선택 업데이트 가능
            Home-->>User: 업데이트 안내 bottom sheet
            alt 사용자가 업데이트 진행 선택
                User->>Home: 업데이트
                Home->>Play: Flexible Update 시작
                Play-->>Home: InstallStatus.DOWNLOADED
                Home-->>User: 재시작 Snackbar
                User->>Home: 재시작
                Home->>Play: completeUpdate()
                Play-->>Activity: 설치 후 앱 재시작
            else 나중에 선택 또는 취소
                Home->>Home: 거절한 versionCode 저장
            end
        else 업데이트 없음 또는 Immediate 대상
            Home->>Home: Flexible flow를 시작하지 않음
        end
    end

    User->>Activity: background 이후 foreground 복귀
    Activity->>Play: 새로운 AppUpdateInfo 조회
    Play-->>Activity: 현재 업데이트 상태

    alt Immediate Update 진행 중
        Activity->>Play: Immediate Update flow 재개
    else 새 minor/major 업데이트이며 Immediate 허용
        Activity->>Play: Immediate Update 시작
        alt 사용자가 취소
            Play-->>Activity: RESULT_CANCELED
            Activity->>Activity: finish()
        else 업데이트 완료
            Play-->>Activity: 설치 후 앱 재시작
        end
    else patch 업데이트 또는 업데이트 없음
        Activity->>Activity: Immediate coordinator는 no-op
        opt Home이 현재 화면
            Home->>Play: 기존 Flexible Update 검사
            Play-->>Home: patch면 선택 업데이트 안내
        end
    end
```

## 🧪 테스트 내역 (선택)

- [x] `git diff --check`
- [ ] Gradle 단위 테스트 및 Android 컴파일 — 프로젝트 지침에 따라 로컬에서 실행하지 않음
- [ ] Play Internal Testing에서 foreground Immediate Update 확인
- [ ] patch Flexible Update 및 cold start Immediate Update 회귀 확인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

- UI 변경 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- fresh process의 첫 `onResume`은 Splash와 중복 검사하지 않고, saved state 복원 및 이후 foreground 복귀부터 Activity가 검사합니다.
- Immediate Update 취소 시 기존 강제 업데이트 정책과 동일하게 Activity를 종료합니다.
- #186은 실제 Play Internal Testing 검증이 남아 있어 이 PR에서 자동으로 close하지 않습니다.

## 💡 코드리뷰 Tip

Gemini Code Assist 리뷰 코멘트가 달리면 `resolve-gemini-review`를 실행하여 미해결 코멘트를 반영하거나 거절 사유를 남길 수 있습니다.
