### PR TITLE
fix: 이모지 선택기 기존 UI 복원

### DIFF
--- a/core/ui/src/commonMain/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiPicker.kt
+++ b/core/ui/src/commonMain/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiPicker.kt
@@ -20,29 +20,21 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -51,148 +43,75 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import bandalart.core.designsystem.generated.resources.Res
-import bandalart.core.designsystem.generated.resources.emoji_picker_category_activities
-import bandalart.core.designsystem.generated.resources.emoji_picker_category_all
-import bandalart.core.designsystem.generated.resources.emoji_picker_category_flags
-import bandalart.core.designsystem.generated.resources.emoji_picker_category_food
-import bandalart.core.designsystem.generated.resources.emoji_picker_category_nature
-import bandalart.core.designsystem.generated.resources.emoji_picker_category_objects
-import bandalart.core.designsystem.generated.resources.emoji_picker_category_people
-import bandalart.core.designsystem.generated.resources.emoji_picker_category_recent
-import bandalart.core.designsystem.generated.resources.emoji_picker_category_smileys
-import bandalart.core.designsystem.generated.resources.emoji_picker_category_symbols
-import bandalart.core.designsystem.generated.resources.emoji_picker_category_travel
-import bandalart.core.designsystem.generated.resources.emoji_picker_close
-import bandalart.core.designsystem.generated.resources.emoji_picker_empty
-import bandalart.core.designsystem.generated.resources.emoji_picker_reset
-import bandalart.core.designsystem.generated.resources.emoji_picker_search_placeholder
-import bandalart.core.designsystem.generated.resources.emoji_picker_title
 import com.nexters.bandalart.core.common.getLocale
 import com.nexters.bandalart.core.ui.NavigationBarHeightDp
