### PR TITLE
feat: Fluent Emoji 카테고리 탐색 추가

### DIFF
--- a/core/ui/src/androidHostTest/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiCatalogTest.kt
+++ b/core/ui/src/androidHostTest/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiCatalogTest.kt
@@ -114,4 +114,53 @@ class FluentEmojiCatalogTest {
             ).map { it.unicode },
         )
     }
+
+    @Test
+    fun allPickerViewKeepsRecentItemsFirstWithoutDuplicatingCatalogItems() {
+        val items =
+            fluentEmojiPickerItems(
+                category = null,
+                recentEmojis = listOf("🚀", "😎", "🎯", "🚀"),
+            )
+
+        assertEquals(listOf("🚀", "🎯"), items.take(2).map { it.unicode })
+        assertEquals(300, items.size)
+        assertEquals(300, items.map { it.unicode }.distinct().size)
+    }
+
+    @Test
+    fun pickerCategoryViewContainsOnlyTheSelectedMetadataGroup() {
+        FluentEmojiCategory.entries
+            .filterNot { it == FluentEmojiCategory.RECENT }
+            .forEach { category ->
+                val items = fluentEmojiPickerItems(category = category, recentEmojis = emptyList())
+
+                assertTrue(items.isNotEmpty())
+                assertTrue(items.all { it.category == category })
+            }
+    }
+
+    @Test
+    fun recentCategoryTabIsOnlyVisibleWhenCatalogBackedRecentItemsExist() {
+        assertTrue(
+            visibleFluentEmojiCategoryTabs(hasRecentEmojis = false)
+                .none { it.category == FluentEmojiCategory.RECENT },
+        )
+        assertTrue(
+            visibleFluentEmojiCategoryTabs(hasRecentEmojis = true)
+                .any { it.category == FluentEmojiCategory.RECENT },
+        )
+        assertEquals(
+            listOf(null) + FluentEmojiCategory.entries,
+            visibleFluentEmojiCategoryTabs(hasRecentEmojis = true).map { it.category },
+        )
+    }
+
+    @Test
+    fun everyCategoryTabUsesAnEmojiFromTheBundledFluentCatalog() {
+        assertTrue(
+            visibleFluentEmojiCategoryTabs(hasRecentEmojis = true)
+                .all { FluentEmojiCatalog.resourceKeyFor(it.iconUnicode) != null },
+        )
+    }
 }

--- a/core/ui/src/commonMain/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiPicker.kt
+++ b/core/ui/src/commonMain/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiPicker.kt
@@ -28,14 +28,21 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,14 +50,81 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import bandalart.core.designsystem.generated.resources.Res
+import bandalart.core.designsystem.generated.resources.emoji_picker_category_activities
+import bandalart.core.designsystem.generated.resources.emoji_picker_category_all
+import bandalart.core.designsystem.generated.resources.emoji_picker_category_flags
+import bandalart.core.designsystem.generated.resources.emoji_picker_category_food
+import bandalart.core.designsystem.generated.resources.emoji_picker_category_nature
+import bandalart.core.designsystem.generated.resources.emoji_picker_category_objects
+import bandalart.core.designsystem.generated.resources.emoji_picker_category_people
+import bandalart.core.designsystem.generated.resources.emoji_picker_category_recent
+import bandalart.core.designsystem.generated.resources.emoji_picker_category_smileys
+import bandalart.core.designsystem.generated.resources.emoji_picker_category_symbols
+import bandalart.core.designsystem.generated.resources.emoji_picker_category_travel
 import com.nexters.bandalart.core.common.getLocale
+import org.jetbrains.compose.resources.stringResource
 
 private const val PICKER_COLUMN_COUNT = 6
 private const val PICKER_VISIBLE_ROW_COUNT = 4
 private val PICKER_CELL_SPACING = 8.dp
