### PR TITLE
docs: KMP 테스트 구조와 백로그 순서 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,10 @@
 - Gemini Code Assist 리뷰 반영 요청은 `plugins/bandalart/skills/resolve-gemini-review/SKILL.md`를 따른다.
 - 새 작업 시작이나 이슈·worktree 생성 요청은 `plugins/bandalart/skills/start-workflow/SKILL.md`를 따른다.
 
+## 테스트
+
+- KMP 테스트 source set 선택, Circuit Presenter 테스트, 로컬·CI 실행 범위는 `docs/KMP_TESTING_GUIDE.md`를 따른다.
+
 ## MCP 설정
 
 - Codex MCP 설정은 `~/.codex/config.toml`의 `mcp_servers`에서 관리한다.

--- a/docs/BACKLOG_EXECUTION_STRATEGY.md
+++ b/docs/BACKLOG_EXECUTION_STRATEGY.md
@@ -1,0 +1,81 @@
+# BandalArt 백로그 실행 우선순위
+
+- 갱신일: 2026-08-06
+- 기준 브랜치: `origin/main`
+- 대상: KMP/Circuit/Metro 기반 앱의 안정화와 신규 기능 백로그
+
+## 현재 기준점
+
+- 계층별 KMP, Circuit, Metro 통합 작업인 #180, #181, #182는 코드 기준 완료되어 닫았다.
+- 포그라운드 복귀 시 강제 업데이트를 다시 검사하는 #186 구현은 PR #215로 `main`에 병합했다.
+- iOS 실제 기기·배포 검증은 계정이 복구될 때 수행할 후속 이슈 #214로 분리했다.
+- 따라서 다음 작업은 남은 마이그레이션이 아니라 테스트·상태 정책을 고정한 뒤 작은 기능부터 확장하는 순서다.
+
+## 실행 원칙
+
+- 최신 `origin/main`에서 이슈별 브랜치를 만들고, 구조 변경은 구현 전에 `docs/` 전략 문서를 작성한다.
+- 한 PR은 독립적으로 머지·되돌릴 수 있는 한 가지 책임만 가진다.
+- 자동 테스트와 CI가 통과한 뒤 다음 단계로 이동한다.
+- 앱 버전 증가는 실제 Internal Testing checkpoint에서만 한다.
+- 외부 SDK, Room schema, 권한, 플랫폼 lifecycle 변경은 작은 UI 기능과 섞지 않는다.
+
+## 실행 순서
+
+### 1. #209 KMP 테스트와 Circuit/Molecule 문서화 — XS
+
+현재 test source set, dependency, Gradle task와 CI 범위를 문서로 고정한다. 이후 모든 PR의 검증 기준으로 사용한다.
+
+### 2. #210 Circuit 상태 보존 정책과 날짜 피커 복원 — S
+
+`remember`, `rememberRetained`, `rememberSaveable`의 책임을 감사하고, 날짜 피커의 미확정 draft가 구성 변경에서 사라지는 문제를 수정한다. 신규 기능이 사용할 one-shot effect 기준도 함께 확인한다.
+
+### 3. #207 설정 화면 이메일 문의 — S
+
+설정 화면에서 `mraz3068@gmail.com`으로 문의 메일 작성기를 여는 Android/iOS launcher를 추가한다. 메일 앱 부재 fallback과 URI encoding을 포함한다.
+
+### 4. #213 햅틱 기반 태스크 셀 빠른 완료 — S~M
+
+task cell long click으로 바텀시트를 열지 않고 완료 처리하며, 성공 시 KMP 햅틱을 한 번 실행한다. 일반 탭 동작은 유지한다.
+
+### 5. #212 Fluent UI Emoji 선택기 — M~L
+
+전체 에셋을 바로 포함하지 않고 스타일·용량 spike, pinned manifest와 resource pipeline, picker UI 순으로 나눈다. 템플릿 기능의 공통 아이콘 catalog 선행 작업이다.
+
+### 6. #211 마감일 기반 로컬 알림 — L
+
+공통 scheduler 계약 뒤 Android와 iOS 로컬 알림을 플랫폼별로 구현한다. 생성·수정·완료·삭제, 권한, 시간대, 재부팅에 대한 idempotent reschedule을 검증한다.
+
+### 7. #206 AdMob Rewarded Ad 기반 추가 생성 — L
+
+모든 사용자 추가 생성을 사전 안내와 reward 완료 뒤 허용한다. 광고 실패가 기존 표 사용을 막지 않도록 creation credit과 정확히 한 번 생성 경계를 먼저 설계한다.
+
+### 8. #208 목표 템플릿 기반 빠른 생성 — L
+
+#212 아이콘 catalog와 #206 생성 gate 뒤에 통합한다. 템플릿 콘텐츠·도메인 검증은 미리 준비할 수 있지만 UI 출하는 두 선행 작업 후 진행한다.
+
+### 9. #156 Android/iOS 위젯 — XL
+
+앱 본체의 데이터·완료·알림 흐름이 안정된 뒤 Android Glance MVP, iOS App Group spike, WidgetKit 순으로 진행한다.
+
+## 별도 운영 트랙
+
+- #214: iOS 개발자 계정 복구 후 실제 기기, 저장소, 설정, navigation, 배포 검증
+- #113: legacy Fastlane credential 폐기·회전과 Android Internal CD 보안 정리
+- #206 외부 준비: AdMob app/rewarded unit, UMP, app-ads.txt, Play Console 광고·Data safety 선언
+
+이 운영 작업은 준비되는 즉시 병행할 수 있지만, 미완료 상태가 앞선 Android 기능 개발을 막지는 않는다.
+
+## Internal Testing checkpoint
+
+버전 증가와 Internal Testing은 아래처럼 실제 기기 검증 가치가 있는 묶음에서만 수행한다.
+
+1. #210 + #207: 상태 복원과 platform mail launcher
+2. #213: long click과 햅틱
+3. #212: 이모지 에셋 용량·성능·다크 모드
+4. #211: 알림 권한·예약·재예약
+5. #206: test/production ad unit end-to-end
+6. #208: 템플릿 + 광고 생성 end-to-end
+
+## 바로 이어갈 작업
+
+#209 문서화 PR을 먼저 마무리하고, 최신 `main`에서 #210 상태 보존 감사와 날짜 피커 복원을 시작한다.