-import org.jetbrains.compose.resources.stringResource
+
+private const val PICKER_COLUMN_COUNT = 6
+private const val PICKER_VISIBLE_ROW_COUNT = 4
+private val PICKER_CELL_SPACING = 8.dp
 
 @Composable
 fun FluentEmojiPicker(
     currentEmoji: String?,
     recentEmojis: List<String>,
     onEmojiSelect: (String) -> Unit,
-    onClose: () -> Unit,
     modifier: Modifier = Modifier,
     expanded: Boolean = false,
 ) {
-    var query by rememberSaveable { mutableStateOf("") }
-    var selectedCategoryName by rememberSaveable { mutableStateOf<String?>(null) }
     var selectedEmoji by rememberSaveable(currentEmoji) { mutableStateOf(currentEmoji) }
-
-    val availableRecentEmojis =
+    val pickerItems =
         remember(recentEmojis) {
-            recentEmojis
-                .distinct()
-                .filter { FluentEmojiCatalog.resourceKeyFor(it) != null }
+            val recentItems =
+                filterFluentEmojiItems(
+                    query = "",
+                    category = FluentEmojiCategory.RECENT,
+                    recentEmojis = recentEmojis,
+                )
+            recentItems + FluentEmojiCatalog.items.filterNot { it in recentItems }
         }
-    val selectedCategory =
-        selectedCategoryName
-            ?.let { FluentEmojiCategory.valueOf(it) }
-            ?.takeUnless {
-                it == FluentEmojiCategory.RECENT && availableRecentEmojis.isEmpty()
-            }
-    val filteredItems =
-        remember(query, selectedCategory, availableRecentEmojis) {
-            filterFluentEmojiItems(
-                query = query,
-                category = selectedCategory,
-                recentEmojis = availableRecentEmojis,
-            )
-        }
-    val sizeModifier =
-        if (expanded) {
-            Modifier.fillMaxHeight()
-        } else {
-            Modifier.heightIn(min = 360.dp, max = 480.dp)
-        }
+    val horizontalPadding = if (expanded) 23.dp else 8.dp
+    val topPadding = if (expanded) 23.dp else 8.dp
+    val bottomPadding = if (expanded) 26.dp else 0.dp
 
-    Column(
+    BoxWithConstraints(
         modifier =
             modifier
-                .then(sizeModifier)
                 .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surface),
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(top = if (expanded) 16.dp else 0.dp),
     ) {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(start = 20.dp, top = 12.dp, end = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Text(
-                text = stringResource(Res.string.emoji_picker_title),
-                style = MaterialTheme.typography.titleLarge,
-                color = MaterialTheme.colorScheme.onSurface,
-            )
-            TextButton(onClick = onClose) {
-                Text(text = stringResource(Res.string.emoji_picker_close))
-            }
-        }
+        val cellSize =
+            (maxWidth -
+                horizontalPadding * 2 -
+                PICKER_CELL_SPACING * (PICKER_COLUMN_COUNT - 1)) / PICKER_COLUMN_COUNT
+        val gridHeight =
+            topPadding +
+                bottomPadding +
+                cellSize * PICKER_VISIBLE_ROW_COUNT +
+                PICKER_CELL_SPACING * (PICKER_VISIBLE_ROW_COUNT - 1)
 
-        OutlinedTextField(
-            value = query,
-            onValueChange = { query = it },
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-            placeholder = {
-                Text(text = stringResource(Res.string.emoji_picker_search_placeholder))
-            },
-            singleLine = true,
-            shape = RoundedCornerShape(14.dp),
-        )
-
-        EmojiCategoryRow(
-            selectedCategory = selectedCategory,
-            hasRecentEmojis = availableRecentEmojis.isNotEmpty(),
-            onCategorySelect = { category ->
-                selectedCategoryName = category?.name
-            },
-        )
-
-        if (filteredItems.isEmpty()) {
-            EmojiPickerEmptyState(
-                onReset = {
-                    query = ""
-                    selectedCategoryName = null
-                },
-                modifier = Modifier.weight(1f),
-            )
-        } else {
+        Column(modifier = Modifier.fillMaxWidth()) {
             LazyVerticalGrid(
-                columns = GridCells.Adaptive(minSize = 56.dp),
+                columns = GridCells.Fixed(PICKER_COLUMN_COUNT),
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .weight(1f),
+                        .height(gridHeight),
                 contentPadding =
                     PaddingValues(
-                        start = 16.dp,
-                        top = 12.dp,
-                        end = 16.dp,
-                        bottom = if (expanded) NavigationBarHeightDp + 16.dp else 16.dp,
+                        start = horizontalPadding,
+                        top = topPadding,
+                        end = horizontalPadding,
+                        bottom = bottomPadding,
                     ),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(PICKER_CELL_SPACING),
+                verticalArrangement = Arrangement.spacedBy(PICKER_CELL_SPACING),
             ) {
                 items(
-                    items = filteredItems,
+                    items = pickerItems,
                     key = FluentEmojiItem::unicode,
                 ) { item ->
                     FluentEmojiPickerCell(
@@ -207,63 +126,7 @@ fun FluentEmojiPicker(
                     )
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun EmojiCategoryRow(
-    selectedCategory: FluentEmojiCategory?,
-    hasRecentEmojis: Boolean,
-    onCategorySelect: (FluentEmojiCategory?) -> Unit,
-) {
-    val categories =
-        remember(hasRecentEmojis) {
-            listOf(null) +
-                (if (hasRecentEmojis) listOf(FluentEmojiCategory.RECENT) else emptyList()) +
-                FluentEmojiCategory.entries.filterNot { it == FluentEmojiCategory.RECENT }
-        }
-    LazyRow(
-        modifier = Modifier.fillMaxWidth(),
-        contentPadding = PaddingValues(horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        items(
-            items = categories,
-            key = { it?.name ?: "all" },
-        ) { category ->
-            val selected = selectedCategory == category
-            Surface(
-                modifier =
-                    Modifier.selectable(
-                        selected = selected,
-                        onClick = { onCategorySelect(category) },
-                    ),
-                shape = RoundedCornerShape(50),
-                color =
-                    if (selected) {
-                        MaterialTheme.colorScheme.primaryContainer
-                    } else {
-                        MaterialTheme.colorScheme.surfaceVariant
-                    },
-                border =
-                    BorderStroke(
-                        width = 1.dp,
-                        color =
-                            if (selected) {
-                                MaterialTheme.colorScheme.primary
-                            } else {
-                                MaterialTheme.colorScheme.outline
-                            },
-                    ),
-            ) {
-                Text(
-                    text = categoryLabel(category),
-                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.onSurface,
-                )
-            }
+            Box(modifier = Modifier.height(NavigationBarHeightDp))
         }
     }
 }
@@ -275,100 +138,38 @@ private fun FluentEmojiPickerCell(
     onClick: () -> Unit,
 ) {
     val contentDescription = item.displayName(getLocale().language)
-    Surface(
-        modifier =
-            Modifier
-                .aspectRatio(1f)
-                .selectable(
-                    selected = selected,
-                    onClick = onClick,
-                ).semantics(mergeDescendants = true) {
-                    this.contentDescription = contentDescription
-                },
-        shape = RoundedCornerShape(14.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant,
+
+    Card(
+        modifier = Modifier.aspectRatio(1f),
+        shape = RoundedCornerShape(12.dp),
         border =
-            BorderStroke(
-                width = if (selected) 2.dp else 1.dp,
-                color =
-                    if (selected) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.outline
-                    },
-            ),
+            if (selected) {
+                BorderStroke(
+                    width = 1.dp,
+                    color = MaterialTheme.colorScheme.outline,
+                )
+            } else {
+                null
+            },
     ) {
         Box(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .padding(8.dp),
+                    .background(MaterialTheme.colorScheme.surfaceVariant)
+                    .selectable(
+                        selected = selected,
+                        onClick = onClick,
+                    ).semantics(mergeDescendants = true) {
+                        this.contentDescription = contentDescription
+                    },
             contentAlignment = Alignment.Center,
         ) {
             BandalartEmoji(
                 unicode = item.unicode,
                 contentDescription = null,
-                size = 32.dp,
+                size = 24.dp,
             )
-            if (selected) {
-                Box(
-                    modifier =
-                        Modifier
-                            .align(Alignment.TopEnd)
-                            .size(16.dp)
-                            .clip(CircleShape)
-                            .background(MaterialTheme.colorScheme.primary)
-                            .clearAndSetSemantics { },
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = "✓",
-                        color = MaterialTheme.colorScheme.onPrimary,
-                        fontSize = 10.sp,
-                        lineHeight = 10.sp,
-                        fontWeight = FontWeight.Bold,
-                    )
-                }
-            }
         }
     }
 }
-
-@Composable
-private fun EmojiPickerEmptyState(
-    onReset: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier = modifier.fillMaxWidth(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(
-                text = stringResource(Res.string.emoji_picker_empty),
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            TextButton(onClick = onReset) {
-                Text(text = stringResource(Res.string.emoji_picker_reset))
-            }
-        }
-    }
-}
-
-@Composable
-private fun categoryLabel(category: FluentEmojiCategory?): String =
-    stringResource(
-        when (category) {
-            null -> Res.string.emoji_picker_category_all
-            FluentEmojiCategory.RECENT -> Res.string.emoji_picker_category_recent
-            FluentEmojiCategory.SMILEYS_AND_EMOTION -> Res.string.emoji_picker_category_smileys
-            FluentEmojiCategory.PEOPLE_AND_BODY -> Res.string.emoji_picker_category_people
-            FluentEmojiCategory.ANIMALS_AND_NATURE -> Res.string.emoji_picker_category_nature
-            FluentEmojiCategory.FOOD_AND_DRINK -> Res.string.emoji_picker_category_food
-            FluentEmojiCategory.TRAVEL_AND_PLACES -> Res.string.emoji_picker_category_travel
-            FluentEmojiCategory.ACTIVITIES -> Res.string.emoji_picker_category_activities
-            FluentEmojiCategory.OBJECTS -> Res.string.emoji_picker_category_objects
-            FluentEmojiCategory.SYMBOLS -> Res.string.emoji_picker_category_symbols
-            FluentEmojiCategory.FLAGS -> Res.string.emoji_picker_category_flags
-        },
-    )

--- a/docs/EMOJI_PICKER_LEGACY_UI_STRATEGY.md
+++ b/docs/EMOJI_PICKER_LEGACY_UI_STRATEGY.md
@@ -1,0 +1,55 @@
+# 이모지 선택기 기존 UI 복원 전략
+
+## 배경
+
+Fluent Emoji 300개 catalog를 도입하면서 기존의 단순한 6열 이모지 grid가 제목, 닫기 버튼, 검색창, 카테고리 chip과 화면 대부분을 차지하는 picker로 변경됐다. 기능은 확장됐지만 반다라트의 기존 ModalBottomSheet와 시각적 밀도·구조가 크게 달라졌다.
+
+이번 작업은 Fluent Emoji resource와 Unicode 저장 방식을 유지하면서 선택 UI만 기존 형태로 되돌린다.
+
+## 목표
+
+- 기존 picker의 6열 카드 grid, padding, 12dp corner, 24dp 이모지와 1dp 선택 테두리를 복원한다.
+- 제목, 닫기 버튼, 검색 field, 카테고리 chip과 선택 check badge를 노출하지 않는다.
+- 기존 4개 행에 해당하는 높이를 viewport로 사용하고 300개 catalog는 세로 스크롤로 탐색한다.
+- 최근 사용 항목은 별도 탭을 추가하지 않고 같은 grid의 앞쪽에 배치한다.
+- ModalBottomSheet가 화면 높이의 92%를 강제로 차지하지 않고 콘텐츠 높이에 맞게 표시되도록 복원한다.
+- 선택 즉시 저장/편집 draft 반영, Unicode DB 저장과 legacy Unicode fallback은 변경하지 않는다.
+
+## 구현 범위
+
+1. `FluentEmojiPicker`
+   - 최근 사용 항목과 나머지 300개 catalog를 `LazyVerticalGrid(GridCells.Fixed(6))`로 표시한다.
+   - 화면 너비와 기존 padding/gap을 기준으로 cell 크기와 4개 행 viewport 높이를 계산한다.
+   - 기존 Card/Box 기반 선택 스타일을 적용한다.
+   - grid 자체만 세로 스크롤되도록 한다.
+2. `BandalartEmojiBottomSheet`
+   - `fillMaxHeight(0.92f)`를 제거하고 기존 `wrapContentSize()`를 적용한다.
+3. 호출부
+   - 기존 UI에 없던 picker 내부 닫기 action을 제거한다.
+   - 외부 탭, back 또는 sheet dismiss 동작은 유지한다.
+
+## 비범위
+
+- Fluent catalog, resource pipeline 또는 Unicode 저장 형식 변경
+- 기존 Unicode를 다른 이모지로 migration
+- Presenter, Room, DataStore 또는 최근 사용 저장 로직 변경
+- 이모지 catalog 개수 변경
+- 인접 화면 리팩터링
+
+## 검증
+
+- catalog 300개 및 Unicode-resource mapping 단위 테스트 통과
+- Home Presenter의 이모지 선택/저장 관련 테스트 통과
+- ktlint 통과
+- 수동 확인 항목
+  - ModalBottomSheet가 기존과 유사한 높이·padding·6열 grid로 표시됨
+  - 4개 행 이후 세로 스크롤 가능
+  - 선택한 이모지에 기존 1dp outline 표시
+  - catalog 밖 legacy Unicode가 기존 화면에서 시스템 이모지로 유지됨
+  - sheet dismiss와 편집 draft 저장 의미 유지
+
+## 완료 조건
+
+- Fluent Emoji를 유지하면서 사용자가 기존 반다라트 picker와 같은 UI로 인식한다.
+- 300개 항목 때문에 sheet가 화면 대부분을 점유하지 않고 grid 내부에서만 스크롤된다.
+- 기존 저장 데이터와 선택 event 흐름에 회귀가 없다.

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartBottomSheet.kt
@@ -273,9 +273,6 @@ fun BandalartBottomSheet(
                                 onEmojiSelect = { selectedEmoji ->
                                     onHomeUiAction(HomeScreen.Event.UpdateEmojiDraft(selectedEmoji))
                                 },
-                                onClose = {
-                                    onHomeUiAction(HomeScreen.Event.CloseEmojiPicker)
-                                },
                             )
                         }
                     }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartEmojiBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartEmojiBottomSheet.kt
@@ -16,7 +16,7 @@
 
 package com.nexters.bandalart.feature.home.ui.bandalart
 
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -42,7 +42,7 @@ fun BandalartEmojiBottomSheet(
         onDismissRequest = {
             onHomeUiAction(HomeScreen.Event.DismissBottomSheet)
         },
-        modifier = modifier.fillMaxHeight(0.92f),
+        modifier = modifier.wrapContentSize(),
         sheetState = bottomSheetState,
         dragHandle = null,
     ) {
@@ -58,9 +58,6 @@ fun BandalartEmojiBottomSheet(
                         emoji = selectedEmoji,
                     ),
                 )
-            },
-            onClose = {
-                onHomeUiAction(HomeScreen.Event.DismissBottomSheet)
             },
         )
     }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartEmojiPicker.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartEmojiPicker.kt
@@ -26,14 +26,12 @@ fun BandalartEmojiPicker(
     recentEmojis: List<String>,
     isBottomSheet: Boolean,
     onEmojiSelect: (String) -> Unit,
-    onClose: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     FluentEmojiPicker(
         currentEmoji = currentEmoji,
         recentEmojis = recentEmojis,
         onEmojiSelect = onEmojiSelect,
-        onClose = onClose,
         modifier = modifier,
         expanded = isBottomSheet,
     )


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #212

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- Fluent Emoji 300개 카탈로그와 Unicode 저장 방식을 유지하면서 기존 6열 이모지 선택 UI를 복원했습니다.
- 검색·카테고리·닫기 UI를 제거하고 기존 4행 높이 안에서 그리드만 세로 스크롤되도록 변경했습니다.
- 기존 카드 크기, 간격, 선택 테두리와 바텀시트 콘텐츠 높이를 복원했습니다.
- 구현 전략과 비범위·검증 기준을 문서화했습니다.

## 🧪 테스트 내역 (선택)

- [ ] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 기능 설명 | <img src="링크" width="300" /> | 기능 설명 | <img src="링크" width="300" /> |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 전체 빌드는 저장소 지침에 따라 실행하지 않았으며, CI에서 정적 검사·테스트·빌드를 확인합니다.
