### PR TITLE
fix: clean release 검증 및 2.2.13 복구 준비

### DIFF
--- a/docs/ANDROID_2_2_13_CLEAN_RELEASE_RECOVERY_STRATEGY.md
+++ b/docs/ANDROID_2_2_13_CLEAN_RELEASE_RECOVERY_STRATEGY.md
@@ -1,0 +1,53 @@
+# Android 2.2.13 Clean Release 복구 전략
+
+## 배경
+
+2.2.12에서 `composeApp/src/commonMain/composeResources`를 제거해 Compose 리소스의 단일 소스를 `core:designsystem`으로 정리했다.
+
+하지만 기존 빌드 산출물이 남아 있던 로컬 배포 worktree에서 `publishReleaseBundle`을 실행하자, Compose resource task가 제거된 source set을 `NO-SOURCE`로 판단하면서 예전 생성물을 삭제하지 않았다. 그 결과 Play Internal Testing에 업로드된 2.2.12 AAB에는 다음 두 리소스 namespace가 모두 포함됐다.
+
+- `bandalart.composeapp.generated.resources`
+- `bandalart.core.designsystem.generated.resources`
+
+Play에 등록된 versionCode `20212`는 재사용할 수 없으므로 clean AAB는 2.2.13 (`20213`)으로 복구 배포한다.
+
+## 목표
+
+- Android 앱 버전을 2.2.13 (`20213`)으로 올린다.
+- release 업로드 전에 clean AAB를 별도로 생성한다.
+- AAB에 `bandalart.composeapp.generated.resources`가 없고 `bandalart.core.designsystem.generated.resources`만 있는지 확인한다.
+- 검증된 AAB와 동일한 소스에서 Play Internal Testing 업로드를 실행한다.
+- 이후 Android Play 배포에서도 같은 stale generated resource 문제가 재발하지 않도록 workflow를 보강한다.
+
+## 범위
+
+### 포함
+
+- patch version `12`에서 `13`으로 상향
+- Android Play 배포 workflow에 clean release AAB 사전 생성 및 구성 검사 단계 추가
+- 기존 2.2.12 출시 노트 유지
+
+### 제외
+
+- UI와 기능 코드 변경
+- Compose 리소스 추가 삭제
+- Production 트랙 배포
+- 2.2.12 Internal 릴리스 삭제 또는 수정
+
+## 검증 순서
+
+1. 최신 `main`과 동일한 clean worktree인지 확인한다.
+2. `./gradlew clean :androidApp:bundleRelease --no-configuration-cache`를 실행한다.
+3. AAB 크기와 Compose resource namespace를 확인한다.
+4. versionName `2.2.13`, versionCode `20213`을 확인한다.
+5. CI의 code quality, unit tests, Android lint/build, iOS framework build가 통과한 뒤 병합한다.
+6. 최신 `main`에서 Play 전체 트랙 최대 versionCode가 `20212`인지 다시 확인한다.
+7. 검증된 clean 산출물 상태에서 `publishReleaseBundle`을 실행한다.
+8. Play Internal 트랙의 최대 versionCode가 `20213`으로 갱신됐는지 확인한다.
+
+## 중단 조건
+
+- clean AAB에 `bandalart.composeapp.generated.resources`가 남아 있다.
+- clean AAB에 `bandalart.core.designsystem.generated.resources`가 없다.
+- Play 전체 트랙 최대 versionCode가 `20213` 이상이다.
+- CI 실패, credential 누락 또는 관리자 권한 우회가 필요하다.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ targetSdk = "36"
 compileSdk = "37"
 majorVersion = "2"
 minorVersion = "2"
-patchVersion = "12"
+patchVersion = "13"
 packageName = "com.nexters.bandalart"
 
 # Gradle Plugin

--- a/plugins/bandalart/skills/deploy-android-playstore/SKILL.md
+++ b/plugins/bandalart/skills/deploy-android-playstore/SKILL.md
@@ -46,15 +46,19 @@ service account는 `client_email`만 기대 계정과 일치하는지 검사하�
 - Play 전체 track의 기존 최대 versionCode
 - 배포 대상 `Internal Testing`
 - release notes
-- 실행할 Android Gradle upload task
+- 실행할 Android clean bundle 및 upload task
 
-### 5. Android AAB build와 업로드
+### 5. Android clean AAB 검증과 업로드
 
-1. 저장소가 설정한 Android release bundle upload task를 configuration cache 없이 실행한다.
-2. 배포 산출물 생성이 목적이므로 이 workflow에서는 Android release build를 실행할 수 있다.
-3. upload target이 Internal track이고 의도한 release status인지 task 설정과 결과에서 확인한다.
-4. 실패하면 즉시 중단하고 secret을 가린 실패 단계와 원인을 보고한다.
-5. 성공하면 AAB, package, versionName/versionCode, track과 결과를 보고한다.
+1. `./gradlew clean :androidApp:bundleRelease --no-configuration-cache`로 기존 생성물을 제거하고 release AAB를 먼저 생성한다.
+2. 생성된 AAB의 versionName/versionCode, 크기와 Compose resource namespace를 검사한다.
+   - 제거된 source set의 generated resource namespace가 남아 있으면 업로드하지 않는다.
+   - 저장소가 사용하는 resource namespace가 없으면 업로드하지 않는다.
+3. 사전 검증이 통과하면 `./gradlew publishReleaseBundle --no-configuration-cache`로 검증된 소스와 산출물 상태에서 업로드한다.
+4. 배포 산출물 생성이 목적이므로 이 workflow에서는 Android release build를 실행할 수 있다.
+5. upload target이 Internal track이고 의도한 release status인지 task 설정과 결과에서 확인한다.
+6. 실패하면 즉시 중단하고 secret을 가린 실패 단계와 원인을 보고한다.
+7. 성공하면 AAB, package, versionName/versionCode, track과 결과를 보고한다.
 
 ## 제약
 


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- 관련 이슈 없음

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- stale Gradle 생성물이 포함된 2.2.12 Internal AAB를 대체하기 위해 앱 버전을 `2.2.13 (20213)`으로 올렸습니다.
- Android Play 배포 workflow를 clean release AAB 생성, 리소스 namespace 검사, 업로드 순서로 보강했습니다.
- 발생 원인과 복구 범위, 중단 조건을 clean release 복구 전략 문서로 기록했습니다.

## 🧪 테스트 내역 (선택)

- [x] clean release AAB 빌드 성공
- [x] AAB에서 `bandalart.composeapp.generated.resources` 제거 확인
- [x] AAB에서 `bandalart.core.designsystem.generated.resources` 유지 확인
- [x] AAB 크기 28MB에서 19MB로 감소 확인
- [ ] Play Internal Testing 2.2.13 업로드 및 설치 확인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| UI 변경 없음 | - | UI 변경 없음 | - |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- Play에 등록된 versionCode `20212`는 재사용할 수 없어 clean AAB를 `20213`으로 복구 배포합니다.
