### PR TITLE
feat: 반다라트 슬롯 정책 및 AdMob SDK 기반 추가

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -30,6 +30,9 @@ android {
         getByName("debug") {
             isDebuggable = true
             applicationIdSuffix = ".dev"
+            resValue("string", "admob_app_id", "ca-app-pub-3940256099942544~3347511713")
+            resValue("string", "admob_rewarded_ad_unit_id", "ca-app-pub-3940256099942544/5224354917")
+            resValue("string", "admob_banner_ad_unit_id", "ca-app-pub-3940256099942544/9214589741")
             manifestPlaceholders +=
                 mapOf(
                     "appName" to "@string/app_name_dev",
@@ -41,6 +44,9 @@ android {
             isMinifyEnabled = true
             isShrinkResources = true
             signingConfig = signingConfigs.getByName("release")
+            resValue("string", "admob_app_id", "ca-app-pub-5570932833347277~6079637815")
+            resValue("string", "admob_rewarded_ad_unit_id", "ca-app-pub-5570932833347277/6659503579")
+            resValue("string", "admob_banner_ad_unit_id", "ca-app-pub-5570932833347277/1215605203")
             manifestPlaceholders +=
                 mapOf(
                     "appName" to "@string/app_name",
@@ -79,8 +85,10 @@ dependencies {
     implementation(libs.app.update)
 
     implementation(libs.firebase.common)
+    implementation(libs.google.mobile.ads.next.gen)
 
     implementation(libs.cmptoast)
+    implementation(libs.kotlinx.coroutines.core)
     implementation(libs.napier)
     "baselineProfile"(project(":baselineprofile"))
 }

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -60,6 +60,7 @@ android {
 
     buildFeatures {
         buildConfig = true
+        resValues = true
     }
 }
 

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
@@ -19,6 +19,7 @@ package com.nexters.bandalart
 import android.app.Application
 import com.google.firebase.Firebase
 import com.google.firebase.initialize
+import com.nexters.bandalart.ads.AdsInitializer
 import com.nexters.bandalart.di.metro.AppGraph
 import com.nexters.bandalart.di.metro.createAndroidAppGraph
 import io.github.aakira.napier.DebugAntilog
@@ -27,6 +28,7 @@ import io.github.aakira.napier.Napier
 class BandalartApplication : Application() {
     lateinit var appGraph: AppGraph
         private set
+    private val adsInitializer by lazy { AdsInitializer(applicationContext) }
 
     override fun onCreate() {
         super.onCreate()
@@ -38,6 +40,7 @@ class BandalartApplication : Application() {
         }
 
         Firebase.initialize(this)
+        adsInitializer.initialize()
 
         multiplatform.network.cmptoast.AppContext
             .apply { set(applicationContext) }

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AdsInitializer.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AdsInitializer.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.ads
+
+import android.content.Context
+import com.google.android.libraries.ads.mobile.sdk.MobileAds
+import com.google.android.libraries.ads.mobile.sdk.initialization.InitializationConfig
+import com.nexters.bandalart.R
+import io.github.aakira.napier.Napier
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+class AdsInitializer(
+    private val context: Context,
+) {
+    private val isInitializationStarted = AtomicBoolean(false)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    fun initialize() {
+        if (!isInitializationStarted.compareAndSet(false, true)) return
+
+        scope.launch {
+            runCatching {
+                MobileAds.initialize(
+                    context,
+                    InitializationConfig.Builder(context.getString(R.string.admob_app_id)).build(),
+                ) {
+                    Napier.d("GMA Next-Gen SDK initialized", tag = "AdsInitializer")
+                }
+            }.onFailure { exception ->
+                isInitializationStarted.set(false)
+                Napier.e("GMA Next-Gen SDK initialization failed", exception, tag = "AdsInitializer")
+            }
+        }
+    }
+}

--- a/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/di/metro/AppGraphTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/di/metro/AppGraphTest.kt
@@ -60,6 +60,7 @@ class AppGraphTest {
         assertSame(appGraph.imageHandlerProvider, appGraph.imageHandlerProvider)
         assertSame(appGraph.supportMailLauncher, appGraph.supportMailLauncher)
         assertSame(appGraph.bandalartRepository, appGraph.bandalartRepository)
+        assertSame(appGraph.bandalartSlotRepository, appGraph.bandalartSlotRepository)
         assertSame(appGraph.inAppUpdateRepository, appGraph.inAppUpdateRepository)
         assertSame(appGraph.onboardingRepository, appGraph.onboardingRepository)
         assertSame(appGraph.settingsRepository, appGraph.settingsRepository)

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/AppGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/AppGraph.kt
@@ -26,6 +26,7 @@ import com.nexters.bandalart.core.datastore.BandalartDataStore
 import com.nexters.bandalart.core.datastore.BandalartDataStoreFactory
 import com.nexters.bandalart.core.datastore.InAppUpdateDataStore
 import com.nexters.bandalart.core.domain.repository.BandalartRepository
+import com.nexters.bandalart.core.domain.repository.BandalartSlotRepository
 import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
 import com.nexters.bandalart.core.domain.repository.OnboardingRepository
 import com.nexters.bandalart.core.domain.repository.SettingsRepository
@@ -60,6 +61,7 @@ interface AppGraph {
     val imageHandlerProvider: ImageHandlerProvider
     val supportMailLauncher: SupportMailLauncher
     val bandalartRepository: BandalartRepository
+    val bandalartSlotRepository: BandalartSlotRepository
     val inAppUpdateRepository: InAppUpdateRepository
     val onboardingRepository: OnboardingRepository
     val settingsRepository: SettingsRepository

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
@@ -17,6 +17,7 @@
 package com.nexters.bandalart.di.metro
 
 import com.nexters.bandalart.core.data.repository.DefaultBandalartRepository
+import com.nexters.bandalart.core.data.repository.DefaultBandalartSlotRepository
 import com.nexters.bandalart.core.data.repository.DefaultInAppUpdateRepository
 import com.nexters.bandalart.core.data.repository.DefaultOnboardingRepository
 import com.nexters.bandalart.core.data.repository.DefaultSettingsRepository
@@ -24,6 +25,7 @@ import com.nexters.bandalart.core.database.BandalartDao
 import com.nexters.bandalart.core.datastore.BandalartDataStore
 import com.nexters.bandalart.core.datastore.InAppUpdateDataStore
 import com.nexters.bandalart.core.domain.repository.BandalartRepository
+import com.nexters.bandalart.core.domain.repository.BandalartSlotRepository
 import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
 import com.nexters.bandalart.core.domain.repository.OnboardingRepository
 import com.nexters.bandalart.core.domain.repository.SettingsRepository
@@ -40,6 +42,11 @@ object RepositoryBindings {
         bandalartDataStore: BandalartDataStore,
         bandalartDao: BandalartDao,
     ): BandalartRepository = DefaultBandalartRepository(bandalartDataStore, bandalartDao)
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideBandalartSlotRepository(bandalartDataStore: BandalartDataStore): BandalartSlotRepository =
+        DefaultBandalartSlotRepository(bandalartDataStore)
 
     @Provides
     @SingleIn(AppScope::class)

--- a/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/repository/BandalartSlotRepositoryTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/repository/BandalartSlotRepositoryTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.data.repository
+
+import com.nexters.bandalart.core.datastore.BandalartDataStore
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class BandalartSlotRepositoryTest {
+    private val dataStore = mockk<BandalartDataStore>()
+    private val repository = DefaultBandalartSlotRepository(dataStore)
+
+    @Test
+    fun currentCountIsUsedAsTheMinimumForExistingUsers() =
+        runTest {
+            coEvery { dataStore.resolveMaxBandalartSlots(5) } returns 5
+
+            assertEquals(5, repository.getMaxBandalartSlots(currentBandalartCount = 5))
+
+            coVerify(exactly = 1) { dataStore.resolveMaxBandalartSlots(5) }
+        }
+
+    @Test
+    fun expansionUsesTheFreeSlotCountAsTheMinimumForNewUsers() =
+        runTest {
+            coEvery { dataStore.expandMaxBandalartSlots(3) } returns 4
+
+            assertEquals(4, repository.expandMaxBandalartSlots(currentBandalartCount = 2))
+
+            coVerify(exactly = 1) { dataStore.expandMaxBandalartSlots(3) }
+        }
+}

--- a/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/repository/DefaultBandalartSlotRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/repository/DefaultBandalartSlotRepository.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.data.repository
+
+import com.nexters.bandalart.core.datastore.BandalartDataStore
+import com.nexters.bandalart.core.domain.policy.resolveMaxBandalartSlots
+import com.nexters.bandalart.core.domain.repository.BandalartSlotRepository
+
+class DefaultBandalartSlotRepository(
+    private val bandalartDataStore: BandalartDataStore,
+) : BandalartSlotRepository {
+    override suspend fun getMaxBandalartSlots(currentBandalartCount: Int): Int =
+        bandalartDataStore.resolveMaxBandalartSlots(
+            minimumSlots = resolveMaxBandalartSlots(currentBandalartCount),
+        )
+
+    override suspend fun expandMaxBandalartSlots(currentBandalartCount: Int): Int =
+        bandalartDataStore.expandMaxBandalartSlots(
+            minimumSlots = resolveMaxBandalartSlots(currentBandalartCount),
+        )
+}

--- a/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreTest.kt
+++ b/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreTest.kt
@@ -80,6 +80,37 @@ class BandalartDataStoreTest {
     }
 
     @Nested
+    @DisplayName("반다라트 최대 슬롯 관련 테스트")
+    inner class MaxBandalartSlotsTest {
+        @Test
+        @DisplayName("저장값이 없으면 전달된 최소 슬롯을 저장해야 한다")
+        fun minimumSlotsAreStoredByDefault() =
+            runTest {
+                assertEquals(3, bandalartDataStore.resolveMaxBandalartSlots(minimumSlots = 3))
+                assertEquals(3, bandalartDataStore.resolveMaxBandalartSlots(minimumSlots = 2))
+            }
+
+        @Test
+        @DisplayName("기존 보유 개수가 저장값보다 크면 최대 슬롯을 보정해야 한다")
+        fun currentCountRaisesStoredSlots() =
+            runTest {
+                bandalartDataStore.resolveMaxBandalartSlots(minimumSlots = 3)
+
+                assertEquals(5, bandalartDataStore.resolveMaxBandalartSlots(minimumSlots = 5))
+            }
+
+        @Test
+        @DisplayName("확장할 때 저장된 최대 슬롯을 정확히 하나 늘려야 한다")
+        fun expansionIncrementsStoredSlots() =
+            runTest {
+                bandalartDataStore.resolveMaxBandalartSlots(minimumSlots = 5)
+
+                assertEquals(6, bandalartDataStore.expandMaxBandalartSlots(minimumSlots = 3))
+                assertEquals(6, bandalartDataStore.resolveMaxBandalartSlots(minimumSlots = 3))
+            }
+    }
+
+    @Nested
     @DisplayName("최근 사용 이모지 관련 테스트")
     inner class RecentEmojisTest {
         @Test

--- a/core/datastore/src/commonMain/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStore.kt
+++ b/core/datastore/src/commonMain/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStore.kt
@@ -22,6 +22,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.catch
@@ -38,6 +39,7 @@ class BandalartDataStore(
         private const val ONBOARDING_COMPLETED_ID = "completed_onboarding_id"
         private const val THEME_MODE = "theme_mode"
         private const val RECENT_EMOJIS = "recent_emojis"
+        private const val MAX_BANDALART_SLOTS = "max_bandalart_slots"
         private const val MAX_RECENT_EMOJIS = 12
     }
 
@@ -46,6 +48,25 @@ class BandalartDataStore(
     private val onboardingCompletedKey = booleanPreferencesKey(ONBOARDING_COMPLETED_ID)
     private val themeModeKey = stringPreferencesKey(THEME_MODE)
     private val recentEmojisKey = stringPreferencesKey(RECENT_EMOJIS)
+    private val maxBandalartSlotsKey = intPreferencesKey(MAX_BANDALART_SLOTS)
+
+    suspend fun resolveMaxBandalartSlots(minimumSlots: Int): Int {
+        var resolvedSlots = minimumSlots
+        dataStore.edit { preferences ->
+            resolvedSlots = maxOf(preferences[maxBandalartSlotsKey] ?: 0, minimumSlots)
+            preferences[maxBandalartSlotsKey] = resolvedSlots
+        }
+        return resolvedSlots
+    }
+
+    suspend fun expandMaxBandalartSlots(minimumSlots: Int): Int {
+        var expandedSlots = minimumSlots + 1
+        dataStore.edit { preferences ->
+            expandedSlots = maxOf(preferences[maxBandalartSlotsKey] ?: 0, minimumSlots) + 1
+            preferences[maxBandalartSlotsKey] = expandedSlots
+        }
+        return expandedSlots
+    }
 
     val themeMode =
         dataStore.data

--- a/core/domain/src/androidHostTest/kotlin/com/nexters/bandalart/core/domain/policy/BandalartSlotPolicyTest.kt
+++ b/core/domain/src/androidHostTest/kotlin/com/nexters/bandalart/core/domain/policy/BandalartSlotPolicyTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.domain.policy
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class BandalartSlotPolicyTest {
+    @Test
+    fun defaultSlotCountIsThree() {
+        assertEquals(3, resolveMaxBandalartSlots(currentBandalartCount = 0))
+    }
+
+    @Test
+    fun existingUsersKeepAtLeastTheirCurrentSlotCount() {
+        assertEquals(5, resolveMaxBandalartSlots(currentBandalartCount = 5))
+    }
+
+    @Test
+    fun creationIsAllowedOnlyWhenAFreeSlotExists() {
+        assertTrue(canCreateBandalart(currentBandalartCount = 2, maxBandalartSlots = 3))
+        assertFalse(canCreateBandalart(currentBandalartCount = 3, maxBandalartSlots = 3))
+    }
+}

--- a/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/policy/BandalartSlotPolicy.kt
+++ b/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/policy/BandalartSlotPolicy.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.domain.policy
+
+const val FREE_BANDALART_SLOT_COUNT = 3
+
+fun resolveMaxBandalartSlots(currentBandalartCount: Int): Int = maxOf(FREE_BANDALART_SLOT_COUNT, currentBandalartCount)
+
+fun canCreateBandalart(
+    currentBandalartCount: Int,
+    maxBandalartSlots: Int,
+): Boolean = currentBandalartCount < maxBandalartSlots

--- a/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/repository/BandalartSlotRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/repository/BandalartSlotRepository.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.domain.repository
+
+interface BandalartSlotRepository {
+    suspend fun getMaxBandalartSlots(currentBandalartCount: Int): Int
+
+    suspend fun expandMaxBandalartSlots(currentBandalartCount: Int): Int
+}

--- a/docs/ADMOB_SLOT_FOUNDATION_STRATEGY.md
+++ b/docs/ADMOB_SLOT_FOUNDATION_STRATEGY.md
@@ -1,0 +1,64 @@
+# AdMob 슬롯 기반 작업 전략
+
+## 목표
+
+반다라트 생성 정책을 기본 무료 슬롯 3개와 보상형 광고 1회당 영구 슬롯 1개 확장 구조로 전환할 수 있는 공통 기반을 만든다. 이번 단계는 KMP 공통 슬롯 정책과 저장소, Android GMA Next-Gen SDK 초기화까지만 포함한다.
+
+## 성공 기준
+
+- 기본 최대 슬롯은 3개다.
+- 저장된 최대 슬롯과 현재 반다라트 수 중 큰 값을 사용해 기존 사용자의 표가 잠기지 않는다.
+- 확장된 최대 슬롯은 Android와 iOS가 공유하는 DataStore 경로에 영구 저장되고, 표를 삭제해도 줄어들지 않는다.
+- 슬롯 확장 1회는 최대 슬롯을 정확히 1개 늘린다.
+- Android debug는 Google 테스트 광고 ID, release는 운영 광고 ID를 사용한다.
+- GMA Next-Gen SDK는 앱 시작 시 백그라운드에서 한 번만 초기화한다.
+
+## 설계
+
+### 공통 슬롯 정책
+
+`core:domain`에 SDK와 무관한 순수 정책을 둔다.
+
+- `FREE_BANDALART_SLOT_COUNT = 3`
+- 현재 반다라트 수와 기본 슬롯 중 큰 값으로 최소 최대 슬롯을 계산한다.
+- 현재 보유 수가 최대 슬롯보다 작을 때만 광고 없이 생성 가능하다고 판단한다.
+
+`BandalartSlotRepository`는 현재 보유 수를 받아 저장된 최대 슬롯을 보정하거나 1개 확장한다. 구현은 기존 `BandalartDataStore`를 사용하고 Metro graph에서 앱 범위 단일 인스턴스로 제공한다.
+
+### 기존 사용자 보정
+
+저장 값이 없는 기존 사용자는 첫 조회에서 `max(3, 현재 보유 개수)`를 저장한다. 저장 값이 있더라도 현재 보유 개수보다 작으면 같은 규칙으로 올린다. 이후 표 삭제는 저장된 최대 슬롯을 낮추지 않는다.
+
+### Android 광고 SDK
+
+`androidApp`에 GMA Next-Gen SDK를 추가한다. 광고 ID는 build type별 Android resource로 분리한다.
+
+- debug: Google 공식 테스트 App ID, Rewarded/Banner ad unit ID
+- release: AdMob 운영 App ID, Rewarded/Banner ad unit ID
+
+`BandalartApplication`은 앱 시작 시 전용 initializer를 호출한다. initializer는 중복 호출을 막고 IO dispatcher에서 SDK를 초기화한다. 이번 단계에서는 광고를 load/show하지 않는다.
+
+## 단계 분리
+
+이번 PR에 포함하지 않는 작업:
+
+- 4번째 생성 시 안내 dialog와 Rewarded Ad 표시
+- reward callback 이후 슬롯 확장 및 새 반다라트 생성 연결
+- 광고 load/show 실패 시 fail-open 처리
+- 홈 하단 Anchored Adaptive Banner UI
+- 광고 이벤트 분석
+- iOS 광고 SDK
+
+위 항목은 플랫폼 gateway와 Home 생성 flow를 함께 설계하는 후속 PR에서 구현한다. 현재의 최대 5개 생성 제한은 보상형 flow가 연결될 때 교체해, 광고를 볼 방법 없이 사용자가 3개에서 막히는 중간 상태를 배포하지 않는다.
+
+## 개인정보 동의 범위
+
+현재 국내 배포 범위에서는 UMP SDK를 이번 단계에 포함하지 않는다. EEA, 영국, 스위스 등 동의가 필요한 지역으로 배포 범위를 확대하거나 개인 맞춤 광고를 요청하기 전에는 CMP/UMP 구성, 개인정보 옵션 진입점, Play Console 및 개인정보처리방침을 별도 작업으로 완료한다.
+
+## 검증
+
+- 슬롯 정책의 기본값, 기존 사용자 보정, 생성 가능 여부 단위 테스트
+- DataStore의 최초 보정, 저장 값 유지, 1회 확장 단위 테스트
+- 저장소가 DataStore에 올바른 최소값을 전달하고 결과를 반환하는 단위 테스트
+- Metro graph 구성 및 Android 광고 resource/dependency 정적 확인
+- 실제 광고 초기화와 테스트 광고 load/show는 후속 UI 연동 단계에서 debug 빌드로 검증

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ packageName = "com.nexters.bandalart"
 # Gradle Plugin
 android-gradle-plugin = "9.3.0"
 google-service = "4.4.2"
+google-mobile-ads-next-gen = "1.2.1"
 
 # Kotlin
 kotlin-core = "2.4.10"
@@ -171,6 +172,7 @@ kmp-firebase-crashlytics = { group = "dev.gitlive", name = "firebase-crashlytics
 kmp-firebase-config = { group = "dev.gitlive", name = "firebase-config", version.ref = "kotlin-firebase" }
 firebase-common = { group = "com.google.firebase", name = "firebase-common-ktx", version.ref = "firebase-common" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
+google-mobile-ads-next-gen = { group = "com.google.android.libraries.ads.mobile.sdk", name = "ads-mobile-sdk", version.ref = "google-mobile-ads-next-gen" }
 
 # Util
 kotlin-ktlint = { group = "com.pinterest", name = "ktlint", version.ref = "kotlin-ktlint-source" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ dependencyResolutionManagement {
                 includeGroupAndSubgroups("androidx")
                 includeGroupAndSubgroups("com.android")
                 includeGroupAndSubgroups("com.google")
+                includeGroup("org.chromium.net")
             }
         }
         mavenCentral()


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #206

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 기본 무료 슬롯을 3개로 정의하고 기존 사용자는 현재 보유 개수 이상의 최대 슬롯을 유지하도록 보정했습니다.
- 최대 슬롯을 공통 DataStore에 영구 저장하고 광고 보상 1회당 정확히 1개 확장할 수 있는 repository를 Metro graph에 연결했습니다.
- 슬롯 정책, DataStore 보정·확장, repository 위임과 graph singleton 테스트를 추가했습니다.
- GMA Next-Gen SDK 1.2.1을 추가하고 Android 앱 시작 시 백그라운드에서 한 번 초기화하도록 구성했습니다.
- debug에는 Google 테스트 광고 ID를, release에는 운영 App·보상형·배너 ID를 적용했습니다.
- KMP 구현 범위와 후속 Rewarded/Banner 작업 경계를 전략 문서로 기록했습니다.

## 🧪 테스트 내역 (선택)

- [x] `:core:domain:testAndroidHostTest`
- [x] `:core:datastore:testAndroidHostTest`
- [x] `:core:data:testAndroidHostTest`
- [x] `:composeApp:testAndroidHostTest`
- [x] `git diff --check origin/main...HEAD`
- [ ] Android debug 빌드 및 테스트 기기에서 GMA 초기화 확인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

- 이번 PR에는 UI 변경이 없습니다.

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 실제 Rewarded Ad 생성 flow와 홈 배너 UI는 후속 PR에서 연결합니다. 광고를 볼 방법 없이 3개에서 막히는 중간 상태를 피하기 위해 기존 HomePresenter의 최대 5개 제한은 아직 유지합니다.
- 현재 국내 배포 범위에서는 UMP SDK를 포함하지 않습니다. 동의 대상 지역으로 배포를 확대하기 전에 별도 연동합니다.
- 전체 Spotless 검사는 main의 기존 `BandalartRepository.kt` 포맷 위반으로 완료되지 않았습니다. 이번 PR에서 추가·수정한 관련 파일의 포맷 위반은 정리했습니다.