+private val CATEGORY_TAB_SPACING = 4.dp
+
+internal data class FluentEmojiCategoryTab(
+    val category: FluentEmojiCategory?,
+    val iconUnicode: String,
+)
+
+private val fluentEmojiCategoryTabs =
+    listOf(
+        FluentEmojiCategoryTab(category = null, iconUnicode = "✨"),
+        FluentEmojiCategoryTab(category = FluentEmojiCategory.RECENT, iconUnicode = "⏰"),
+        FluentEmojiCategoryTab(
+            category = FluentEmojiCategory.SMILEYS_AND_EMOTION,
+            iconUnicode = "😍",
+        ),
+        FluentEmojiCategoryTab(category = FluentEmojiCategory.PEOPLE_AND_BODY, iconUnicode = "💪"),
+        FluentEmojiCategoryTab(category = FluentEmojiCategory.ANIMALS_AND_NATURE, iconUnicode = "🐻"),
+        FluentEmojiCategoryTab(category = FluentEmojiCategory.FOOD_AND_DRINK, iconUnicode = "🍉"),
+        FluentEmojiCategoryTab(category = FluentEmojiCategory.TRAVEL_AND_PLACES, iconUnicode = "🚀"),
+        FluentEmojiCategoryTab(category = FluentEmojiCategory.ACTIVITIES, iconUnicode = "🎯"),
+        FluentEmojiCategoryTab(category = FluentEmojiCategory.OBJECTS, iconUnicode = "📚"),
+        FluentEmojiCategoryTab(category = FluentEmojiCategory.SYMBOLS, iconUnicode = "✔️"),
+        FluentEmojiCategoryTab(category = FluentEmojiCategory.FLAGS, iconUnicode = "🏁"),
+    )
+
+internal fun visibleFluentEmojiCategoryTabs(hasRecentEmojis: Boolean): List<FluentEmojiCategoryTab> =
+    if (hasRecentEmojis) {
+        fluentEmojiCategoryTabs
+    } else {
+        fluentEmojiCategoryTabs.filterNot { it.category == FluentEmojiCategory.RECENT }
+    }
+
+internal fun fluentEmojiPickerItems(
+    category: FluentEmojiCategory?,
+    recentEmojis: List<String>,
+): List<FluentEmojiItem> {
+    if (category != null && category != FluentEmojiCategory.RECENT) {
+        return filterFluentEmojiItems(query = "", category = category)
+    }
+
+    val recentItems =
+        filterFluentEmojiItems(
+            query = "",
+            category = FluentEmojiCategory.RECENT,
+            recentEmojis = recentEmojis,
+        )
+    if (category == FluentEmojiCategory.RECENT) {
+        return recentItems
+    }
+
+    val recentUnicode = recentItems.mapTo(mutableSetOf(), FluentEmojiItem::unicode)
+    return recentItems + FluentEmojiCatalog.items.filterNot { it.unicode in recentUnicode }
+}
 
 @Composable
 fun FluentEmojiPicker(
@@ -60,20 +134,43 @@ fun FluentEmojiPicker(
     modifier: Modifier = Modifier,
     expanded: Boolean = false,
 ) {
+    var selectedCategoryName by rememberSaveable { mutableStateOf<String?>(null) }
     var selectedEmoji by rememberSaveable(currentEmoji) { mutableStateOf(currentEmoji) }
-    val pickerItems =
+    val hasRecentEmojis =
         remember(recentEmojis) {
-            val recentItems =
-                filterFluentEmojiItems(
-                    query = "",
-                    category = FluentEmojiCategory.RECENT,
-                    recentEmojis = recentEmojis,
-                )
-            recentItems + FluentEmojiCatalog.items.filterNot { it in recentItems }
+            fluentEmojiPickerItems(
+                category = FluentEmojiCategory.RECENT,
+                recentEmojis = recentEmojis,
+            ).isNotEmpty()
         }
+    val selectedCategory =
+        selectedCategoryName
+            ?.let { savedName ->
+                FluentEmojiCategory.entries.firstOrNull { it.name == savedName }
+            }?.takeUnless { it == FluentEmojiCategory.RECENT && !hasRecentEmojis }
+    val pickerItems =
+        remember(selectedCategory, recentEmojis) {
+            fluentEmojiPickerItems(
+                category = selectedCategory,
+                recentEmojis = recentEmojis,
+            )
+        }
+    val gridState = rememberLazyGridState()
+    val previousHasRecentEmojis = remember { mutableStateOf(hasRecentEmojis) }
     val horizontalPadding = if (expanded) 23.dp else 8.dp
     val topPadding = if (expanded) 23.dp else 8.dp
     val bottomPadding = if (expanded) 26.dp else 0.dp
+
+    LaunchedEffect(hasRecentEmojis) {
+        val transitionedToEmpty = previousHasRecentEmojis.value && !hasRecentEmojis
+        previousHasRecentEmojis.value = hasRecentEmojis
+        if (
+            transitionedToEmpty &&
+            selectedCategoryName == FluentEmojiCategory.RECENT.name
+        ) {
+            selectedCategoryName = null
+        }
+    }
 
     BoxWithConstraints(
         modifier =
@@ -88,13 +185,13 @@ fun FluentEmojiPicker(
                 PICKER_CELL_SPACING * (PICKER_COLUMN_COUNT - 1)) / PICKER_COLUMN_COUNT
         val gridHeight =
             topPadding +
-                bottomPadding +
                 cellSize * PICKER_VISIBLE_ROW_COUNT +
                 PICKER_CELL_SPACING * (PICKER_VISIBLE_ROW_COUNT - 1)
 
         Column(modifier = Modifier.fillMaxWidth()) {
             LazyVerticalGrid(
                 columns = GridCells.Fixed(PICKER_COLUMN_COUNT),
+                state = gridState,
                 modifier =
                     Modifier
                         .fillMaxWidth()
@@ -104,7 +201,7 @@ fun FluentEmojiPicker(
                         start = horizontalPadding,
                         top = topPadding,
                         end = horizontalPadding,
-                        bottom = bottomPadding,
+                        bottom = 0.dp,
                     ),
                 horizontalArrangement = Arrangement.spacedBy(PICKER_CELL_SPACING),
                 verticalArrangement = Arrangement.spacedBy(PICKER_CELL_SPACING),
@@ -122,6 +219,81 @@ fun FluentEmojiPicker(
                                 onEmojiSelect(item.unicode)
                             }
                         },
+                    )
+                }
+            }
+            EmojiCategoryRow(
+                selectedCategory = selectedCategory,
+                hasRecentEmojis = hasRecentEmojis,
+                onCategorySelect = { category ->
+                    if (selectedCategory != category) {
+                        gridState.requestScrollToItem(0)
+                        selectedCategoryName = category?.name
+                    }
+                },
+                modifier = Modifier.padding(bottom = bottomPadding),
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmojiCategoryRow(
+    selectedCategory: FluentEmojiCategory?,
+    hasRecentEmojis: Boolean,
+    onCategorySelect: (FluentEmojiCategory?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val tabs = remember(hasRecentEmojis) { visibleFluentEmojiCategoryTabs(hasRecentEmojis) }
+
+    LazyRow(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .selectableGroup(),
+        contentPadding = PaddingValues(horizontal = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(CATEGORY_TAB_SPACING),
+    ) {
+        items(
+            items = tabs,
+            key = { it.category?.name ?: "all" },
+        ) { tab ->
+            val selected = selectedCategory == tab.category
+            val label = categoryLabel(tab.category)
+
+            Surface(
+                modifier =
+                    Modifier
+                        .size(48.dp)
+                        .selectable(
+                            selected = selected,
+                            role = Role.Tab,
+                            onClick = { onCategorySelect(tab.category) },
+                        ).semantics(mergeDescendants = true) {
+                            contentDescription = label
+                        },
+                shape = RoundedCornerShape(12.dp),
+                color =
+                    if (selected) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surface
+                    },
+                border =
+                    if (selected) {
+                        BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
+                    } else {
+                        null
+                    },
+            ) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    BandalartEmoji(
+                        unicode = tab.iconUnicode,
+                        contentDescription = null,
+                        size = 24.dp,
                     )
                 }
             }
@@ -171,3 +343,21 @@ private fun FluentEmojiPickerCell(
         }
     }
 }
+
+@Composable
+private fun categoryLabel(category: FluentEmojiCategory?): String =
+    stringResource(
+        when (category) {
+            null -> Res.string.emoji_picker_category_all
+            FluentEmojiCategory.RECENT -> Res.string.emoji_picker_category_recent
+            FluentEmojiCategory.SMILEYS_AND_EMOTION -> Res.string.emoji_picker_category_smileys
+            FluentEmojiCategory.PEOPLE_AND_BODY -> Res.string.emoji_picker_category_people
+            FluentEmojiCategory.ANIMALS_AND_NATURE -> Res.string.emoji_picker_category_nature
+            FluentEmojiCategory.FOOD_AND_DRINK -> Res.string.emoji_picker_category_food
+            FluentEmojiCategory.TRAVEL_AND_PLACES -> Res.string.emoji_picker_category_travel
+            FluentEmojiCategory.ACTIVITIES -> Res.string.emoji_picker_category_activities
+            FluentEmojiCategory.OBJECTS -> Res.string.emoji_picker_category_objects
+            FluentEmojiCategory.SYMBOLS -> Res.string.emoji_picker_category_symbols
+            FluentEmojiCategory.FLAGS -> Res.string.emoji_picker_category_flags
+        },
+    )

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@
 
 - [이모지 picker 하단 inset 수정](features/emoji/EMOJI_PICKER_BOTTOM_INSETS_FIX_STRATEGY.md)
 - [이모지 picker legacy UI 전략](features/emoji/EMOJI_PICKER_LEGACY_UI_STRATEGY.md)
+- [Fluent Emoji 카테고리 탐색](features/emoji/FLUENT_EMOJI_CATEGORY_NAVIGATION_STRATEGY.md)
 - [Fluent Emoji picker 마이그레이션](features/emoji/FLUENT_EMOJI_PICKER_MIGRATION_STRATEGY.md)
 - [Fluent Emoji resource spike](features/emoji/FLUENT_EMOJI_RESOURCE_SPIKE.md)
 

--- a/docs/architecture/state/COMPOSE_STATE_LIFETIME_GUIDE.md
+++ b/docs/architecture/state/COMPOSE_STATE_LIFETIME_GUIDE.md
@@ -104,7 +104,7 @@ in-flight flag만 retain하고 작업 coroutine은 composition에 묶으면, 구
 | 보상형 광고 coordinator/request/recovery flag | `rememberRetained` + DataStore | retained는 회전 연결, DataStore는 process death와 exactly-once 복구 담당 |
 | `BandalartDatePicker` 연·월·일 | `rememberSaveable(draftKey)` | `draftKey`를 identity input으로 사용해 작은 미확정 UI 입력을 저장. cross-process identity 보장은 별도 검증 필요 |
 | 이모지 picker 선택 | `rememberSaveable` 사용 중 | 현재 상위 draft와 의미가 중복될 수 있어 stateless 또는 `remember(currentEmoji)`로 정리할 후보 |
-| 이모지 picker 카테고리 | `rememberSaveable` 예정 | 작은 UI filter이며 카테고리 기능 브랜치에서 적용 예정 |
+| 이모지 picker 카테고리 | `rememberSaveable` | 작은 UI filter이며 configuration/process recreation 뒤 선택 복원 가치가 있음 |
 | `LazyGridState` 등 공식 `remember…State` | 해당 컴포넌트 API | framework의 Saver와 상태 계약을 재사용 |
 
 ## inputs와 identity 검증 규칙

--- a/docs/features/emoji/FLUENT_EMOJI_CATEGORY_NAVIGATION_STRATEGY.md
+++ b/docs/features/emoji/FLUENT_EMOJI_CATEGORY_NAVIGATION_STRATEGY.md
@@ -1,0 +1,54 @@
+# Fluent Emoji 카테고리 탐색 전략
+
+## 배경
+
+Microsoft Fluent Emoji는 picker 컴포넌트가 아니라 asset과 metadata를 제공한다. 각 emoji의 `metadata.json`에는 `group`, `cldr`, `keywords`, `glyph`, `unicode`가 있고, 현재 프로젝트의 생성 pipeline은 이 `group`을 9개 `FluentEmojiCategory`로 이미 정규화한다.
+
+현재 `FluentEmojiPicker`는 최근 사용 항목 뒤에 전체 300개 catalog를 한 grid로 이어 붙인다. 카테고리 filter와 한국어·영어·일본어 label resource는 남아 있지만, 이전의 제목·검색·text chip·전체 높이 picker를 기존 compact UI로 복원하는 과정에서 category selector도 함께 숨겨졌다. 300개를 세로 스크롤만으로 찾기 어려우므로 compact UI는 유지하면서 Teams처럼 category icon으로 목록을 전환한다.
+
+## 목표
+
+- 기존 6열·4행 grid 높이와 Fluent Color cell UI를 유지한다.
+- grid 아래에 가로 스크롤 가능한 48dp category icon tab 한 줄을 제공한다.
+- `모두`, 유효한 최근 사용이 있을 때만 `최근 사용`, Fluent metadata의 9개 group 순서로 노출한다.
+- `모두`는 현재 동작처럼 최근 사용을 앞에 두고 나머지 300개를 중복 없이 표시한다.
+- category를 선택하면 해당 group 항목만 표시하고 grid를 첫 항목으로 이동한다.
+- category 이동만으로 현재 emoji 선택값이나 저장 callback을 변경하지 않는다.
+- 각 tab은 선택 semantics와 한국어·영어·일본어 접근성 이름을 제공한다.
+
+## 구현 경계
+
+1. `FluentEmojiPicker`
+   - category 선택은 picker 내부의 일시적인 UI element state이므로 `rememberSaveable`로 소유한다.
+   - `LazyRow`와 `selectableGroup`으로 icon tab을 제공하고, 선택된 tab을 색상과 border로 구분한다.
+   - catalog에 포함된 대표 Fluent Emoji를 tab icon으로 사용한다.
+   - 실제 category tab click에서만 grid를 맨 위로 이동하고, configuration 복원 시 저장된 scroll 위치는 유지한다.
+   - 같은 composition에서 유효했던 최근 목록이 비게 될 때만 `모두`로 정규화한다. configuration 복원 직후 DataStore의 일시적인 빈 초기값은 저장된 최근 category를 지우지 않는다.
+2. `FluentEmojiCatalogTest`
+   - 전체 view의 최근 사용 우선·중복 제거, 최근 tab 노출 조건, category별 부분집합, tab icon catalog 포함을 검증한다.
+
+## 비범위
+
+- 검색창·picker 제목·내부 닫기 버튼 복원
+- catalog 300개, category taxonomy, 생성 pipeline 또는 asset 재생성
+- Presenter, Room, DataStore, 최근 사용 저장 규칙 변경
+- Unicode 저장 형식이나 기존 데이터 migration
+- bottom sheet inset 또는 화면 높이 정책 변경
+
+## 완료 조건
+
+- 사용자가 category icon을 눌러 9개 Fluent metadata group과 최근 사용 목록을 직접 열 수 있다.
+- 전체 view와 emoji 선택 callback의 기존 동작이 유지된다.
+- 최근 사용이 비어 있으면 빈 tab이 노출되지 않는다.
+- category 전환 뒤 목록이 항상 첫 항목부터 보인다.
+- core UI host test와 정적 검사가 통과한다.
+
+## 필수 수동 검증
+
+현재 `core/ui`에는 Compose interaction test harness가 없으므로 다음 항목은 Android와 iOS picker에서 직접 확인한다.
+
+- 각 icon tab을 누르면 해당 metadata group만 표시되고 선택 tab의 색상·border가 바뀐다.
+- category 전환은 grid를 첫 항목으로 이동하지만 화면 회전·configuration 복원은 기존 category와 scroll 위치를 유지한다.
+- TalkBack·VoiceOver가 tab을 선택 가능한 tab과 현지화된 category 이름으로 읽는다.
+- 48dp tab touch target과 가로 스크롤이 큰 글자·라이트·다크 모드에서 겹치지 않는다.
+- category 이동만으로 emoji 선택 callback이나 저장값이 바뀌지 않는다.


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #212

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- Fluent Emoji picker 아래에 전체, 최근 사용, metadata 9개 그룹을 전환하는 가로 스크롤 category tab을 추가했습니다.
- 기존 6열·4행 compact grid와 최근 항목 우선 정렬을 유지하고, category를 실제로 누를 때만 목록을 첫 항목으로 이동합니다.
- 유효한 최근 이모지가 없으면 최근 tab을 숨기고, configuration 복원 직후의 일시적인 빈 초기값은 저장된 category를 지우지 않도록 했습니다.
- 각 48dp tab에 `Role.Tab`, 선택 상태, 한국어·영어·일본어 접근성 이름을 제공합니다.
- 전체/최근/category 부분집합과 tab icon catalog 포함 계약을 host test로 추가했습니다.

## 🧪 테스트 내역 (선택)

- [x] `./gradlew :core:ui:testAndroidHostTest --no-daemon --no-configuration-cache`
- [x] `FluentEmojiCatalogTest` 12 tests / 0 failures
- [x] `git diff --check`
- [ ] Android/iOS 실기기에서 category 전환·회전·TalkBack/VoiceOver 수동 확인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 카테고리 탐색 | Internal Testing에서 확인 예정 | 접근성 | 실기기에서 확인 예정 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 검색창·picker 제목·asset taxonomy 변경은 범위에 포함하지 않았습니다.
- Compose interaction harness가 없어 실제 tab click과 보조기술 동작은 후속 Internal Testing에서 확인합니다.