--- a/docs/KMP_TESTING_GUIDE.md
+++ b/docs/KMP_TESTING_GUIDE.md
@@ -1,0 +1,146 @@
+# KMP 테스트 소스셋과 Circuit Presenter 테스트 가이드
+
+- 작성 기준: 2026-08-06, `docs/kmp-testing-guide`
+- 관련 이슈: [#209](https://github.com/Nexters/BandalArt-KMP/issues/209)
+- 대상 구성: AGP 9 Android-KMP plugin, Kotlin Multiplatform, Circuit 0.35.1, JUnit 5
+
+## 결론
+
+- `androidHostTest`는 프로젝트가 임의로 붙인 이름이 아니라 `com.android.kotlin.multiplatform.library`가 제공하는 공식 Android 호스트 테스트 source set이다.
+- 현재 테스트는 모두 `androidHostTest`에 있고, `commonTest`, `androidDeviceTest`, iOS test source set은 아직 없다.
+- 현재 JUnit 5, MockK, Robolectric 기반 테스트를 억지로 `commonTest`로 옮기지 않는다. 공통 테스트의 플랫폼 중복 실행 가치가 생길 때 `kotlin.test`와 multiplatform test dependency로 별도 전환한다.
+- Circuit Presenter 테스트는 `Presenter.test()`가 Molecule과 Turbine을 내부에서 조합한다. 프로젝트 코드가 Molecule API를 직접 import하지 않으므로 `molecule-runtime`을 직접 선언할 필요가 없다.
+- CI의 `allTests`는 현재 존재하는 10개 KMP 모듈의 `testAndroidHostTest`를 모두 실행한다. `androidApp`의 JVM 단위 테스트는 별도 `:androidApp:testDebugUnitTest`로 실행한다.
+
+## Source set 선택 기준
+
+| Source set | 실행 위치 | 사용할 때 | 현재 예 |
+| --- | --- | --- | --- |
+| `commonTest` | 구성된 각 KMP target | 플랫폼 API 없이 동일 계약을 Android와 iOS 등에서 검증할 가치가 있을 때 | 없음 |
+| `androidHostTest` | 로컬 JVM | JUnit 5, MockK, Robolectric, Android API 또는 Android target 실제 구현을 사용할 때 | Repository, Room, DataStore, Presenter, Metro graph |
+| `androidDeviceTest` | Android emulator/device | 실제 framework, lifecycle, UI, 권한, 시스템 integration이 필요할 때 | 없음 |
+| iOS test source set | Kotlin/Native simulator/device | iOS `actual` 구현이나 Native에서만 발생하는 동작을 검증할 때 | 없음 |
+
+AGP Android-KMP plugin에서는 host/device test가 기본 비활성이다. 이 저장소의 `KmpAndroidPlugin`은 `src/androidHostTest` 디렉터리가 있는 모듈에만 `withHostTest`를 활성화한다. 공식 migration 표도 기존 `src/test`를 `src/androidHostTest`, `src/androidTest`를 `src/androidDeviceTest`로 옮기도록 안내한다.
+
+- [Android Developers: Android-KMP plugin 설정과 test source set](https://developer.android.com/kotlin/multiplatform/plugin)
+- [Kotlin Multiplatform: 공통·플랫폼 테스트 실행](https://kotlinlang.org/docs/multiplatform/multiplatform-run-tests.html)
+
+### `commonTest`로 옮길지 판단하는 질문
+
+아래 질문이 모두 `예`일 때만 이동을 고려한다.
+
+1. 테스트 대상과 fixture가 Android/JVM API를 사용하지 않는가?
+2. JUnit 5 전용 API, MockK JVM, Robolectric, `java.io` 등을 `kotlin.test`와 multiplatform dependency로 바꿀 수 있는가?
+3. 같은 테스트를 iOS/Native에서도 실행해 실제 회귀를 잡을 수 있는가?
+4. Native test 시간과 유지비보다 플랫폼 간 계약을 검증하는 가치가 큰가?
+
+단순히 production 코드가 `commonMain`에 있다는 이유만으로 테스트도 `commonTest`로 옮기지는 않는다. 현재 순수 로직 후보인 `ThemeModeTest`, `InAppUpdatePolicyTest`도 2~3개의 작은 JUnit 5 테스트라서, 이들만 이동하면 runner가 이원화되고 iOS 전용 회귀를 추가로 잡지 못한다. 공통 도메인 계약 테스트가 늘어날 때 함께 전환한다.
+
+## 현재 모듈 감사 결과
+
+| 모듈 | `androidHostTest` 내용 | 현재 위치 판단 |
+| --- | --- | --- |
+| `composeApp` | Metro `AppGraph` 생성과 factory 연결, Robolectric/Application | Android host 유지 |
+| `core:common` | Android color 변환, 날짜 포맷, 인앱 업데이트 정책 | Android color와 JUnit 5 때문에 유지. 정책 테스트는 향후 공통 후보 |
+| `core:data` | Repository와 DAO/DataStore 협력, MockK | Android host 유지 |
+| `core:database` | Room DAO/Robolectric, Android database path | Android host 유지 |
+| `core:datastore` | JVM temp file 기반 DataStore와 Android path | Android host 유지 |
+| `core:domain` | `ThemeMode` 순수 로직 | 향후 공통 후보지만 지금은 유지 |
+| `feature:complete` | Circuit Presenter와 repository recording fake | Android host 유지 |
+| `feature:home` | Circuit Presenter 상태·event·navigation, Turbine helper | Android host 유지 |
+| `feature:onboarding` | Circuit Presenter 중복 입력과 root navigation | Android host 유지 |
+| `feature:splash` | Circuit Presenter 초기 routing | Android host 유지 |
+
+현재 `commonTest`, `androidDeviceTest`, `src/test`, `src/androidTest`, iOS test 디렉터리는 없다. 이번 감사에서는 테스트 파일을 이동하지 않는다.
+
+## Circuit, Molecule, Turbine의 관계
+
+Circuit 공식 문서에서 `Presenter.test()`는 `presenterTestOf()`의 단축 API이며, Molecule로 composable Presenter를 실행하고 Turbine으로 방출된 `CircuitUiState`를 검증할 수 있게 한다.
+
+```kotlin
+runTest {
+    presenter.test {
+        val state = awaitItem()
+        state.eventSink(Event.Submit)
+        assertEquals(expected, awaitItem())
+    }
+}
+```
+
+- [Circuit 공식 Testing 문서](https://slackhq.github.io/circuit/docs/testing/)
+
+프로젝트가 소비 중인 `circuit-test:0.35.1` Gradle Module Metadata를 확인한 결과는 다음과 같다.
+
+- common metadata와 Android/JVM/iOS/JS/Wasm/macOS 변형을 게시한다.
+- `molecule-runtime:2.2.0`과 `turbine:1.2.1`을 전이 의존성으로 제공한다.
+- 따라서 `Presenter.test()`만 쓰는 모듈은 `libs.circuit.test`만 직접 선언하면 된다.
+- `feature:home`은 테스트 코드가 `app.cash.turbine.ReceiveTurbine`을 직접 import하므로 `libs.turbine`을 직접 선언한 현재 구성이 맞다.
+- 프로젝트 production/test 코드에는 `app.cash.molecule` 직접 import가 없다. 직접 `moleculeFlow`, `launchMolecule` 등을 사용하기 전에는 Molecule dependency를 추가하지 않는다.
+
+Circuit Presenter 테스트를 iOS source set에서도 실행하는 것은 기술적으로 가능하다. 다만 현재 Presenter가 공통 코드에 있고 Android host test가 상태 전이와 navigation 계약을 이미 검증하며, iOS `actual` 구현을 Presenter가 직접 사용하지 않는다. 같은 테스트를 Native에서 중복 실행하는 비용보다 이점이 작으므로 지금은 추가하지 않는다. iOS platform adapter나 Native 전용 상태 분기가 생기면 해당 계약만 iOS test로 추가한다.
+
+## 로컬 실행 명령
+
+전체 host test와 Android app JVM test:
+
+```bash
+./gradlew allTests :androidApp:testDebugUnitTest
+```
+
+특정 KMP 모듈의 host test:
+
+```bash
+./gradlew :feature:home:testAndroidHostTest
+./gradlew :core:database:testAndroidHostTest
+```
+
+Circuit/Metro 변경의 대표 회귀 검사:
+
+```bash
+./gradlew \
+  :feature:complete:testAndroidHostTest \
+  :feature:home:testAndroidHostTest \
+  :feature:onboarding:testAndroidHostTest \
+  :feature:splash:testAndroidHostTest \
+  :composeApp:testAndroidHostTest
+```
+
+`androidDeviceTest`는 아직 활성화하지 않았으므로 이 저장소에 대응 task가 없다. `baselineprofile`은 앱의 unit test 체계와 별개의 계측 모듈이며, 실제 기기/에뮬레이터 기반 성능 검증이 필요할 때 해당 workflow에서 실행한다.
+
+## CI 실행 범위
+
+`.github/workflows/android-ci.yml`의 Unit tests job은 macOS/JDK 21에서 다음 명령을 실행한다.
+
+```bash
+./gradlew allTests :androidApp:testDebugUnitTest --stacktrace
+```
+
+2026-08-06의 성공한 CI 로그에서 `allTests`가 아래 task를 모두 실행한 것을 확인했다.
+
+```text
+:composeApp:testAndroidHostTest
+:core:common:testAndroidHostTest
+:core:data:testAndroidHostTest
+:core:database:testAndroidHostTest
+:core:datastore:testAndroidHostTest
+:core:domain:testAndroidHostTest
+:feature:complete:testAndroidHostTest
+:feature:home:testAndroidHostTest
+:feature:onboarding:testAndroidHostTest
+:feature:splash:testAndroidHostTest
+```
+
+`androidApp:testDebugUnitTest`는 현재 `NO-SOURCE`지만 Android application module에 테스트가 추가될 경우를 위해 명시적으로 유지한다. Android lint/build와 iOS framework build는 각각 별도 CI job이며 테스트 실행을 대체하지 않는다.
+
+문서만 변경한 PR은 workflow의 `paths-ignore: "**/*.md"` 조건으로 Android CI가 시작되지 않는다. 문서 PR에서는 링크와 저장소 구성 대조가 검증 기준이고, 코드나 Gradle 구성이 함께 바뀌면 전체 CI를 실행한다.
+
+## 새 테스트 추가 규칙
+
+1. 먼저 테스트하려는 계약이 공통인지 플랫폼 전용인지 정한다.
+2. 현재 runner와 dependency로 충분하면 새 framework를 추가하지 않는다.
+3. Circuit Presenter는 `Presenter.test()`와 `FakeNavigator`를 우선 사용한다.
+4. Turbine 타입/API를 직접 import하는 모듈만 Turbine을 직접 dependency로 선언한다.
+5. Android framework가 필요한 로컬 테스트는 `androidHostTest`와 Robolectric을 사용한다.
+6. 실제 시스템 UI, permission, notification, widget처럼 host fake로 의미가 없는 동작만 `androidDeviceTest`로 올린다.
+7. 새 test source set을 만들면 로컬 task뿐 아니라 CI 진입 task가 실제로 포함하는지 로그로 확인한다.


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #209

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- AGP KMP의 `commonTest`, `androidHostTest`, `androidDeviceTest` 선택 기준과 현재 모듈별 테스트 배치를 정리했습니다.
- Circuit Presenter 테스트가 Molecule과 Turbine을 사용하는 구조, 전이·직접 의존성의 경계를 문서화했습니다.
- 실제 Gradle task와 CI 실행 범위를 확인하고 이후 백로그 실행 순서를 최신 완료 상태에 맞게 갱신했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

문서 전용 변경으로 Gradle 빌드는 실행하지 않았습니다. 저장소 구성, Circuit 0.35.1 Gradle metadata와 최근 성공한 CI의 실제 test task 로그를 대조했습니다.

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 기능 설명 | <img src="링크" width="300" /> | 기능 설명 | <img src="링크" width="300" /> |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 현재 테스트를 억지로 `commonTest`로 이동하지 않고, 플랫폼 간 중복 실행 가치가 생길 때 전환하도록 기준을 고정했습니다.

## 💡 코드리뷰 Tip

Gemini Code Assist 리뷰 코멘트가 달리면 `resolve-gemini-review`를 실행하여 미해결 코멘트를 반영하거나 거절 사유를 남길 수 있습니다.
