### PR TITLE
feat: 반다라트 슬롯 정책 및 AdMob SDK 기반 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,6 +31,9 @@ android {
         getByName("debug") {
             isDebuggable = true
             applicationIdSuffix = ".dev"
+            resValue("string", "admob_app_id", "ca-app-pub-3940256099942544~3347511713")
+            resValue("string", "admob_rewarded_ad_unit_id", "ca-app-pub-3940256099942544/5224354917")
+            resValue("string", "admob_banner_ad_unit_id", "ca-app-pub-3940256099942544/9214589741")
             manifestPlaceholders += mapOf(
                 "appName" to "@string/app_name_dev",
             )
@@ -41,6 +44,9 @@ android {
             isMinifyEnabled = true
             isShrinkResources = true
             signingConfig = signingConfigs.getByName("release")
+            resValue("string", "admob_app_id", "ca-app-pub-5570932833347277~6079637815")
+            resValue("string", "admob_rewarded_ad_unit_id", "ca-app-pub-5570932833347277/6659503579")
+            resValue("string", "admob_banner_ad_unit_id", "ca-app-pub-5570932833347277/1215605203")
             manifestPlaceholders += mapOf(
                 "appName" to "@string/app_name",
             )
@@ -87,6 +93,7 @@ dependencies {
         libs.androidx.core,
         libs.androidx.navigation.compose,
         libs.androidx.hilt.navigation.compose,
+        libs.google.mobile.ads.next.gen,
         libs.timber,
 
         libs.bundles.circuit

--- a/app/src/main/kotlin/com/nexters/bandalart/MainActivity.kt
+++ b/app/src/main/kotlin/com/nexters/bandalart/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color.Companion.White
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import com.nexters.bandalart.ads.AdsInitializer
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
 import com.nexters.bandalart.core.designsystem.theme.Gray50
 import com.nexters.bandalart.feature.home.ShareScreen
@@ -38,9 +39,13 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var circuit: Circuit
 
+    @Inject
+    lateinit var adsInitializer: AdsInitializer
+
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         super.onCreate(savedInstanceState)
+        adsInitializer.initialize()
         enableEdgeToEdge(
             statusBarStyle = SystemBarStyle.light(TRANSPARENT, TRANSPARENT),
             navigationBarStyle = SystemBarStyle.light(TRANSPARENT, TRANSPARENT),

--- a/app/src/main/kotlin/com/nexters/bandalart/ads/AdsInitializer.kt
+++ b/app/src/main/kotlin/com/nexters/bandalart/ads/AdsInitializer.kt
@@ -1,0 +1,41 @@
+package com.nexters.bandalart.ads
+
+import android.content.Context
+import com.google.android.libraries.ads.mobile.sdk.MobileAds
+import com.google.android.libraries.ads.mobile.sdk.initialization.InitializationConfig
+import com.nexters.bandalart.R
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@Singleton
+class AdsInitializer @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val isInitializationStarted = AtomicBoolean(false)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    fun initialize() {
+        if (!isInitializationStarted.compareAndSet(false, true)) return
+
+        scope.launch {
+            runCatching {
+                MobileAds.initialize(
+                    context,
+                    InitializationConfig.Builder(context.getString(R.string.admob_app_id)).build(),
+                ) {
+                    Timber.d("GMA Next-Gen SDK initialized")
+                }
+            }.onFailure { exception ->
+                isInitializationStarted.set(false)
+                Timber.e(exception, "GMA Next-Gen SDK initialization failed")
+            }
+        }
+    }
+}

--- a/core/data/src/main/kotlin/com/nexters/bandalart/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/kotlin/com/nexters/bandalart/core/data/di/RepositoryModule.kt
@@ -1,10 +1,12 @@
 package com.nexters.bandalart.core.data.di
 
 import com.nexters.bandalart.core.data.repository.BandalartRepositoryImpl
+import com.nexters.bandalart.core.data.repository.BandalartSlotRepositoryImpl
 import com.nexters.bandalart.core.data.repository.GuestLoginTokenRepositoryImpl
 import com.nexters.bandalart.core.data.repository.InAppUpdateRepositoryImpl
 import com.nexters.bandalart.core.data.repository.OnboardingRepositoryImpl
 import com.nexters.bandalart.core.domain.repository.BandalartRepository
+import com.nexters.bandalart.core.domain.repository.BandalartSlotRepository
 import com.nexters.bandalart.core.domain.repository.GuestLoginTokenRepository
 import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
 import com.nexters.bandalart.core.domain.repository.OnboardingRepository
@@ -29,6 +31,12 @@ internal abstract class RepositoryModule {
     abstract fun bindBandalartRepository(
         bandalartRepositoryImpl: BandalartRepositoryImpl,
     ): BandalartRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindBandalartSlotRepository(
+        bandalartSlotRepositoryImpl: BandalartSlotRepositoryImpl,
+    ): BandalartSlotRepository
 
     @Binds
     @Singleton

--- a/core/data/src/main/kotlin/com/nexters/bandalart/core/data/repository/BandalartSlotRepositoryImpl.kt
+++ b/core/data/src/main/kotlin/com/nexters/bandalart/core/data/repository/BandalartSlotRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.nexters.bandalart.core.data.repository
+
+import com.nexters.bandalart.core.datastore.BandalartDataStore
+import com.nexters.bandalart.core.domain.policy.resolveMaxBandalartSlots
+import com.nexters.bandalart.core.domain.repository.BandalartSlotRepository
+import javax.inject.Inject
+
+internal class BandalartSlotRepositoryImpl @Inject constructor(
+    private val bandalartDataStore: BandalartDataStore,
+) : BandalartSlotRepository {
+    override suspend fun getMaxBandalartSlots(currentBandalartCount: Int): Int {
+        return bandalartDataStore.resolveMaxBandalartSlots(
+            minimumSlots = resolveMaxBandalartSlots(currentBandalartCount),
+        )
+    }
+
+    override suspend fun expandMaxBandalartSlots(currentBandalartCount: Int): Int {
+        return bandalartDataStore.expandMaxBandalartSlots(
+            minimumSlots = resolveMaxBandalartSlots(currentBandalartCount),
+        )
+    }
+}

--- a/core/datastore/src/main/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStore.kt
+++ b/core/datastore/src/main/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStore.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import java.io.IOException
@@ -24,12 +25,32 @@ class BandalartDataStore @Inject constructor(
         private const val RECENT_BANDALART_ID = "recent_bandalart_id"
         private const val COMPLETED_BANDALART_LIST_ID = "completed_bandalart_list_id"
         private const val ONBOARDING_COMPLETED_ID = "completed_onboarding_id"
+        private const val MAX_BANDALART_SLOTS = "max_bandalart_slots"
     }
 
     private val guestLoginTokenKey = stringPreferencesKey(GUEST_LOGIN_TOKEN)
     private val recentBandalartKey = longPreferencesKey(RECENT_BANDALART_ID)
     private val completedBandalartListKey = stringPreferencesKey(COMPLETED_BANDALART_LIST_ID)
     private val onboardingCompletedKey = booleanPreferencesKey(ONBOARDING_COMPLETED_ID)
+    private val maxBandalartSlotsKey = intPreferencesKey(MAX_BANDALART_SLOTS)
+
+    suspend fun resolveMaxBandalartSlots(minimumSlots: Int): Int {
+        var resolvedSlots = minimumSlots
+        dataStore.edit { preferences ->
+            resolvedSlots = maxOf(preferences[maxBandalartSlotsKey] ?: 0, minimumSlots)
+            preferences[maxBandalartSlotsKey] = resolvedSlots
+        }
+        return resolvedSlots
+    }
+
+    suspend fun expandMaxBandalartSlots(minimumSlots: Int): Int {
+        var expandedSlots = minimumSlots + 1
+        dataStore.edit { preferences ->
+            expandedSlots = maxOf(preferences[maxBandalartSlotsKey] ?: 0, minimumSlots) + 1
+            preferences[maxBandalartSlotsKey] = expandedSlots
+        }
+        return expandedSlots
+    }
 
     suspend fun setGuestLoginToken(guestLoginToken: String) {
         dataStore.edit { preferences ->

--- a/core/domain/src/main/kotlin/com/nexters/bandalart/core/domain/policy/BandalartSlotPolicy.kt
+++ b/core/domain/src/main/kotlin/com/nexters/bandalart/core/domain/policy/BandalartSlotPolicy.kt
@@ -1,0 +1,11 @@
+package com.nexters.bandalart.core.domain.policy
+
+const val FREE_BANDALART_SLOT_COUNT = 3
+
+fun resolveMaxBandalartSlots(currentBandalartCount: Int): Int =
+    maxOf(FREE_BANDALART_SLOT_COUNT, currentBandalartCount)
+
+fun canCreateBandalart(
+    currentBandalartCount: Int,
+    maxBandalartSlots: Int,
+): Boolean = currentBandalartCount < maxBandalartSlots

--- a/core/domain/src/main/kotlin/com/nexters/bandalart/core/domain/repository/BandalartSlotRepository.kt
+++ b/core/domain/src/main/kotlin/com/nexters/bandalart/core/domain/repository/BandalartSlotRepository.kt
@@ -1,0 +1,7 @@
+package com.nexters.bandalart.core.domain.repository
+
+interface BandalartSlotRepository {
+    suspend fun getMaxBandalartSlots(currentBandalartCount: Int): Int
+
+    suspend fun expandMaxBandalartSlots(currentBandalartCount: Int): Int
+}

--- a/core/domain/src/test/kotlin/com/nexters/bandalart/core/domain/policy/BandalartSlotPolicyTest.kt
+++ b/core/domain/src/test/kotlin/com/nexters/bandalart/core/domain/policy/BandalartSlotPolicyTest.kt
@@ -1,0 +1,19 @@
+package com.nexters.bandalart.core.domain.policy
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class BandalartSlotPolicyTest : StringSpec({
+    "기본 슬롯은 3개다" {
+        resolveMaxBandalartSlots(currentBandalartCount = 0) shouldBe 3
+    }
+
+    "기존 사용자가 3개보다 많이 보유하면 현재 개수까지 보장한다" {
+        resolveMaxBandalartSlots(currentBandalartCount = 5) shouldBe 5
+    }
+
+    "현재 개수가 최대 슬롯보다 적을 때만 바로 생성할 수 있다" {
+        canCreateBandalart(currentBandalartCount = 2, maxBandalartSlots = 3) shouldBe true
+        canCreateBandalart(currentBandalartCount = 3, maxBandalartSlots = 3) shouldBe false
+    }
+})

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ gradle-dependency-handler-extensions = "1.1.0"
 
 google-secrets = "2.0.1"
 google-service = "4.4.2"
+google-mobile-ads-next-gen = "1.2.1"
 
 kotlin-core = "2.3.21"
 kotlin-detekt = "1.23.6"
@@ -134,6 +135,7 @@ facebook-shimmer = { group = "com.facebook.shimmer", name = "shimmer", version.r
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics-ktx" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics-ktx" }
+google-mobile-ads-next-gen = { group = "com.google.android.libraries.ads.mobile.sdk", name = "ads-mobile-sdk", version.ref = "google-mobile-ads-next-gen" }
 compose-stable-marker = { group = "com.github.skydoves", name = "compose-stable-marker", version.ref = "compose-stable-marker" }
 
 circuit-foundation = { group = "com.slack.circuit", name = "circuit-foundation", version.ref = "circuit" }

--- a/plugins/yb/skills/create-pr/SKILL.md
+++ b/plugins/yb/skills/create-pr/SKILL.md
@@ -1,17 +1,15 @@
 ---
 name: create-pr
-description: YeoBee Android PR creation workflow in the yb plugin. Use when the user says yb:create-pr, create-pr, create pr, PR 만들어줘, or asks Codex to create a GitHub PR while preserving the project template.
+description: Bandalart Android PR creation workflow. Use when the user says create-pr, create pr, PR 만들어줘, or asks Codex to create a GitHub PR while preserving the project template.
 ---
 
-# YB Create PR
-
-Codex-native migration of Claude `yb:create-pr`. Keep `.claude/plugins/yb/skills/create-pr/SKILL.md` unchanged as legacy reference.
+# Bandalart Create PR
 
 ## Inputs
 
 - Optional `--branch` / `-b`: source branch. Default: current branch.
 - Optional `--base`: target branch. Default: infer from branch history, fallback `develop`.
-- Required reviewer: the working counterpart who should review the PR.
+- Optional `--reviewer`: reviewer to request when the user explicitly names one.
 
 ## Workflow
 
@@ -36,21 +34,16 @@ Codex-native migration of Claude `yb:create-pr`. Keep `.claude/plugins/yb/skills
    - `docs:` -> `📃 docs`
    - `refactor:` -> `🔨 refactor`
    - `test:` -> `✅ test`
-7. Determine the required reviewer.
-   - Reviewer assignment is mandatory and must be the working counterpart for the task.
-   - If the user explicitly named a reviewer, use that reviewer.
-   - Otherwise, determine the current GitHub user with `gh api user --jq .login` and use the YeoBee counterpart mapping:
-     - `easyhooon` -> `LeeOhHyung`
-     - `LeeOhHyung` -> `easyhooon`
-   - If the current user is not in the mapping, ask for the reviewer before showing the preview.
-8. Show a preview with base/head, label, assignee, reviewer, title, and full body. Ask for confirmation before creating the PR.
+7. Use a reviewer only when the user explicitly names one. Do not infer or require a reviewer.
+8. Show a preview with base/head, label, assignee, optional reviewer, title, and full body. Ask for confirmation before creating the PR.
 9. Create the PR with `gh pr create`.
    - Use `--assignee @me`.
-   - Always include `--reviewer {reviewer}`.
-10. Report PR number, URL, title, label, assignee, reviewer, base, and head branch.
+   - Include `--reviewer {reviewer}` only when a reviewer was explicitly provided.
+10. Report PR number, URL, title, label, assignee, optional reviewer, base, and head branch.
 
 ## Constraints
 
 - Do not remove or reshape the PR template.
 - Do not include Codex/Claude boilerplate in the PR body.
+- Do not invent or require a reviewer for this personal project.
 - If `gh` auth or network fails, stop with the failing command context.


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #206

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 반다라트 기본 무료 슬롯을 3개로 정의했습니다.
- 기존 사용자는 현재 보유 개수와 3개 중 큰 값으로 최대 슬롯을 보정합니다.
- 확장된 최대 슬롯을 DataStore에 영구 저장하고 한 번에 1개씩 확장할 수 있는 저장소를 추가했습니다.
- 슬롯 생성 가능 여부와 기존 사용자 보정 정책의 단위 테스트를 추가했습니다.
- 개인 프로젝트 PR workflow에서 리뷰어 지정을 선택 사항으로 변경했습니다.
- GMA Next-Gen SDK 1.2.1을 추가하고 앱 시작 시 백그라운드에서 한 번만 초기화하도록 구성했습니다.
- debug에는 Google 테스트 광고 ID, release에는 AdMob 운영 App·보상형·배너 ID를 적용했습니다.

## 🧪 테스트 내역 (선택)

- [ ] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [ ] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 기능 설명 | <img src="링크" width="300" /> | 기능 설명 | <img src="링크" width="300" /> |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
-

## 💡 코드리뷰 Tip

Gemini Code Assist 리뷰 코멘트가 달리면 Claude Code에서 `/yb:resolve-gemini-review`를 실행하여 미해결 코멘트를 일괄 반영하거나 거절 사유를 남길 수 있습니다.
