### PR TITLE
feat: add recent emoji history

### DIFF
--- a/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/repository/SettingsRepositoryTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/repository/SettingsRepositoryTest.kt
@@ -35,6 +35,7 @@ class SettingsRepositoryTest {
     fun storedValuesAreMappedToThemeModeWithSystemFallback() =
         runTest {
             every { dataStore.themeMode } returns flowOf("unexpected")
+            every { dataStore.recentEmojis } returns flowOf(emptyList())
 
             val repository = DefaultSettingsRepository(dataStore)
 
@@ -45,11 +46,26 @@ class SettingsRepositoryTest {
     fun themeSelectionIsStoredAsStableString() =
         runTest {
             every { dataStore.themeMode } returns flowOf(null)
+            every { dataStore.recentEmojis } returns flowOf(emptyList())
             coEvery { dataStore.setThemeMode(any()) } returns Unit
             val repository = DefaultSettingsRepository(dataStore)
 
             repository.setThemeMode(ThemeMode.DARK)
 
             coVerify(exactly = 1) { dataStore.setThemeMode("dark") }
+        }
+
+    @Test
+    fun recentEmojisAreExposedAndSelectionsAreStored() =
+        runTest {
+            every { dataStore.themeMode } returns flowOf(null)
+            every { dataStore.recentEmojis } returns flowOf(listOf("🎯", "🚀"))
+            coEvery { dataStore.addRecentEmoji(any()) } returns Unit
+            val repository = DefaultSettingsRepository(dataStore)
+
+            assertEquals(listOf("🎯", "🚀"), repository.recentEmojis.first())
+            repository.addRecentEmoji("🎯")
+
+            coVerify(exactly = 1) { dataStore.addRecentEmoji("🎯") }
         }
 }

--- a/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/repository/DefaultSettingsRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/repository/DefaultSettingsRepository.kt
@@ -27,8 +27,13 @@ class DefaultSettingsRepository(
 ) : SettingsRepository {
     override val themeMode: Flow<ThemeMode> =
         bandalartDataStore.themeMode.map(ThemeMode::fromStorageValue)
+    override val recentEmojis: Flow<List<String>> = bandalartDataStore.recentEmojis
 
     override suspend fun setThemeMode(themeMode: ThemeMode) {
         bandalartDataStore.setThemeMode(themeMode.storageValue)
+    }
+
+    override suspend fun addRecentEmoji(emoji: String) {
+        bandalartDataStore.addRecentEmoji(emoji)
     }
 }

--- a/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreTest.kt
+++ b/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreTest.kt
@@ -104,7 +104,7 @@ class BandalartDataStoreTest {
         @DisplayName("최근 12개까지만 저장해야 한다")
         fun recentEmojisAreLimitedToTwelveItems() =
             runTest {
-                (1..13).forEach { index ->
+                for (index in 1..13) {
                     bandalartDataStore.addRecentEmoji("emoji-$index")
                 }
 

--- a/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreTest.kt
+++ b/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreTest.kt
@@ -80,6 +80,42 @@ class BandalartDataStoreTest {
     }
 
     @Nested
+    @DisplayName("최근 사용 이모지 관련 테스트")
+    inner class RecentEmojisTest {
+        @Test
+        @DisplayName("초기값은 빈 목록이어야 한다")
+        fun recentEmojisAreEmptyByDefault() =
+            runTest {
+                assertEquals(emptyList<String>(), bandalartDataStore.recentEmojis.first())
+            }
+
+        @Test
+        @DisplayName("중복을 제거하고 최신 사용 순으로 저장해야 한다")
+        fun recentEmojisAreDeduplicatedAndMovedToFront() =
+            runTest {
+                bandalartDataStore.addRecentEmoji("🎯")
+                bandalartDataStore.addRecentEmoji("🚀")
+                bandalartDataStore.addRecentEmoji("🎯")
+
+                assertEquals(listOf("🎯", "🚀"), bandalartDataStore.recentEmojis.first())
+            }
+
+        @Test
+        @DisplayName("최근 12개까지만 저장해야 한다")
+        fun recentEmojisAreLimitedToTwelveItems() =
+            runTest {
+                (1..13).forEach { index ->
+                    bandalartDataStore.addRecentEmoji("emoji-$index")
+                }
+
+                assertEquals(
+                    (13 downTo 2).map { index -> "emoji-$index" },
+                    bandalartDataStore.recentEmojis.first(),
+                )
+            }
+    }
+
+    @Nested
     @DisplayName("완료된 반다라트 목록 관련 테스트")
     inner class CompletedBandalartListTest {
         @Test

--- a/core/datastore/src/commonMain/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStore.kt
+++ b/core/datastore/src/commonMain/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStore.kt
@@ -37,12 +37,15 @@ class BandalartDataStore(
         private const val COMPLETED_BANDALART_LIST_ID = "completed_bandalart_list_id"
         private const val ONBOARDING_COMPLETED_ID = "completed_onboarding_id"
         private const val THEME_MODE = "theme_mode"
+        private const val RECENT_EMOJIS = "recent_emojis"
+        private const val MAX_RECENT_EMOJIS = 12
     }
 
     private val recentBandalartKey = longPreferencesKey(RECENT_BANDALART_ID)
     private val completedBandalartListKey = stringPreferencesKey(COMPLETED_BANDALART_LIST_ID)
     private val onboardingCompletedKey = booleanPreferencesKey(ONBOARDING_COMPLETED_ID)
     private val themeModeKey = stringPreferencesKey(THEME_MODE)
+    private val recentEmojisKey = stringPreferencesKey(RECENT_EMOJIS)
 
     val themeMode =
         dataStore.data
@@ -52,6 +55,19 @@ class BandalartDataStore(
                 else
                     throw exception
             }.map { preferences -> preferences[themeModeKey] }
+
+    val recentEmojis =
+        dataStore.data
+            .catch { exception ->
+                if (exception is IOException)
+                    emit(emptyPreferences())
+                else
+                    throw exception
+            }.map { preferences ->
+                preferences[recentEmojisKey]
+                    ?.let { Json.decodeFromString<List<String>>(it) }
+                    ?: emptyList()
+            }
 
     suspend fun setRecentBandalartId(recentBandalartId: Long) {
         dataStore.edit { preferences ->
@@ -153,6 +169,19 @@ class BandalartDataStore(
     suspend fun setThemeMode(themeMode: String) {
         dataStore.edit { preferences ->
             preferences[themeModeKey] = themeMode
+        }
+    }
+
+    suspend fun addRecentEmoji(emoji: String) {
+        dataStore.edit { preferences ->
+            val currentEmojis =
+                preferences[recentEmojisKey]
+                    ?.let { Json.decodeFromString<List<String>>(it) }
+                    ?: emptyList()
+            val updatedEmojis =
+                (listOf(emoji) + currentEmojis.filterNot { it == emoji })
+                    .take(MAX_RECENT_EMOJIS)
+            preferences[recentEmojisKey] = Json.encodeToString(updatedEmojis)
         }
     }
 }

--- a/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
@@ -69,6 +69,7 @@
     <string name="emoji_picker_empty">No emojis found.</string>
     <string name="emoji_picker_reset">Show all</string>
     <string name="emoji_picker_category_all">All</string>
+    <string name="emoji_picker_category_recent">Recent</string>
     <string name="emoji_picker_category_smileys">Smileys</string>
     <string name="emoji_picker_category_people">People</string>
     <string name="emoji_picker_category_nature">Nature</string>

--- a/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
@@ -69,6 +69,7 @@
     <string name="emoji_picker_empty">該当する絵文字がありません。</string>
     <string name="emoji_picker_reset">すべて表示</string>
     <string name="emoji_picker_category_all">すべて</string>
+    <string name="emoji_picker_category_recent">最近使用</string>
     <string name="emoji_picker_category_smileys">表情・感情</string>
     <string name="emoji_picker_category_people">人</string>
     <string name="emoji_picker_category_nature">動物・自然</string>

--- a/core/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -69,6 +69,7 @@
     <string name="emoji_picker_empty">검색 결과가 없어요.</string>
     <string name="emoji_picker_reset">전체 보기</string>
     <string name="emoji_picker_category_all">모두</string>
+    <string name="emoji_picker_category_recent">최근 사용</string>
     <string name="emoji_picker_category_smileys">표정·감정</string>
     <string name="emoji_picker_category_people">사람</string>
     <string name="emoji_picker_category_nature">동물·자연</string>

--- a/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/repository/SettingsRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/repository/SettingsRepository.kt
@@ -21,6 +21,9 @@ import kotlinx.coroutines.flow.Flow
 
 interface SettingsRepository {
     val themeMode: Flow<ThemeMode>
+    val recentEmojis: Flow<List<String>>
 
     suspend fun setThemeMode(themeMode: ThemeMode)
+
+    suspend fun addRecentEmoji(emoji: String)
 }

--- a/core/ui/src/androidHostTest/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiCatalogTest.kt
+++ b/core/ui/src/androidHostTest/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiCatalogTest.kt
@@ -53,7 +53,7 @@ class FluentEmojiCatalogTest {
                 .size,
         )
         assertEquals(
-            FluentEmojiCategory.entries.toSet(),
+            FluentEmojiCategory.entries.filterNot { it == FluentEmojiCategory.RECENT }.toSet(),
             FluentEmojiCatalog.items.map { it.category }.toSet(),
         )
         assertTrue(
@@ -93,5 +93,25 @@ class FluentEmojiCatalogTest {
 
         val uncategorizedAlias = FluentEmojiCatalog.items.first { it.koreanAliases.isEmpty() }
         assertEquals(uncategorizedAlias.unicode, uncategorizedAlias.displayName(Language.KOREAN))
+    }
+
+    @Test
+    fun recentFilterKeepsStoredOrderAndDropsItemsOutsideTheCatalog() {
+        val recentItems =
+            filterFluentEmojiItems(
+                query = "",
+                category = FluentEmojiCategory.RECENT,
+                recentEmojis = listOf("🚀", "😎", "🎯", "🚀"),
+            )
+
+        assertEquals(listOf("🚀", "🎯"), recentItems.map { it.unicode })
+        assertEquals(
+            listOf("🎯"),
+            filterFluentEmojiItems(
+                query = "target",
+                category = FluentEmojiCategory.RECENT,
+                recentEmojis = listOf("🚀", "🎯"),
+            ).map { it.unicode },
+        )
     }
 }

--- a/core/ui/src/commonMain/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiCatalog.kt
+++ b/core/ui/src/commonMain/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiCatalog.kt
@@ -19,6 +19,7 @@ package com.nexters.bandalart.core.ui.component.emoji
 import com.nexters.bandalart.core.common.Language
 
 internal enum class FluentEmojiCategory {
+    RECENT,
     SMILEYS_AND_EMOTION,
     PEOPLE_AND_BODY,
     ANIMALS_AND_NATURE,
@@ -49,10 +50,21 @@ internal data class FluentEmojiItem(
 internal fun filterFluentEmojiItems(
     query: String,
     category: FluentEmojiCategory?,
+    recentEmojis: List<String> = emptyList(),
 ): List<FluentEmojiItem> {
     val normalizedQuery = query.trim().lowercase()
-    return FluentEmojiCatalog.items.filter { item ->
-        val matchesCategory = category == null || item.category == category
+    val candidates =
+        if (category == FluentEmojiCategory.RECENT) {
+            val itemByUnicode = FluentEmojiCatalog.items.associateBy(FluentEmojiItem::unicode)
+            recentEmojis.distinct().mapNotNull(itemByUnicode::get)
+        } else {
+            FluentEmojiCatalog.items
+        }
+    return candidates.filter { item ->
+        val matchesCategory =
+            category == null ||
+                category == FluentEmojiCategory.RECENT ||
+                item.category == category
         val matchesQuery =
             normalizedQuery.isEmpty() ||
                 item.unicode.contains(normalizedQuery) ||

--- a/core/ui/src/commonMain/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiPicker.kt
+++ b/core/ui/src/commonMain/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiPicker.kt
@@ -66,6 +66,7 @@ import bandalart.core.designsystem.generated.resources.emoji_picker_category_foo
 import bandalart.core.designsystem.generated.resources.emoji_picker_category_nature
 import bandalart.core.designsystem.generated.resources.emoji_picker_category_objects
 import bandalart.core.designsystem.generated.resources.emoji_picker_category_people
+import bandalart.core.designsystem.generated.resources.emoji_picker_category_recent
 import bandalart.core.designsystem.generated.resources.emoji_picker_category_smileys
 import bandalart.core.designsystem.generated.resources.emoji_picker_category_symbols
 import bandalart.core.designsystem.generated.resources.emoji_picker_category_travel
@@ -81,6 +82,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun FluentEmojiPicker(
     currentEmoji: String?,
+    recentEmojis: List<String>,
     onEmojiSelect: (String) -> Unit,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
@@ -90,12 +92,24 @@ fun FluentEmojiPicker(
     var selectedCategoryName by rememberSaveable { mutableStateOf<String?>(null) }
     var selectedEmoji by rememberSaveable(currentEmoji) { mutableStateOf(currentEmoji) }
 
-    val selectedCategory = selectedCategoryName?.let { FluentEmojiCategory.valueOf(it) }
+    val availableRecentEmojis =
+        remember(recentEmojis) {
+            recentEmojis
+                .distinct()
+                .filter { FluentEmojiCatalog.resourceKeyFor(it) != null }
+        }
+    val selectedCategory =
+        selectedCategoryName
+            ?.let { FluentEmojiCategory.valueOf(it) }
+            ?.takeUnless {
+                it == FluentEmojiCategory.RECENT && availableRecentEmojis.isEmpty()
+            }
     val filteredItems =
-        remember(query, selectedCategory) {
+        remember(query, selectedCategory, availableRecentEmojis) {
             filterFluentEmojiItems(
                 query = query,
                 category = selectedCategory,
+                recentEmojis = availableRecentEmojis,
             )
         }
     val sizeModifier =
@@ -146,6 +160,7 @@ fun FluentEmojiPicker(
 
         EmojiCategoryRow(
             selectedCategory = selectedCategory,
+            hasRecentEmojis = availableRecentEmojis.isNotEmpty(),
             onCategorySelect = { category ->
                 selectedCategoryName = category?.name
             },
@@ -199,9 +214,15 @@ fun FluentEmojiPicker(
 @Composable
 private fun EmojiCategoryRow(
     selectedCategory: FluentEmojiCategory?,
+    hasRecentEmojis: Boolean,
     onCategorySelect: (FluentEmojiCategory?) -> Unit,
 ) {
-    val categories = remember { listOf(null) + FluentEmojiCategory.entries }
+    val categories =
+        remember(hasRecentEmojis) {
+            listOf(null) +
+                (if (hasRecentEmojis) listOf(FluentEmojiCategory.RECENT) else emptyList()) +
+                FluentEmojiCategory.entries.filterNot { it == FluentEmojiCategory.RECENT }
+        }
     LazyRow(
         modifier = Modifier.fillMaxWidth(),
         contentPadding = PaddingValues(horizontal = 16.dp),
@@ -339,6 +360,7 @@ private fun categoryLabel(category: FluentEmojiCategory?): String =
     stringResource(
         when (category) {
             null -> Res.string.emoji_picker_category_all
+            FluentEmojiCategory.RECENT -> Res.string.emoji_picker_category_recent
             FluentEmojiCategory.SMILEYS_AND_EMOTION -> Res.string.emoji_picker_category_smileys
             FluentEmojiCategory.PEOPLE_AND_BODY -> Res.string.emoji_picker_category_people
             FluentEmojiCategory.ANIMALS_AND_NATURE -> Res.string.emoji_picker_category_nature

--- a/docs/FLUENT_EMOJI_PICKER_MIGRATION_STRATEGY.md
+++ b/docs/FLUENT_EMOJI_PICKER_MIGRATION_STRATEGY.md
@@ -76,6 +76,21 @@ renderer 또는 resource codegen 문제가 생기면 feature 호출부를 기존
 - 기존 값 선택 표시, 동일 항목 중복 callback 방지, dismiss 무변경은 Presenter/수동 검증
 - 실제 Compose interaction harness는 #217에서 추가하고 이번 단계는 host unit test와 Android/iOS CI compile로 검증
 
+## 최근 사용 브랜치의 성공 기준
+
+- 최근 선택한 Unicode를 중복 없이 최신순 최대 12개까지 기존 KMP DataStore에 저장한다.
+- 새 repository를 추가하지 않고 `SettingsRepository` → `BandalartDataStore` 경로를 재사용한다.
+- DataStore에는 Unicode 목록만 JSON으로 저장하고 사용자 목표나 개인 콘텐츠는 저장하지 않는다.
+- 독립 시트와 셀 편집 draft에서 선택한 이모지를 모두 최근 사용에 기록한다.
+- 최근 사용 category는 저장 순서를 유지하며, 현재 300개 catalog에서 제거된 Unicode는 UI에서 자동 제외한다.
+- 최근 목록이 비어 있을 때는 category를 노출하지 않고, 하나 이상 있을 때만 검색·category 필터와 같이 사용한다.
+
+### 최근 사용 검증
+
+- DataStore 초기값, 최신순, 중복 제거, 12개 상한을 host test로 검증한다.
+- repository Flow·저장 위임과 Presenter의 독립/draft 선택 기록을 검증한다.
+- catalog에 없는 저장값 제외·최근순 유지·검색 결과를 unit test로 검증한다.
+
 ## picker UI 이전 구조와 제약
 
 - `BandalartEmojiPicker`가 24개 문자열과 4×6 레이아웃을 직접 소유한다.

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeSettingsRepository.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeSettingsRepository.kt
@@ -23,15 +23,27 @@ import kotlinx.coroutines.flow.asStateFlow
 
 class FakeSettingsRepository(
     initialThemeMode: ThemeMode = ThemeMode.SYSTEM,
+    private val beforeRecentEmojiSave: suspend (String) -> Unit = {},
 ) : SettingsRepository {
     private val themeModeState = MutableStateFlow(initialThemeMode)
+    private val recentEmojisState = MutableStateFlow<List<String>>(emptyList())
 
     override val themeMode = themeModeState.asStateFlow()
+    override val recentEmojis = recentEmojisState.asStateFlow()
 
     val savedThemeModes = mutableListOf<ThemeMode>()
+    val savedRecentEmojis = mutableListOf<String>()
 
     override suspend fun setThemeMode(themeMode: ThemeMode) {
         savedThemeModes += themeMode
         themeModeState.value = themeMode
+    }
+
+    override suspend fun addRecentEmoji(emoji: String) {
+        beforeRecentEmojiSave(emoji)
+        savedRecentEmojis += emoji
+        recentEmojisState.value =
+            (listOf(emoji) + recentEmojisState.value.filterNot { it == emoji })
+                .take(12)
     }
 }

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterEditTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterEditTest.kt
@@ -126,7 +126,11 @@ class HomePresenterEditTest {
                 state.eventSink(HomeScreen.Event.SaveCell)
                 do {
                     state = awaitItem()
-                } while (repository.mainCellUpdate == null || state.bottomSheet != null)
+                } while (
+                    repository.mainCellUpdate == null ||
+                    state.recentEmojis != listOf("🚀") ||
+                    state.bottomSheet != null
+                )
 
                 val update = requireNotNull(repository.mainCellUpdate)
                 assertEquals(1L, update.bandalartId)
@@ -287,7 +291,7 @@ class HomePresenterEditTest {
                     state = awaitItem()
                 } while (
                     repository.emojiUpdates.isEmpty() ||
-                    settingsRepository.savedRecentEmojis.isEmpty() ||
+                    state.recentEmojis != listOf("🌟") ||
                     state.bottomSheet != null
                 )
 
@@ -360,9 +364,9 @@ class HomePresenterEditTest {
                 allowFirstSave.complete(Unit)
                 do {
                     state = awaitItem()
-                } while (settingsRepository.recentEmojis.value != listOf("🚀", "🌟"))
+                } while (state.recentEmojis != listOf("🚀", "🌟"))
 
-                assertEquals(listOf("🚀", "🌟"), settingsRepository.recentEmojis.value)
+                assertEquals(listOf("🚀", "🌟"), state.recentEmojis)
             }
         }
 

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterEditTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterEditTest.kt
@@ -379,13 +379,12 @@ class HomePresenterEditTest {
     private fun presenter(
         repository: FakeBandalartRepository,
         settingsRepository: FakeSettingsRepository = FakeSettingsRepository(),
-    ) =
-        HomePresenter(
-            navigator = FakeNavigator(HomeScreen),
-            bandalartRepository = repository,
-            inAppUpdateRepository = FakeInAppUpdateRepository(),
-            settingsRepository = settingsRepository,
-        )
+    ) = HomePresenter(
+        navigator = FakeNavigator(HomeScreen),
+        bandalartRepository = repository,
+        inAppUpdateRepository = FakeInAppUpdateRepository(),
+        settingsRepository = settingsRepository,
+    )
 
     private suspend fun ReceiveTurbine<HomeScreen.State>.awaitLoadedBandalart(bandalartId: Long,): HomeScreen.State {
         var state = awaitItem()

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterEditTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterEditTest.kt
@@ -24,6 +24,7 @@ import com.nexters.bandalart.feature.home.HomeScreen
 import com.nexters.bandalart.feature.home.model.CellType
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -97,7 +98,8 @@ class HomePresenterEditTest {
         runTest {
             val mainCell = cell(id = 10L, title = "기존 목표")
             val repository = repositoryWithCells(mainCell = mainCell)
-            val presenter = presenter(repository)
+            val settingsRepository = FakeSettingsRepository()
+            val presenter = presenter(repository, settingsRepository)
 
             presenter.test {
                 var state = awaitLoadedBandalart(1L)
@@ -135,6 +137,7 @@ class HomePresenterEditTest {
                 assertEquals("🚀", update.entity.profileEmoji)
                 assertEquals("#ABCDEF", update.entity.mainColor)
                 assertEquals("#123456", update.entity.subColor)
+                assertEquals(listOf("🚀"), settingsRepository.savedRecentEmojis)
             }
         }
 
@@ -261,7 +264,8 @@ class HomePresenterEditTest {
             val mainCell = cell(id = 10L, title = null)
             val subCell = cell(id = 11L, title = "서브", parentId = mainCell.id)
             val repository = repositoryWithCells(mainCell = mainCell)
-            val presenter = presenter(repository)
+            val settingsRepository = FakeSettingsRepository()
+            val presenter = presenter(repository, settingsRepository)
 
             presenter.test {
                 var state = awaitLoadedBandalart(1L)
@@ -281,12 +285,17 @@ class HomePresenterEditTest {
                 state.eventSink(HomeScreen.Event.UpdateBandalartEmoji(1L, mainCell.id, "🚀"))
                 do {
                     state = awaitItem()
-                } while (repository.emojiUpdates.isEmpty() || state.bottomSheet != null)
+                } while (
+                    repository.emojiUpdates.isEmpty() ||
+                    settingsRepository.savedRecentEmojis.isEmpty() ||
+                    state.bottomSheet != null
+                )
 
                 val update = repository.emojiUpdates.single()
                 assertEquals(1L, update.bandalartId)
                 assertEquals(mainCell.id, update.cellId)
                 assertEquals("🌟", update.entity.profileEmoji)
+                assertEquals(listOf("🌟"), settingsRepository.savedRecentEmojis)
             }
         }
 
@@ -317,6 +326,46 @@ class HomePresenterEditTest {
             }
         }
 
+    @Test
+    fun recentEmojiWritesAreSerializedInSelectionOrder() =
+        runTest {
+            val mainCell = cell(id = 10L, title = "기존 목표")
+            val firstSaveStarted = CompletableDeferred<Unit>()
+            val allowFirstSave = CompletableDeferred<Unit>()
+            val repository = repositoryWithCells(mainCell = mainCell)
+            val settingsRepository =
+                FakeSettingsRepository(
+                    beforeRecentEmojiSave = { emoji ->
+                        if (emoji == "🌟") {
+                            firstSaveStarted.complete(Unit)
+                            allowFirstSave.await()
+                        }
+                    },
+                )
+            val presenter = presenter(repository, settingsRepository)
+
+            presenter.test {
+                var state = awaitLoadedBandalart(1L)
+                state.eventSink(HomeScreen.Event.OpenEmoji)
+                do {
+                    state = awaitItem()
+                } while (state.bottomSheet !is HomeScreen.BottomSheetState.Emoji)
+
+                state.eventSink(HomeScreen.Event.UpdateBandalartEmoji(1L, mainCell.id, "🌟"))
+                firstSaveStarted.await()
+
+                state.eventSink(HomeScreen.Event.OpenCell(CellType.MAIN, false, mainCell))
+                state = awaitCellSheet()
+                state.eventSink(HomeScreen.Event.UpdateEmojiDraft("🚀"))
+                allowFirstSave.complete(Unit)
+                do {
+                    state = awaitItem()
+                } while (settingsRepository.recentEmojis.value != listOf("🚀", "🌟"))
+
+                assertEquals(listOf("🚀", "🌟"), settingsRepository.recentEmojis.value)
+            }
+        }
+
     private fun repositoryWithCells(
         mainCell: BandalartCellEntity,
         childCells: Map<Long, List<BandalartCellEntity>> = emptyMap(),
@@ -327,12 +376,15 @@ class HomePresenterEditTest {
         childCells = childCells,
     )
 
-    private fun presenter(repository: FakeBandalartRepository) =
+    private fun presenter(
+        repository: FakeBandalartRepository,
+        settingsRepository: FakeSettingsRepository = FakeSettingsRepository(),
+    ) =
         HomePresenter(
             navigator = FakeNavigator(HomeScreen),
             bandalartRepository = repository,
             inAppUpdateRepository = FakeInAppUpdateRepository(),
-            settingsRepository = FakeSettingsRepository(),
+            settingsRepository = settingsRepository,
         )
 
     private suspend fun ReceiveTurbine<HomeScreen.State>.awaitLoadedBandalart(bandalartId: Long,): HomeScreen.State {

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeBottomSheets.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeBottomSheets.kt
@@ -41,6 +41,7 @@ internal fun HomeBottomSheets(
                 isBlankCell = bottomSheet.initialCellData.title.isNullOrEmpty(),
                 onHomeUiAction = eventSink,
                 bottomSheetData = bottomSheet,
+                recentEmojis = state.recentEmojis,
             )
         }
 
@@ -49,6 +50,7 @@ internal fun HomeBottomSheets(
                 bandalartId = bottomSheet.bandalartId,
                 cellId = bottomSheet.cellId,
                 currentEmoji = bottomSheet.currentEmoji,
+                recentEmojis = state.recentEmojis,
                 onHomeUiAction = eventSink,
             )
         }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
@@ -43,6 +43,7 @@ data object HomeScreen : ParcelableScreen, StaticScreen {
         val imageRequest: ImageRequest? = null,
         val updateVersionCode: Int? = null,
         val themeMode: ThemeMode = ThemeMode.SYSTEM,
+        val recentEmojis: ImmutableList<String> = persistentListOf(),
         val effect: Effect? = null,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -79,7 +79,18 @@ class HomePresenter(
         val completingTaskCellIds = remember { mutableSetOf<Long>() }
         val pendingEffects = remember { ArrayDeque<HomeScreen.Effect>() }
         val themeMode by settingsRepository.themeMode.collectAsState(initial = ThemeMode.SYSTEM)
+        val recentEmojis by settingsRepository.recentEmojis.collectAsState(initial = emptyList())
         val scope = rememberCoroutineScope()
+        val recentEmojiSaveJob = remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
+
+        fun recordRecentEmoji(emoji: String) {
+            val previousJob = recentEmojiSaveJob.value
+            recentEmojiSaveJob.value =
+                scope.launch {
+                    previousJob?.join()
+                    settingsRepository.addRecentEmoji(emoji)
+                }
+        }
 
         fun emitEffect(newEffect: HomeScreen.Effect) {
             if (effect == newEffect || pendingEffects.lastOrNull() == newEffect) return
@@ -252,13 +263,14 @@ class HomePresenter(
                 )
         }
 
-        fun updateEmojiDraft(emoji: String) {
-            val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.Cell ?: return
+        fun updateEmojiDraft(emoji: String): Boolean {
+            val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.Cell ?: return false
             bottomSheet =
                 currentSheet.copy(
                     bandalartData = currentSheet.bandalartData.copy(profileEmoji = emoji),
                     isEmojiPickerOpened = false,
                 )
+            return true
         }
 
         fun updateThemeColor(
@@ -459,6 +471,7 @@ class HomePresenter(
             imageRequest = imageRequest,
             updateVersionCode = updateVersionCode,
             themeMode = themeMode,
+            recentEmojis = recentEmojis.toPersistentList(),
             effect = effect,
         ) { event ->
             when (event) {
@@ -518,7 +531,11 @@ class HomePresenter(
                 is HomeScreen.Event.UpdateDescription -> updateDescription(event.description)
                 is HomeScreen.Event.UpdateDueDate -> updateDueDate(event.dueDate)
                 is HomeScreen.Event.UpdateCompletion -> updateCompletion(event.isCompleted)
-                is HomeScreen.Event.UpdateEmojiDraft -> updateEmojiDraft(event.emoji)
+                is HomeScreen.Event.UpdateEmojiDraft -> {
+                    if (updateEmojiDraft(event.emoji)) {
+                        recordRecentEmoji(event.emoji)
+                    }
+                }
                 is HomeScreen.Event.UpdateThemeColor ->
                     updateThemeColor(
                         mainColor = event.mainColor,
@@ -548,6 +565,7 @@ class HomePresenter(
                     ) {
                         isUpdatingBandalartEmoji = true
                         bottomSheet = null
+                        event.emoji?.let(::recordRecentEmoji)
                         scope.launch {
                             try {
                                 updateBandalartEmoji(

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -81,11 +81,12 @@ class HomePresenter(
         val themeMode by settingsRepository.themeMode.collectAsState(initial = ThemeMode.SYSTEM)
         val recentEmojis by settingsRepository.recentEmojis.collectAsState(initial = emptyList())
         val scope = rememberCoroutineScope()
-        val recentEmojiSaveJob = remember { mutableStateOf<kotlinx.coroutines.Job?>(null) }
+        val recentEmojiSaveJobs = remember { mutableListOf<kotlinx.coroutines.Job>() }
 
         fun recordRecentEmoji(emoji: String) {
-            val previousJob = recentEmojiSaveJob.value
-            recentEmojiSaveJob.value =
+            val previousJob = recentEmojiSaveJobs.lastOrNull()
+            recentEmojiSaveJobs.clear()
+            recentEmojiSaveJobs +=
                 scope.launch {
                     previousJob?.join()
                     settingsRepository.addRecentEmoji(emoji)

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartBottomSheet.kt
@@ -104,6 +104,7 @@ fun BandalartBottomSheet(
     cellType: CellType,
     isBlankCell: Boolean,
     bottomSheetData: HomeScreen.BottomSheetState.Cell,
+    recentEmojis: List<String>,
     onHomeUiAction: (HomeScreen.Event) -> Unit,
 ) {
     val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -267,6 +268,7 @@ fun BandalartBottomSheet(
                                                 ),
                                         ),
                                 currentEmoji = bottomSheetData.bandalartData.profileEmoji,
+                                recentEmojis = recentEmojis,
                                 isBottomSheet = false,
                                 onEmojiSelect = { selectedEmoji ->
                                     onHomeUiAction(HomeScreen.Event.UpdateEmojiDraft(selectedEmoji))
@@ -457,6 +459,7 @@ private fun BandalartMainCellBottomSheetPreview() {
                     initialBandalartData = dummyBandalartData,
                     bandalartData = dummyBandalartData,
                 ),
+            recentEmojis = listOf("🎯", "🚀"),
             onHomeUiAction = {},
         )
     }
@@ -478,6 +481,7 @@ private fun BandalartSubCellBottomSheetPreview() {
                     initialBandalartData = dummyBandalartData,
                     bandalartData = dummyBandalartData,
                 ),
+            recentEmojis = listOf("🎯", "🚀"),
             onHomeUiAction = {},
         )
     }
@@ -499,6 +503,7 @@ private fun BandalartTaskCellBottomSheetPreview() {
                     initialBandalartData = dummyBandalartData,
                     bandalartData = dummyBandalartData,
                 ),
+            recentEmojis = listOf("🎯", "🚀"),
             onHomeUiAction = {},
         )
     }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartEmojiBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartEmojiBottomSheet.kt
@@ -32,6 +32,7 @@ fun BandalartEmojiBottomSheet(
     bandalartId: Long,
     cellId: Long,
     currentEmoji: String?,
+    recentEmojis: List<String>,
     onHomeUiAction: (HomeScreen.Event) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -47,6 +48,7 @@ fun BandalartEmojiBottomSheet(
     ) {
         BandalartEmojiPicker(
             currentEmoji = currentEmoji,
+            recentEmojis = recentEmojis,
             isBottomSheet = true,
             onEmojiSelect = { selectedEmoji ->
                 onHomeUiAction(
@@ -73,6 +75,7 @@ private fun BandalartEmojiBottomSheetPreview() {
             bandalartId = 0L,
             cellId = 0L,
             currentEmoji = "😎",
+            recentEmojis = listOf("🎯", "🚀"),
             onHomeUiAction = {},
         )
     }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartEmojiPicker.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartEmojiPicker.kt
@@ -23,6 +23,7 @@ import com.nexters.bandalart.core.ui.component.emoji.FluentEmojiPicker
 @Composable
 fun BandalartEmojiPicker(
     currentEmoji: String?,
+    recentEmojis: List<String>,
     isBottomSheet: Boolean,
     onEmojiSelect: (String) -> Unit,
     onClose: () -> Unit,
@@ -30,6 +31,7 @@ fun BandalartEmojiPicker(
 ) {
     FluentEmojiPicker(
         currentEmoji = currentEmoji,
+        recentEmojis = recentEmojis,
         onEmojiSelect = onEmojiSelect,
         onClose = onClose,
         modifier = modifier,


### PR DESCRIPTION
## 🔗 관련 이슈

- Refs #212

## 📙 작업 설명

- 선택한 이모지를 KMP DataStore에 중복 없이 최신순 최대 12개까지 저장합니다.
- 이모지 피커에 최근 사용 카테고리를 추가하고, 유효한 기록이 있을 때만 노출합니다.
- 독립 이모지 시트와 셀 편집 draft의 선택을 모두 기록하며 비동기 저장도 선택 순서대로 직렬화합니다.
- 현재 300개 catalog에서 제거된 저장값은 UI에서 자동 제외하고 검색 필터를 함께 지원합니다.
- 한국어·영어·일본어 최근 사용 라벨과 DataStore·repository·catalog·Presenter 테스트를 추가했습니다.

## 🧪 테스트 내역 (선택)

- [x] DataStore 초기값·최신순·중복 제거·12개 상한 host test 추가
- [x] repository Flow 및 저장 위임 test 추가
- [x] catalog 외 저장값 제외·최근순·검색 test 추가
- [x] standalone·cell draft 기록 및 지연 저장 순서 Presenter test 추가
- [x] 코드 리뷰 2회 및 재검토 통과
- [x] XML parsing, git diff --check
- [ ] Android/iOS 빌드와 전체 테스트는 CI에서 확인

## 📸 스크린샷 또는 시연 영상 (선택)

- 실기기 UI 검증은 후속 Internal Testing 단계에서 진행합니다.

## 💬 추가 설명 or 리뷰 포인트 (선택)

- 사용자 목표나 개인 콘텐츠가 아니라 선택한 Unicode 목록만 저장합니다.
- 출시 artifact 크기 및 Internal Testing 검증이 남아 있어 #212는 이 PR에서 닫지 않습니다.
- 전체 전략과 성공 기준은 docs/FLUENT_EMOJI_PICKER_MIGRATION_STRATEGY.md에 기록했습니다.
