### PR TITLE
docs: 로컬 알림 구현 전략 정리

### DIFF
--- a/docs/BACKLOG_EXECUTION_STRATEGY.md
+++ b/docs/BACKLOG_EXECUTION_STRATEGY.md
@@ -1,6 +1,6 @@
 # BandalArt 백로그 실행 우선순위
 
-- 갱신일: 2026-08-08
+- 갱신일: 2026-08-09
 - 기준 브랜치: `origin/main`
 - 대상: KMP/Circuit/Metro 기반 앱의 안정화와 신규 기능 백로그
 
@@ -11,8 +11,48 @@
 - KMP 테스트 가이드 #209, Circuit 상태 보존과 날짜 피커 복원 #210, 설정 화면 이메일 문의 #207은 각각 PR #216, #218, #220으로 `main`에 병합해 완료했다.
 - 태스크 셀 롱클릭 완료와 KMP 햅틱 #213은 PR #227로 `main`에 병합했다.
 - Fluent UI Emoji #212는 Color 300개 resource pipeline, 공통 renderer, picker·최근 사용과 Android 출시 검증을 완료했고 PR #245에서 metadata category 탐색을 추가했다. iOS 실제 기기·artifact 검증은 #214로 이관했다.
-- AdMob #206은 PR #241에서 무료 슬롯 정책과 Android GMA SDK 기반을, PR #243에서 사전 안내→Rewarded→정확히 한 개 생성과 process 복구를 병합했다. 현재 후속 작업에서 홈 Banner와 test-ad Internal 검증을 진행한다.
+- AdMob #206은 PR #241에서 무료 슬롯 정책과 Android GMA SDK 기반을, PR #243에서 사전 안내→Rewarded→정확히 한 개 생성과 process 복구를, PR #247에서 홈 Anchored Adaptive Banner를 병합했다. 보관된 `2.2.18 (20218)` AAB의 metadata·release note가 Play Internal release와 일치하며, 실제 설치본의 전체 Rewarded·Banner acceptance와 운영·개인정보 설정은 후속으로 남아 있다. Play API로 업로드 binary SHA나 Git SHA를 대조할 수는 없다.
 - 따라서 다음 작업은 남은 마이그레이션이 아니라 테스트·상태 정책을 고정한 뒤 작은 기능부터 확장하는 순서다.
+
+## 실제 출하 현황 체크리스트
+
+2026-08-09 기준 코드 병합, 스토어 업로드, 수동 검증을 서로 다른 완료 조건으로 기록한다.
+
+### `main` 병합·CI
+
+- [x] `origin/main`은 PR #248까지 병합된 `0058885c`이며 해당 PR의 CI는 통과했다.
+- [x] 현재 열린 PR은 없다.
+- [x] PR #241의 무료 슬롯·GMA 기반, PR #243의 Rewarded 생성 흐름, PR #245의 Fluent Emoji category 탐색, PR #247의 adaptive test banner가 `main`에 병합됐다.
+
+### Android Play Internal Testing
+
+- [x] Play Internal Testing에 `2.2.18 (20218)`이 `completed` 상태로 업로드됐다.
+- [x] PR #247 병합 시점 `374908af` worktree에 보관된 release AAB의 package·`2.2.18 (20218)` metadata와 release note가 Play release와 일치한다. Play API로 업로드 binary SHA나 Git SHA를 대조할 수는 없다.
+- [x] AAB에 Rewarded·Banner 공식 test unit ID가 있고 production unit ID가 없음을 확인했다.
+- [x] 사용자 수동 확인에서 Internal 설치본의 Rewarded 광고, 홈 Banner와 기존 컬러 emoji category 탐색 UI 노출을 확인했다.
+- [ ] Rewarded 중도 종료 시 미생성, 보상 뒤 정확히 한 개 생성·영구 슬롯 유지, 광고 실패 fail-open과 Banner no-fill·재진입까지 전체 acceptance를 완료한다.
+- [ ] 운영 AdMob unit, UMP, `app-ads.txt`, Play Console 광고·Data safety 선언을 완료한다.
+
+### 로컬 작업 — 아직 Internal 미반영
+
+- [ ] Teams식 단색 category 아이콘과 선택 category 제목: `fix/fluent-emoji-category-icons`에서 로컬 테스트 12개 통과, 아직 commit·PR·merge·Internal 배포 전이다.
+- [ ] 홈 Banner `320x50` 고정과 추가 bottom sheet의 중복 window inset 제거: `fix/home-bottom-insets-banner-height`에서 로컬 테스트 2개 통과, 아직 commit·PR·merge·Internal 배포 전이다.
+- [ ] #211 로컬 알림 조사·전략과 공통 foundation: 로컬 구현·검증 중이며 아직 commit·PR·merge·Internal 배포 전이다.
+
+### iOS·TestFlight
+
+- [ ] App Store Connect의 `1.1.0` build를 생성하고 TestFlight에 업로드한다. 현재 `1.1.0` build train은 0건이다.
+- [ ] TestFlight 설치본에서 데이터 보존, Circuit/Metro, Fluent Emoji, navigation과 현재 iOS AdMob no-op/fail-open 경계를 검증한다. iOS Banner는 아직 구현되지 않았다.
+- [x] 과거 TestFlight `1.0.0 (1·2·3)`과 `1.0.1 (2)`가 모두 만료돼 활성 build가 없음을 확인했다.
+
+### Fastlane CD
+
+- [x] PR #248의 Android/iOS Fastlane CD 복구 코드는 `main`에 병합됐고 CI는 통과했다.
+- [x] Android signing을 포함한 기존 repository secret 이름은 등록돼 있다.
+- [ ] 2026-08-08에 재발급한 Play publisher JSON으로 `PLAY_SERVICE_ACCOUNT_JSON`을 교체하고 preflight를 통과시킨다. 현재 secret 갱신일은 재발급보다 앞서므로 기존 값은 폐기된 것으로 취급한다.
+- [ ] GitHub Environment를 구성한다. 현재 Environment는 0개다.
+- [ ] iOS signing·App Store Connect secret을 등록한다. 현재 iOS 배포 secret은 없다.
+- [ ] GitHub Actions에서 Android Internal과 iOS TestFlight workflow를 각각 최초 1회 성공시킨다. 현재 배포 workflow 실행 기록은 0건이다.
 
 ## 실행 원칙
 
@@ -48,11 +88,11 @@ Color 300개 catalog, pinned manifest와 resource pipeline, 공통 renderer, pic
 
 ### 6. #211 마감일 기반 로컬 알림 — L
 
-공통 scheduler 계약 뒤 Android와 iOS 로컬 알림을 플랫폼별로 구현한다. 생성·수정·완료·삭제, 권한, 시간대, 재부팅에 대한 idempotent reschedule을 검증한다.
+공식 API와 저장소 접점을 조사해 제품 시간·집계·권한·reconcile 정책을 확정했고 예정 PR 2 공통 foundation까지 로컬 구현·검토·테스트했다. GitHub에 생성된 알림 PR은 아직 없다. 현재 남은 단계는 계획한 예정 PR 1 문서와 예정 PR 2 foundation 경계로 변경을 나눠 각각 commit·PR·CI·merge하는 것이다. 이후 Android와 iOS vertical slice를 플랫폼별로 구현하고 두 플랫폼이 준비된 뒤 설정 UX를 활성화한다. 생성·수정·완료·삭제, 권한, 시간대, 재부팅에 대한 idempotent reschedule을 검증한다. 구체적인 단계는 [로컬 알림 구현 전략](features/notifications/LOCAL_DEADLINE_NOTIFICATION_STRATEGY.md)을 따른다.
 
 ### 7. #206 AdMob Rewarded Ad 기반 추가 생성 — L
 
-PR #241에서 기본 무료 슬롯 3개, 영구 슬롯 저장·보정과 Android GMA SDK 기반을 병합했다. PR #243에서 사전 안내, Rewarded 완료 뒤 정확히 한 번 생성, 광고 실패 fail-open과 process 복구를 연결했다. 현재 후속 작업에서 홈 Anchored Adaptive Banner를 연결하고 Rewarded·Banner 테스트 광고를 함께 Internal 검증한다.
+PR #241에서 기본 무료 슬롯 3개, 영구 슬롯 저장·보정과 Android GMA SDK 기반을 병합했다. PR #243에서 사전 안내, Rewarded 완료 뒤 정확히 한 번 생성, 광고 실패 fail-open과 process 복구를 연결했고 PR #247에서 홈 Anchored Adaptive Banner를 연결했다. 보관 AAB의 metadata·release note가 Play Internal의 `2.2.18 (20218)` release와 일치하며 Rewarded·Banner test unit ID도 확인했다. Play API로 binary SHA나 Git SHA를 대조할 수는 없다. 기본 노출은 설치본에서 확인했지만 전체 end-to-end acceptance와 운영·개인정보 설정은 아직 완료되지 않았다.
 
 ### 8. #208 목표 템플릿 기반 빠른 생성 — L
 
@@ -65,7 +105,7 @@ PR #241에서 기본 무료 슬롯 3개, 영구 슬롯 저장·보정과 Android
 ## 별도 운영 트랙
 
 - #214: iOS 개발자 계정 복구 후 실제 기기, 저장소, 설정, navigation, 배포 검증
-- #113: legacy Google key·Firebase token 폐기 완료, Android/iOS Fastlane CD PR 및 첫 workflow 배포 검증 진행
+- #113: legacy Google key·Firebase token 폐기와 PR #248 Fastlane CD 복구 병합 완료, GitHub Environment·secret 구성과 첫 workflow 배포 검증 진행
 - #206 외부 준비: AdMob app/rewarded/banner unit, UMP, app-ads.txt, Play Console 광고·Data safety 선언
 
 이 운영 작업은 준비되는 즉시 병행할 수 있지만, 미완료 상태가 앞선 Android 기능 개발을 막지는 않는다.
@@ -78,9 +118,9 @@ PR #241에서 기본 무료 슬롯 3개, 영구 슬롯 저장·보정과 Android
 2. #213: long click과 햅틱
 3. #212: 이모지 에셋 용량·성능·다크 모드 — Android 완료, iOS는 #214로 이관
 4. #211: 알림 권한·예약·재예약
-5. #206: Rewarded 생성 flow — 구현 완료, Home Banner와 Android test ad end-to-end는 Internal Testing에서 확인
+5. #206: Rewarded 생성 flow·Home Banner test build — Internal 업로드와 기본 노출 확인, 전체 end-to-end acceptance는 미완료
 6. #208: 템플릿 + 광고 생성 end-to-end
 
 ## 바로 이어갈 작업
 
-#214 iOS `1.1.0` TestFlight 업데이트 검증을 진행한다. CD 환경이 준비되면 GitHub workflow를 우선 사용하고, 준비 전에는 Xcode Organizer를 fallback으로 사용한다. 기존 App Store `1.0.1` 위 업데이트, 데이터 보존, Circuit/Metro 흐름, Fluent Emoji category와 App Thinning 결과를 검증한다. Firebase 콘솔 관측은 비차단 후속 검증으로 분리하며, 구체적인 절차는 `releases/ios/IOS_TESTFLIGHT_UPDATE_STRATEGY.md`를 따른다.
+#211 로컬 알림의 로컬 변경을 예정 PR 1 조사·전략과 예정 PR 2 공통 foundation 경계로 분리해 각각 commit·PR·CI·merge한다. 그다음 예정 PR 3 Android WorkManager vertical slice를 시작하고 플랫폼 권한·UI 활성화는 계획된 후속 PR로 유지한다. #214 iOS TestFlight와 #206 Android test-ad 전체 acceptance는 credential·배포 환경이 준비되는 즉시 별도 운영 트랙에서 병행한다.

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,8 @@
 ### Home, Settings, Updates
 
 - [태스크 셀 햅틱 완료](features/home/TASK_CELL_HAPTIC_COMPLETION_STRATEGY.md)
+- [마감일 기반 로컬 알림 조사](features/notifications/LOCAL_DEADLINE_NOTIFICATION_RESEARCH.md)
+- [마감일 기반 로컬 알림 구현 전략](features/notifications/LOCAL_DEADLINE_NOTIFICATION_STRATEGY.md)
 - [이메일 문의](features/settings/EMAIL_INQUIRY_STRATEGY.md)
 - [설정 bottom sheet typography](features/settings/SETTINGS_BOTTOM_SHEET_TYPOGRAPHY_STRATEGY.md)
 - [설정 theme](features/settings/SETTINGS_THEME_STRATEGY.md)

--- a/docs/features/notifications/LOCAL_DEADLINE_NOTIFICATION_RESEARCH.md
+++ b/docs/features/notifications/LOCAL_DEADLINE_NOTIFICATION_RESEARCH.md
@@ -1,0 +1,188 @@
+# 마감일 기반 로컬 알림 조사
+
+- 조사일: 2026-08-09
+- 관련 이슈: [#211 목표 마감일 기반 로컬 알림 도입](https://github.com/Nexters/BandalArt-KMP/issues/211)
+- 기준 commit: `0058885c`
+- 범위: 서버·FCM 없이 Android/iOS에서 마감일 로컬 알림을 제공하기 위한 공식 API 제약과 현재 저장소 접점 확인
+
+이 문서는 구현 전략의 입력 자료다. 구체적인 인터페이스, 모듈 배치, PR 분할과 출시 순서는 후속 전략 문서에서 확정한다.
+
+## 결론
+
+서버나 push infrastructure 없이 두 플랫폼 모두 구현할 수 있다. Android는 “오전 9시 이후 시스템이 허용하는 시점”의 지연을 수용한다면 WorkManager one-time unique work가 맞고, iOS는 `UNCalendarNotificationTrigger` one-shot request가 맞다. exact alarm, FCM, APNs 등록과 Push Notifications capability는 v1에 필요하지 않다.
+
+다만 플랫폼 scheduler보다 먼저 해결할 저장소 문제가 있다.
+
+1. main cell의 due date 제거가 현재 DAO patch 의미 때문에 실제 DB에 반영되지 않는다.
+2. task update가 부모 sub/main의 완료 상태를 자동 변경하므로 변경한 셀만 예약·취소해서는 stale 알림을 막을 수 없다.
+3. 앱 ON/OFF preference와 OS permission/channel authorization은 별도 상태여야 한다.
+4. Android warm `singleTask`와 iOS cold-start response를 Splash 이후 Home까지 전달하는 buffered selection 경계가 없다.
+5. 같은 날 다건 UX와 iOS의 공개되지 않은 pending request 상한 때문에 per-cell 무제한 예약 여부를 제품·구조 결정으로 남겨야 한다.
+
+따라서 #211은 단순 notification API 연결이 아니라 DB source-of-truth 기반 reconcile, 권한 상태, lifecycle navigation, 실제 기기 검증을 함께 다루는 L 크기 작업이라는 기존 백로그 판단이 타당하다.
+
+## 1. 현재 제품 요구
+
+이슈 #211은 사용자가 설정에서 기능을 직접 켠 경우에만 OS 권한을 요청하고, 미완료이며 제목과 마감일이 유효한 셀을 기기 현지 시각 오전 9시에 알리는 v1을 정의한다. 날짜 변경·제거, 완료·완료 취소, 셀·반다라트 삭제, 설정 OFF/ON 뒤에도 예약이 중복되거나 오래 남지 않아야 한다. 알림 탭은 셀 편집창까지 열지 않고 해당 반다라트를 선택한 홈으로 이동하는 수준이 v1 범위다.
+
+## 2. 저장소에서 확인한 사실
+
+### 2.1 데이터와 날짜 표현
+
+- `BandalartCellDBEntity`는 `bandalartId`, `title`, `dueDate`, `isCompleted`, `parentId`를 이미 저장한다. 알림 자체를 위한 Room 컬럼은 없다: `core/database/src/commonMain/kotlin/com/nexters/bandalart/core/database/entity/BandalartCellDBEntity.kt`.
+- `BandalartCellEntity`도 같은 값을 공통 domain에 노출한다. 셀 ID는 Room 자동 생성 `Long`이고 플랫폼 예약 식별자의 원천으로 사용할 수 있다: `core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/entity/BandalartCellEntity.kt`.
+- 날짜 피커는 선택 날짜를 `yyyy-MM-ddT00:00` 형태의 현지 날짜·시간 문자열로 만든다. DB 값은 instant나 UTC timestamp가 아니다: `feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartDatePicker.kt`.
+- 현재 Android `minSdk`는 28, `targetSdk`는 36이고 iOS deployment target은 16.6이다: `gradle/libs.versions.toml`, `iosApp/iosApp.xcodeproj/project.pbxproj`.
+
+따라서 기존 `dueDate`를 마감일이라는 달력 날짜로 해석해 기기의 현재 time zone에서 오전 9시를 계산해야 한다. 문자열을 UTC instant로 간주하면 날짜가 바뀔 수 있다.
+
+### 2.2 저장·완료·삭제 경계
+
+- Home의 셀 저장은 main/sub/task 세 repository 메서드로 나뉜다. 빠른 완료도 task update 메서드를 재사용하고, 셀·반다라트 삭제도 repository를 통한다: `feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt`.
+- 실제 Room write는 `DefaultBandalartRepository`에 모여 있다: `core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/repository/DefaultBandalartRepository.kt`.
+- main cell update는 `updateDto.dueDate ?: current.dueDate`로 병합한다. UI가 날짜 제거를 `null`로 전달해도 기존 main due date가 유지되므로, #211의 “due date 제거 시 예약 취소”를 구현하기 전에 nullable patch 의미를 분리해야 한다: `core/database/src/commonMain/kotlin/com/nexters/bandalart/core/database/BandalartDao.kt`의 `updateMainCellWithDto`.
+- task update 뒤 DAO가 부모 sub cell과 main cell의 완료 상태를 자동으로 다시 계산한다. 한 task 변경이 여러 셀의 알림 적격성을 바꿀 수 있다: `core/database/src/commonMain/kotlin/com/nexters/bandalart/core/database/BandalartDao.kt`의 `updateCompletionStatus`.
+- sub cell 삭제는 물리 삭제가 아니라 해당 sub cell과 자식 task cell을 모두 초기화하고, task cell 삭제도 셀을 초기화한다. main cell 삭제만 FK cascade로 반다라트 전체를 제거한다: 같은 파일의 `deleteCellOrReset`, `resetSubCellWithChildren`, `resetTaskCell`.
+- DAO에는 반다라트별 전체 셀 조회는 있지만, 전체 DB에서 알림 적격 셀만 조회하거나 ID가 없을 때 nullable하게 조회하는 API는 없다.
+- main due date는 `bandalarts`와 main row인 `bandalart_cells`에 중복 저장된다. reminder source가 두 테이블을 모두 읽으면 main 목표를 중복 예약할 수 있다.
+
+이 구조에서는 화면 이벤트마다 서로 다른 예약 명령을 직접 조합할 경우 부모 자동 완료와 하위 셀 일괄 초기화를 놓칠 위험이 있다. DB write 성공 뒤 최소한 해당 반다라트의 최종 상태를 다시 읽는 동기화 경계가 필요하며, 플랫폼 예약 실패가 이미 성공한 Room write를 되돌려서는 안 된다.
+
+### 2.3 설정과 권한 UI 접점
+
+- `SettingsRepository`는 현재 theme와 최근 이모지만 노출하고, 값은 기존 `bandalart.preferences_pb` DataStore에 저장한다: `core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/repository/SettingsRepository.kt`, `core/datastore/src/commonMain/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStore.kt`.
+- 설정 bottom sheet는 Home의 단일 modal 상태이며 화면 설정과 앱 정보 섹션을 가진다. 알림 toggle을 넣을 직접 UI 접점은 `feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/settings/SettingsBottomSheet.kt`다.
+- 설정의 영속값은 repository `Flow`를 Home Presenter가 수집하고 event로 갱신하는 기존 패턴이 있다: `feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt`.
+- 알림 사용 의사와 OS authorization은 같은 상태가 아니다. DataStore toggle이 ON이어도 사용자가 시스템 설정에서 권한을 끌 수 있고, OS 권한을 다시 얻지 못한 상태에서 toggle만 ON으로 저장할 수도 있다. UI는 두 상태를 구분해야 한다.
+
+### 2.4 앱 시작, 플랫폼 binding과 알림 탭
+
+- Metro `PlatformBindings`가 Android/iOS 구현을 공통 `AppGraph`에 주입하는 기존 경계다: `composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/AppGraph.kt`.
+- Android graph는 `BandalartApplication.onCreate`에서 한 번 만들어진다. 앱 프로세스가 살아 있지 않아도 실행되는 WorkManager Worker가 application graph와 Room에 접근할 수 있는 접점이다: `androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt`.
+- iOS graph는 `MainViewController`에서 생성되고 Swift `AppDelegate`는 현재 Firebase 초기화만 한다: `composeApp/src/iosMain/kotlin/com/nexters/bandalart/MainViewController.kt`, `iosApp/iosApp/iosApp.swift`.
+- Android `MainActivity`는 `singleTask`지만 notification intent 처리나 `onNewIntent`가 없다. iOS `AppDelegate`도 `UNUserNotificationCenterDelegate`를 연결하지 않는다.
+- 공통 navigation은 Splash를 root로 시작하고 Home은 DataStore의 `recentBandalartId`로 선택 항목을 복원한다. 외부 URI나 pending navigation request를 처리하는 공통 deep-link 계층은 현재 없다: `composeApp/src/commonMain/kotlin/com/nexters/bandalart/BandalartApp.kt`, `feature/splash/src/commonMain/kotlin/com/nexters/bandalart/feature/splash/presenter/SplashPresenter.kt`, `feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt`.
+
+따라서 알림 탭 처리는 앱 종료·Splash·onboarding·이미 열린 Home의 네 상태를 모두 고려해야 한다. 단순히 launch intent를 만드는 것만으로는 이미 실행 중인 `singleTask` Activity나 iOS foreground/background response에서 올바른 반다라트를 선택할 수 없다.
+
+### 2.5 의존성과 테스트 기반
+
+- AndroidX WorkManager 의존성은 아직 version catalog와 모듈에 없다. `androidApp`에는 Android 13 notification permission과 notification channel 구현도 없다.
+- 공통 날짜 계산에 `kotlinx-datetime` 0.6.1을 사용할 수 있다. 현재 저장·표시는 `yyyy-MM-dd'T'HH:mm` 형태와 별도의 expect/actual `LocalDateTime` wrapper를 사용하므로 저장 형식은 유지하고 reminder projection에서만 `LocalDate`로 정규화하는 편이 범위가 작다: `gradle/libs.versions.toml`, `core/common/src/commonMain/kotlin/com/nexters/bandalart/core/common/extension/String.kt`.
+- repository, DataStore, DAO, Home Presenter와 Metro graph에 JUnit 5/MockK/Circuit/Robolectric 기반 `androidHostTest`가 이미 있다.
+- `androidDeviceTest`와 iOS test target은 아직 없다. 프로젝트 테스트 가이드도 실제 permission·notification처럼 host fake가 의미 없는 검증만 device test로 올리도록 규정한다: `docs/architecture/kmp/KMP_TESTING_GUIDE.md`.
+- 다국어 문자열은 Compose resources의 한국어 기본값, 영어, 일본어 세 묶음으로 관리한다: `core/designsystem/src/commonMain/composeResources/values*/strings.xml`.
+
+## 3. Android 공식 API 조사
+
+### 3.1 WorkManager와 시간 정확도
+
+- WorkManager는 앱 재시작과 기기 재부팅 뒤에도 유지돼야 하는 deferrable persistent work용 API다. 반면 exact alarm은 Doze를 깨우므로 알람 시계나 캘린더처럼 정밀성이 사용자 핵심 기능인 경우에만 사용하도록 Android가 제한한다: [Persistent work](https://developer.android.com/develop/background-work/background-tasks/persistent), [Schedule alarms](https://developer.android.com/develop/background-work/services/alarms).
+- one-time work의 `initialDelay`는 작업이 실행될 수 있는 **최소 지연**이다. 실제 실행 시각은 시스템 최적화와 Doze 등의 영향을 받으므로 오전 9시 정각을 보장하지 않는다: [Define work requests](https://developer.android.com/develop/background-work/background-tasks/persistent/getting-started/define-work).
+- unique work는 논리 작업 이름으로 중복 enqueue를 막는다. one-time work를 `ExistingWorkPolicy.REPLACE`로 enqueue하면 같은 이름의 기존 작업을 취소하고 새 작업으로 교체할 수 있고, name/tag/id로 취소·관찰할 수 있다: [Manage work](https://developer.android.com/develop/background-work/background-tasks/persistent/how-to/manage-work).
+- 조사 시점의 stable WorkManager는 2.11.2이고 minSdk 23, compileSdk 33 이상을 요구한다. 이 저장소의 minSdk 28/compileSdk 37과 호환된다: [WorkManager release notes](https://developer.android.com/jetpack/androidx/releases/work).
+
+따라서 v1이 “마감일 오전 중 알림”의 지연을 허용한다면 WorkManager one-time unique work가 공식 API 용도에 맞는다. “오전 9시 정각”이 SLA라면 WorkManager로 보장할 수 없으며, 그 요구가 실제로 생길 때 AlarmManager와 특별 권한의 비용을 다시 평가해야 한다. v1에는 `SCHEDULE_EXACT_ALARM` 또는 `USE_EXACT_ALARM`을 추가할 근거가 없다.
+
+### 3.2 권한과 notification channel
+
+- targetSdk 36인 이 앱은 Android 13(API 33) 이상에서 `POST_NOTIFICATIONS` runtime permission 적용 대상이다. 신규 설치의 알림은 기본 OFF이며, target 33 이상 앱은 권한 prompt를 요청할 시점을 직접 정할 수 있다: [Notification runtime permission](https://developer.android.com/develop/ui/compose/notifications/notification-permission).
+- Android 8(API 26) 이상에서는 모든 알림에 channel이 필요하다. channel 생성은 반복해도 안전하지만 생성 뒤 앱이 importance와 동작을 바꿀 수 없고 사용자가 시스템 설정에서 변경할 수 있다: [Create and manage notification channels](https://developer.android.com/develop/ui/compose/notifications/channels).
+- 앱의 알림 ON preference, `POST_NOTIFICATIONS` 허용 여부, `deadline_reminder` channel 차단 여부는 서로 다른 상태다. 지원 범위 전체가 API 28 이상이므로 모든 기기에서 channel 상태도 확인해야 한다.
+- Android 공식 permission 문서는 ADB로 허용·거절·신규 설치 상태를 재현하는 명령도 제공한다. 자동화된 policy test와 별개로 실제 prompt 회귀 검증에 사용할 수 있다: [Notification runtime permission testing](https://developer.android.com/develop/ui/compose/notifications/notification-permission).
+
+### 3.3 알림 grouping과 탭 navigation
+
+- Android의 grouped notification은 각 child에 같은 group key를 지정하는 것만으로 끝나지 않는다. 별도의 summary notification에 `setGroupSummary(true)`를 지정해야 한다: [Create a group of notifications](https://developer.android.com/develop/ui/views/notifications/group).
+- notification 탭이 Activity를 열 때 explicit `PendingIntent`와 올바른 back stack을 구성해야 한다. 공식 예시는 mutable input이 필요하지 않은 일반 탭 intent에 `FLAG_IMMUTABLE`을 사용하고, 기존 extras를 갱신할 때 `FLAG_UPDATE_CURRENT`를 함께 사용한다: [Start an Activity from a notification](https://developer.android.com/develop/ui/views/notifications/navigation).
+- 현재 `MainActivity`가 `singleTask`이므로 cold start의 `onCreate`와 이미 실행 중인 앱의 `onNewIntent`를 모두 처리해야 한다. v1은 앱 외부 URI를 받을 필요가 없으므로 public deep-link intent filter를 추가하지 않고 explicit app intent로 구현할 수 있다.
+
+### 3.4 재부팅, 시간대와 최종 실행 검증
+
+- WorkManager가 persistent work를 재부팅 뒤 복구하므로 v1에서 별도 `BOOT_COMPLETED` receiver와 permission은 필요하지 않다: [Persistent work](https://developer.android.com/develop/background-work/background-tasks/persistent).
+- 기존 initial delay는 time zone이나 사용자가 수동으로 바꾼 시계에서 “새 현지 날짜 오전 9시” 의미를 저절로 다시 계산하는 계약이 아니다. `TIME_SET`과 `TIMEZONE_CHANGED`는 manifest-declared implicit broadcast 제한의 예외이지만 Android는 불필요한 listener를 피하도록 요구한다: [Implicit broadcast exceptions](https://developer.android.com/develop/background-work/background-tasks/broadcasts/broadcast-exceptions).
+- 이 기능에서 receiver가 필요하다면 DB를 직접 오래 읽는 대신 unique reconcile work만 enqueue해야 한다. 실제 DB 비교와 예약 교체는 background work가 맡아야 한다.
+- Worker 실행 시에는 예약 당시 input만 신뢰하지 않고 현재 DB에서 toggle, 셀 존재, 제목, 완료 상태, due date를 다시 확인해야 오래된 알림을 막을 수 있다. 권한 거절이나 stale work는 영구 retry할 일시 장애가 아니므로 정상 종료시키는 편이 무한 재시도를 피한다.
+
+### 3.5 테스트와 진단
+
+- WorkManager integration test는 `TestDriver.setInitialDelayMet`으로 initial delay 충족을 가상화할 수 있고 Worker 구현은 별도 worker test API로 단위 검증할 수 있다: [Integration testing](https://developer.android.com/develop/background-work/background-tasks/testing/persistent/integration-testing), [Test Worker implementations](https://developer.android.com/develop/background-work/background-tasks/testing/persistent/worker-impl).
+- 예약 상태는 `adb shell dumpsys jobscheduler`와 WorkManager diagnostics로 확인할 수 있다: [Debug WorkManager](https://developer.android.com/develop/background-work/background-tasks/testing/persistent/debug).
+- Doze와 App Standby는 공식 ADB 절차로 강제 진입·해제할 수 있다. initial delay의 실제 지연 허용 수준은 에뮬레이터/기기에서 별도로 검증해야 한다: [Test with Doze and App Standby](https://developer.android.com/training/monitoring-device-state/doze-standby).
+
+### 3.6 현재 저장소에 미치는 영향
+
+- suspend DB 검증을 수행하는 `CoroutineWorker`를 위해 WorkManager `work-runtime-ktx`와 `work-testing` 의존성을 version catalog와 Android 대상 모듈에 새로 추가해야 한다. 현재 저장소에는 WorkManager가 없다.
+- scheduler/Worker/notification publisher는 Android SDK를 참조하지만 eligibility, stable ID, 날짜 정책과 desired-state 계산은 공통 테스트가 가능하다. 기존 `PlatformBindings`는 플랫폼 구현을 common graph에 전달할 수 있는 경계다.
+- Worker는 `BandalartApplication.appGraph`를 통해 app-scoped Room/repository에 접근할 수 있다. 다만 domain repository에는 nullable cell lookup이나 active reminder projection이 없어 Worker 최종 검증과 전체 reconcile을 위한 읽기 계약이 추가로 필요하다.
+- 알림 permission 요청처럼 화면 lifecycle이 필요한 동작은 `feature/home`의 기존 `FlexibleUpdateEffect` expect/actual 패턴과 `rememberLauncherForActivityResult`를 재사용할 수 있다. app-scoped scheduler/status 조회와 일회성 OS prompt effect는 분리 대상이다.
+- notification intent의 `bandalartId`는 cold/warm start 모두에서 app-scoped pending selection으로 전달하고 Home이 목록을 읽은 뒤 소비해야 한다. 현재 Home Presenter는 Room 목록의 각 emission에서 `recentBandalartId`를 다시 읽지만 DataStore 변경 자체는 Room emission을 만들지 않으므로 warm app에서 값만 저장해서는 화면 선택이 즉시 바뀌지 않는다.
+- 조사 단계에서는 cell별 unique work와 Android child/summary 조합도 검토했다. 그러나 task write의 parent 자동 완료, iOS pending capacity와 cross-board summary navigation이 복잡해 최종 전략은 `(bandalartId, dueDate)` batch를 가까운 순서로 제한해 예약하고 cross-board Android summary를 만들지 않는 방식으로 결정한다.
+
+## 4. iOS 공식 API 조사
+
+### 4.1 권한과 설정 상태
+
+- Apple은 알림이 필요한 맥락에서 권한을 요청하고, 예약 전에 현재 notification settings를 확인하도록 안내한다. 최초 요청 뒤에는 같은 API를 다시 호출해도 시스템 prompt가 다시 나타나지 않는다: [Asking permission to use notifications](https://developer.apple.com/documentation/usernotifications/asking-permission-to-use-notifications).
+- `requestAuthorization` completion은 background thread에서 호출될 수 있고, 반환 Boolean만 장기 상태로 저장하기보다 `getNotificationSettings`로 현재 authorization을 다시 확인해야 한다: [requestAuthorization(options:completionHandler:)](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/requestauthorization(options:completionhandler:)), [authorizationStatus](https://developer.apple.com/documentation/usernotifications/unnotificationsettings/authorizationstatus).
+- `denied` 상태에서는 시스템이 앱의 로컬 알림 예약 시도를 무시한다. `authorized`, `provisional`, `denied`, `notDetermined`를 앱의 ON/OFF preference와 별도로 다뤄야 한다: [UNAuthorizationStatus](https://developer.apple.com/documentation/usernotifications/unnotificationsettings/authorizationstatus).
+- iOS 16 이상에서는 `UIApplication.openNotificationSettingsURLString`으로 앱의 알림 설정 화면을 열 수 있다. 프로젝트의 deployment target이 16.6이므로 이 API를 직접 사용할 수 있다: [openNotificationSettingsURLString](https://developer.apple.com/documentation/uikit/uiapplication/opennotificationsettingsurlstring).
+- 로컬 알림만 사용하는 경우 APNs 등록, Push Notifications capability와 새 Info.plist usage-description key는 필요하지 않다. v1의 사용자 가치에는 `.alert`와 `.sound`면 충분하고 badge, time-sensitive, critical, provisional authorization은 별도 제품 결정 없이는 범위에 넣지 않는다. Focus와 Scheduled Summary에 따라 시스템 표시가 지연될 수 있다는 점은 수용 기준에 반영해야 한다.
+
+### 4.2 예약, 교체와 취소
+
+- 로컬 알림은 `UNMutableNotificationContent`, trigger, `UNNotificationRequest`를 만들고 `UNUserNotificationCenter.add`로 등록한다. 조건이 바뀌면 기존 pending request를 제거해야 한다: [Scheduling a notification locally from your app](https://developer.apple.com/documentation/usernotifications/scheduling-a-notification-locally-from-your-app).
+- `UNCalendarNotificationTrigger`는 `DateComponents`의 지정 필드가 일치하는 시점에 발화한다. one-shot은 `repeats = false`로 만들고, `nextTriggerDate`로 실제 다음 발화 시각을 검증할 수 있다: [UNCalendarNotificationTrigger](https://developer.apple.com/documentation/usernotifications/uncalendarnotificationtrigger), [DateComponents](https://developer.apple.com/documentation/foundation/datecomponents).
+- 같은 identifier로 새 pending request를 추가하면 이전 request를 교체한다. `deadline.v1.<bandalartId>.<cellId>`처럼 앱 기능 namespace와 두 stable ID를 모두 포함하면 upsert가 가능하다: [UNNotificationRequest.identifier](https://developer.apple.com/documentation/usernotifications/unnotificationrequest/identifier).
+- pending request 전체 조회, identifier별 pending 제거, 이미 Notification Center에 표시된 delivered notification 제거는 서로 다른 API다. 날짜 변경·완료·삭제 뒤 이미 표시된 stale 항목까지 없애려면 pending과 delivered를 구분해 정리해야 한다: [getPendingNotificationRequests](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/getpendingnotificationrequests(completionhandler:)), [removePendingNotificationRequests](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/removependingnotificationrequests(withidentifiers:)), [removeDeliveredNotifications](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/removedeliverednotifications(withidentifiers:)).
+- 시스템은 한 앱의 pending request 수를 제한하지만 Apple의 현행 공개 API 문서와 SDK header는 이 기능이 의존할 수 있는 숫자를 명시하지 않는다. 셀 수가 계속 늘 수 있다면 모든 미래 마감일을 무기한 개별 예약하는 전제는 안전하지 않다.
+
+### 4.3 foreground, 탭과 grouping
+
+- 앱이 foreground일 때 표시 여부는 `UNUserNotificationCenterDelegate.willPresent`에서 결정하고, 사용자의 탭과 action은 `didReceive`에서 처리한다. 두 callback의 completion handler는 반드시 호출해야 한다: [Handling notifications and notification-related actions](https://developer.apple.com/documentation/usernotifications/handling-notifications-and-notification-related-actions).
+- delegate는 앱 launch 완료 전에 notification center에 연결해야 종료 상태에서 탭한 response도 받을 수 있다. 현재 저장소에서는 `iosApp/iosApp/iosApp.swift`의 `AppDelegate.didFinishLaunching`이 그 접점이다.
+- `threadIdentifier`가 같은 알림은 시스템 UI에서 시각적으로 그룹화할 수 있다. 그러나 이것만으로 제품이 원하는 “N개의 목표가 오늘 마감” 요약 문구나 정확한 count가 보장되지는 않는다: [UNMutableNotificationContent.threadIdentifier](https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent/threadidentifier).
+- `categoryIdentifier`는 custom action/category 연결용이며 grouping 식별자가 아니다. v1에 action button이 없다면 category 등록은 탭 routing과 별개로 최소화할 수 있다.
+
+### 4.4 시간대 변화
+
+- `DateComponents`는 calendar와 time zone 문맥에서 평가된다. 현재 calendar/time zone 변화를 추적하는 Foundation API가 있지만, 여행 뒤 기존 `UNCalendarNotificationTrigger`가 새 지역의 오전 9시로 어떻게 재해석되는지는 공개 문서가 제품 정책 수준으로 충분히 명시하지 않는다: [Calendar.autoupdatingCurrent](https://developer.apple.com/documentation/foundation/calendar/autoupdatingcurrent), [TimeZone.autoupdatingCurrent](https://developer.apple.com/documentation/foundation/timezone/autoupdatingcurrent).
+- UIKit은 날짜 변경, 통신사 시각 갱신, DST 변화 같은 중요한 시간 변경 notification을 제공한다. foreground 복귀 때의 재조정과 함께 실제 기기에서 여행·DST 시나리오를 검증해야 한다: [UIApplication.significantTimeChangeNotification](https://developer.apple.com/documentation/uikit/uiapplication/significanttimechangenotification).
+
+### 4.5 현재 저장소에 미치는 영향
+
+- Swift `AppDelegate`가 notification center delegate를 launch 완료 전에 등록하고 `willPresent`, `didReceive`를 처리할 수 있다. 플랫폼 scheduler 자체는 `iosMain` 구현으로 두고 Metro `PlatformBindings`에 주입할 수 있다.
+- UserNotifications completion API를 suspend로 감쌀 수 있지만 callback thread에서 Compose/Circuit 상태를 직접 바꾸면 안 된다.
+- notification `userInfo`의 primitive `bandalartId`는 Compose navigator가 준비되기 전에 도착할 수 있다. cold start response를 buffer한 뒤 Splash/onboarding을 지나 Home이 소비하는 bridge가 필요하다.
+- 앱 toggle이 ON이고 OS 상태가 `notDetermined`일 때만 prompt를 요청하는 흐름, `denied`일 때 OS 설정 이동을 제공하는 흐름, foreground 복귀 때 settings를 다시 읽는 흐름이 분리돼야 한다.
+- 오전 9시 calendar components를 만들기 전에 due date 문자열을 달력 날짜로 정규화하고, 이미 지난 날짜와 오늘 오전 9시 이후를 제외해야 한다. `nextTriggerDate`가 없거나 과거면 등록하지 않는 방어가 가능하다.
+- pending 상한 숫자가 공개 계약이 아니므로 per-cell 무제한 예약, 가까운 일정만 rolling 예약, 날짜·반다라트 단위 집계 중 하나를 후속 전략에서 선택해야 한다. `threadIdentifier`만으로 집계 문구를 대체할 수 없다.
+- Compose resources 문자열은 notification daemon이 표시 시점에 자동 해석하지 않는다. 예약 시점에 현재 언어 문구를 content에 넣거나 iOS host의 `Localizable.strings`와 `localizedUserNotificationString(forKey:arguments:)`를 사용해야 한다. 후자는 예약 뒤 시스템 언어가 바뀌어도 표시 시점 locale을 따를 수 있다.
+
+## 5. 교차 플랫폼에서 확인해야 할 설계 질문
+
+후속 전략에서 다음을 명시적으로 결정해야 한다.
+
+1. DB가 source of truth일 때 `schedule/cancel` 명령형 API와 `reconcile` API의 책임을 어떻게 나눌지
+2. 한 셀 변경 뒤 해당 셀만 동기화할지, 부모 자동 완료까지 포함해 해당 반다라트 전체를 동기화할지
+3. 알림 ON 저장, OS 권한 요청, 권한 거절·영구 거절, 시스템 설정 이동을 어떤 상태 머신으로 표현할지
+4. 앱 시작, foreground 복귀, 시간대 변경에서 reconcile을 각각 누가 호출할지
+5. 같은 날 여러 셀을 개별 알림과 summary/group으로 어떻게 보여 줄지
+6. 알림 탭의 `bandalartId`를 Splash/onboarding을 지나 Home Presenter까지 유실 없이 전달할 최소 경계
+7. Android WorkManager의 지연 허용 범위가 제품 기대에 맞는지와 iOS pending request 수 상한을 어떻게 다룰지
+8. 플랫폼 예약 상태 전체 열람이 불완전하거나 비용이 클 때 stale 예약을 무해하게 만드는 최종 실행 시 검증 방식
+
+## 6. 현재까지 확인된 주요 위험
+
+- **오래된 알림:** 저장 이후 플랫폼 예약 갱신이 실패하면 DB와 pending 예약이 달라진다. 다음 시작 시 reconcile과 발송 직전 유효성 확인이 필요하다.
+- **main 날짜 제거 실패:** 현재 DAO의 main update는 `null`을 “기존 값 유지”로 사용해 사용자가 main due date를 제거할 수 없다. 이 상태에서 cancel 연동만 추가하면 DB source of truth가 이미 잘못된다.
+- **부모 자동 완료 누락:** task 하나를 완료하면 DAO가 sub/main도 완료할 수 있다. 셀 단위 hook만으로는 부모 예약이 남는다.
+- **삭제 범위 오판:** UI의 “삭제”가 셀 종류에 따라 cascade delete 또는 다수 셀 reset으로 달라진다.
+- **시간대 의미 혼동:** `dueDate`는 현지 달력 날짜인데 instant처럼 변환하면 여행이나 DST 전환에서 다른 날짜 알림이 될 수 있다.
+- **권한과 toggle 불일치:** 앱 preference와 시스템 authorization을 하나의 Boolean으로 취급하면 설정 UI가 실제 동작을 잘못 표시한다.
+- **실행 중 탭 유실:** Android `singleTask`와 iOS delegate response를 공통 Home 선택으로 넘기는 경로가 현재 없다.
+- **테스트 공백:** JVM fake로 정책과 idempotency는 검증할 수 있지만 실제 OS 권한 prompt, 종료 상태 delivery, Doze와 iOS notification response는 현재 CI가 자동 검증하지 않는다.
+
+## 7. 출처
+
+플랫폼 공식 문서 링크는 Android/iOS 조사 절의 주장 가까이에 둔다. 저장소 구조에 관한 근거는 위에 적은 기준 commit의 파일 경로다.

--- a/docs/features/notifications/LOCAL_DEADLINE_NOTIFICATION_STRATEGY.md
+++ b/docs/features/notifications/LOCAL_DEADLINE_NOTIFICATION_STRATEGY.md
@@ -1,0 +1,321 @@
+# 마감일 기반 로컬 알림 구현 전략
+
+- 작성일: 2026-08-09
+- 관련 이슈: [#211 목표 마감일 기반 로컬 알림 도입](https://github.com/Nexters/BandalArt-KMP/issues/211)
+- 기준 commit: `0058885c`
+- 조사 근거: [마감일 기반 로컬 알림 조사](LOCAL_DEADLINE_NOTIFICATION_RESEARCH.md)
+
+## 현재 진행률 체크리스트
+
+2026-08-09 기준 로컬 구현 완료와 실제 출하 완료를 분리해 기록한다. 아래 `예정 PR`은 구현 전략의 분할 단위이며 아직 생성된 GitHub PR이 아니다. 모든 항목은 아직 Android Internal이나 iOS TestFlight에 포함되지 않았다.
+
+### 예정 PR 1 — 조사·전략
+
+- [x] 공식 API와 저장소 접점 조사를 로컬 문서로 작성했다.
+- [x] 제품 시간·집계·권한·reconcile 정책과 PR 분할 전략을 로컬에서 검토했다.
+- [ ] 조사·전략 문서를 commit하고 PR을 생성해 CI 통과 후 `main`에 병합한다.
+
+### 예정 PR 2 — 공통 foundation
+
+- [x] main cell due date의 full-snapshot 삭제 의미, notification preference, reminder projection·parser·planner·batch와 scheduler/authorization/reconciler 계약을 로컬에서 구현했다.
+- [x] 공통 foundation 변경을 로컬 리뷰하고 관련 테스트를 통과시켰다.
+- [ ] 공통 foundation을 commit하고 PR을 생성해 CI 통과 후 `main`에 병합한다.
+
+### 예정 PR 3 — Android vertical slice
+
+- [ ] WorkManager scheduler·Worker·channel·permission adapter를 구현한다.
+- [ ] 시간 변경 reconcile과 cold/warm notification navigation을 구현·검증한다.
+- [ ] Android Internal 설치본에서 실제 권한과 전달을 검증한다.
+
+### 예정 PR 4 — iOS vertical slice
+
+- [ ] UserNotifications scheduler·authorization adapter를 구현한다.
+- [ ] AppDelegate delegate, launch-target bridge와 pending/delivered reconcile을 구현·검증한다.
+- [ ] TestFlight 설치본에서 실제 권한과 전달을 검증한다.
+
+### 예정 PR 5 — UX 활성화·배포 검증
+
+- [ ] 설정 toggle·권한 상태·시스템 설정 action과 명시적 마감일 삭제 UX를 구현한다.
+- [ ] 한국어·영어·일본어 문구와 접근성을 검증한다.
+- [ ] Android Internal과 iOS TestFlight의 전체 acceptance checklist를 완료한다.
+- [ ] #211 완료 조건 확인 뒤 umbrella issue를 닫는다.
+
+## 1. 목표
+
+- 사용자가 설정에서 직접 기능을 켠 경우에만 OS 알림 권한을 요청한다.
+- 제목과 마감일이 있고 완료되지 않은 main/sub/task 셀을 기기 현지 시각 오전 9시를 목표로 마감일 당일에 알린다.
+- 날짜 변경·제거, 완료·완료 취소, 셀 초기화, 반다라트 삭제 뒤 오래된 알림을 남기지 않는다.
+- 서버, FCM, APNs remote push 없이 Android/iOS의 로컬 scheduler만 사용한다.
+- 권한 거절이나 플랫폼 예약 실패가 이미 성공한 셀 저장을 실패시키지 않는다.
+- 알림을 누르면 해당 반다라트를 선택한 Home으로 이동한다. 셀 편집창 직접 열기는 v1 범위가 아니다.
+
+## 2. 선행 수정
+
+기존 `BandalartDao.updateMainCellWithDto()`는 `dueDate = updateDto.dueDate ?: current.dueDate`로 처리했다. UI에서 main 셀 날짜를 제거해 `null`을 보내도 기존 날짜가 유지됐으므로 foundation에서 due date를 title·description과 다른 full-snapshot 값으로 정의한다. 현재 Home 저장 경로는 기존 날짜를 유지할 때도 현재 `dueDate`를 전달하고, 삭제할 때만 `null`을 전달한다. 따라서 `null = 제거`이며 별도의 `미변경` 상태는 없다. 향후 due date를 생략하는 partial caller가 필요하면 세 상태를 표현하는 별도 patch 타입을 먼저 도입해야 한다.
+
+foundation 단계에서 main cell update DTO의 due date snapshot 의미를 바로잡고 다음을 회귀 테스트한다.
+
+- main 셀 날짜 제거가 Room과 UI에 실제 반영된다.
+- title/description의 기존 patch 의미는 의도치 않게 바뀌지 않는다.
+- 날짜 제거 뒤 reminder desired state에서 해당 셀이 제외된다.
+
+현재 날짜 피커의 `초기화`는 날짜 삭제가 아니라 오늘 날짜 선택이다. UX 활성화 단계에서 main/sub/task 공통으로 명시적인 `마감일 삭제` action을 추가하고, 기존 action은 실제 의미에 맞는 문구로 바꾼다.
+
+## 3. 제품 정책
+
+### 3.1 시간
+
+- 기준 목표 시각은 due date의 기기 현지 시각 오전 9시다.
+- Android WorkManager의 09:00은 실행 가능한 가장 이른 시각이며 실행 상한이 없다. v1의 사용자·완료 문구는 `마감일 당일 알림`이고, 09:00 정각 또는 오전 전달을 보장하지 않는다.
+- 예약을 새로 계산하는 시점에 오늘 09:00이 이미 지났다면 새 request를 만들지 않는다. 09:00 전에 예약된 Android work가 앱이 background인 동안 지연되면 due date 당일 안에서만 표시할 수 있지만, 09:00 이후 foreground reconcile이 실행되면 사용자가 이미 앱을 보고 있으므로 그 pending work를 취소한다. 다음 날 실행된 stale work도 폐기한다.
+- `dueDate`는 UTC instant가 아니라 현지 달력 날짜로 해석한다. 저장 형식은 기존 `yyyy-MM-dd'T'HH:mm`을 그대로 유지하며 #211에서 date-only 저장 migration을 하지 않는다. reminder projection만 현재 datetime과 기존 데이터·테스트의 초 포함 datetime 변형을 읽어 `LocalDate`로 정규화하고, 파싱할 수 없는 값은 제외한다.
+
+### 3.2 적격 셀
+
+다음 조건을 모두 만족할 때만 reminder item을 만든다.
+
+- 셀이 Room에 존재한다.
+- 제목을 trim한 결과가 비어 있지 않다.
+- due date를 달력 날짜로 파싱할 수 있다.
+- 셀이 완료되지 않았다.
+- due date의 현지 09:00 목표 시각이 reconcile 시점보다 미래다.
+- 사용자의 마감일 알림 preference가 ON이다.
+
+main 목표의 알림 원본은 중복된 `bandalarts.dueDate`가 아니라 안정적인 cell ID가 있는 `bandalart_cells`로 통일한다.
+
+### 3.3 같은 날 여러 목표
+
+플랫폼 예약 단위는 셀별이 아니라 `(bandalartId, dueDate)` batch다. desired batch는 due date, bandalart ID 순으로 정렬하고 두 플랫폼 모두 가까운 32개까지만 예약한다. `32`는 문서화되지 않은 iOS 상한을 추정하는 값이 아니라 무제한 pending을 피하기 위한 v1 제품 제한이다.
+
+```kotlin
+data class DeadlineReminderBatch(
+    val id: String, // deadline.v1.board.<bandalartId>.date.<yyyy-MM-dd>
+    val bandalartId: Long,
+    val dueDate: LocalDate,
+    val items: List<DeadlineReminderItem>,
+)
+```
+
+- 한 건이면 `{목표명}을 완료할 시간이에요.`를 표시한다.
+- 두 건 이상이면 `{count}개의 목표가 오늘 마감이에요.`를 표시한다.
+- batch를 누르면 그 batch의 반다라트를 선택한다.
+- 서로 다른 반다라트의 batch를 하나의 Android group summary로 묶지 않는다. summary tap에는 하나의 올바른 반다라트를 선택할 수 없고 별도 lifecycle이 필요하기 때문이다.
+- iOS `threadIdentifier`도 count summary 계약으로 사용하지 않는다. 각 board/date batch가 자체 집계 문구와 tap 목적지를 가진다.
+- 32개를 넘는 batch는 가까운 순서로 대기 상태가 된다. app-scoped scheduling health에 overflow count를 노출하고 설정 화면에 `먼 날짜 알림 N개는 아직 예약되지 않음`을 표시한다.
+- mutation, 앱 시작, foreground, 시간 변경 reconcile에서 만료된 batch를 제거하고 다음 가까운 batch로 refill한다. 사용자가 장기간 앱을 다시 열지 않으면 대기 batch가 예약되지 않을 수 있음을 v1 제한으로 명시한다.
+- 플랫폼 add가 32개 이전에 실패하면 성공한 batch 수와 overflow를 health에 반영하고 같은 순서를 유지한다. 순서를 바꿔 가까운 알림을 starvation시키지 않는다.
+
+## 4. source of truth와 reconcile
+
+Room의 현재 셀 상태와 DataStore의 사용자 preference만 durable source of truth다. WorkManager work와 iOS pending/delivered notification은 삭제 후 재생성할 수 있는 파생 상태다.
+
+### 4.1 공통 흐름
+
+```mermaid
+flowchart LR
+    A["Room write 성공"] --> B["전체 reminder projection 재조회"]
+    B --> C["공통 policy로 전역 top 32 desired 계산"]
+    C --> D["platform replaceAll"]
+    D -->|실패| E["로그 후 저장 성공 유지"]
+    F["앱 시작·foreground·시간 변경"] --> G["전체 desired state reconcile"]
+    G --> D
+```
+
+- task write는 DAO가 parent sub/main 완료까지 자동 변경하므로 변경 셀 하나만 schedule/cancel하지 않는다.
+- 모든 관련 write 성공 뒤 전역 projection과 가까운 32개를 다시 계산해 `replaceAll()`한다. 한 반다라트의 가까운 일정이 다른 반다라트의 먼 예약을 즉시 퇴출하거나, 삭제된 일정 자리에 overflow batch를 refill할 수 있어야 하기 때문이다.
+- sub/task reset과 main/반다라트 삭제도 같은 전역 reconcile 경계를 사용한다.
+- 설정 ON은 전체 reconcile, OFF는 기능 namespace의 pending/delivered 상태 전체 제거다.
+- 앱 시작과 foreground 복귀는 이전 예약 실패, 앱 업데이트와 시스템 설정 변경을 복구하기 위해 전체 reconcile한다.
+- reconcile은 app-scoped mutex로 직렬화한다. 동시에 실행된 오래된 desired state가 최신 예약을 덮지 않게 한다.
+
+### 4.2 공통 계약
+
+`core/domain`에 플랫폼 SDK 타입이 없는 계약을 둔다.
+
+- `DeadlineReminderItem`, `DeadlineReminderBatch`
+- legacy/new due date를 정규화하는 parser
+- Clock/TimeZone을 주입받는 eligibility/planner
+- `DeadlineReminderScheduler`
+  - `replaceAll(batches)`
+  - `clearAll()`
+- `DeadlineNotificationAuthorization`
+  - 현재 상태 조회
+  - 명시적 사용자 action에서의 요청
+  - OS 알림 설정 열기
+- `DeadlineReminderReconciler`
+  - `reconcileAll()`
+  - 예약 오류를 Room write와 분리하는 best-effort 경계
+- `DeadlineReminderSchedulingHealth`
+  - scheduled count, overflow count, 마지막 platform error category
+  - 설정 화면의 degraded 상태와 capacity 회귀 테스트 입력
+
+전체/반다라트별 reminder projection은 별도 repository로 두어 기존 `BandalartRepository`의 UI CRUD 계약을 notification query로 비대하게 만들지 않는다.
+
+## 5. 설정과 권한 상태
+
+DataStore의 `deadlineReminderEnabled`는 사용자의 의사이며 OS authorization과 별도다. 공통 effective 상태는 `Unsupported`, `Requestable`, `Granted`, `Quiet`, `Blocked`로 정규화한다.
+
+1. 기본값은 OFF다.
+2. 사용자가 toggle을 누르면 오전 9시를 목표로 한 당일 알림과 잠금 화면 제목 노출을 설명한다.
+3. `Requestable`일 때만 prompt를 요청한다.
+4. `Granted` 또는 `Quiet`이면 preference를 ON으로 저장하고 전체 reconcile한다.
+5. 최초 요청이 거절·dismiss되면 preference는 OFF로 유지하고 due date 저장 등 다른 기능은 그대로 제공한다. 결과 뒤 public permission flag와 rationale을 다시 읽어 재요청 가능 여부를 갱신한다.
+6. ON 이후 사용자가 시스템 설정에서 권한 또는 Android channel을 끄면 사용자 의도는 유지한다. 설정 UI에는 `시스템 알림 꺼짐`과 설정 이동 action을 표시하고 플랫폼 예약은 정리한다.
+7. OS 설정에서 다시 허용한 뒤 foreground로 돌아오면 상태를 재조회하고 전체 reconcile한다.
+8. toggle OFF는 preference 저장 후 pending/delivered notification을 모두 정리한다.
+
+권한 prompt는 Presenter의 app-scoped service에서 임의로 띄우지 않는다. Android는 화면 lifecycle을 가진 Compose effect/Activity Result API가 담당하고 iOS는 설정 action이 호출한 permission adapter가 담당한다.
+
+- Android 13 이상은 `checkSelfPermission`, `shouldShowRequestPermissionRationale`과 `PackageManager`의 public `FLAG_PERMISSION_USER_SET`/`FLAG_PERMISSION_USER_FIXED`를 함께 사용한다. permission이 있으면 `Granted`, user flag가 없으면 fresh install 또는 swipe dismiss로 보고 `Requestable`, rationale이 true인 일반 거절도 설명 뒤 명시적 재요청이 가능한 `Requestable`, user-fixed 또는 user-set 상태에서 rationale이 false면 `Blocked`다. Activity Result의 false만으로 Blocked를 확정하지 않는다. API 32 이하는 앱 전체 알림과 channel 상태로 `Granted`/`Blocked`를 판정한다.
+- Android `Requestable` 재토글은 rationale을 먼저 보여 준 뒤 사용자가 다시 동의한 경우에만 prompt를 요청한다. `Blocked` 재토글은 prompt 없이 시스템 설정을 연다.
+- iOS `notDetermined`는 `Requestable`, `authorized`는 `Granted`, `provisional`/`ephemeral` 또는 alert가 조용한 설정은 `Quiet`, `denied`는 `Blocked`로 매핑한다. sound/alert 설정은 설명 상태에 반영하되 authorization이 허용된 request 자체는 유지한다.
+- 설정 복귀 때 effective 상태를 다시 읽어 `Granted`/`Quiet`이면 reconcile하고 `Blocked`면 pending 상태를 정리한다.
+
+## 6. Android
+
+- `androidx.work:work-runtime-ktx` 2.11.2의 `CoroutineWorker`와 one-time unique work를 사용하고 `work-testing`으로 검증한다.
+- exact alarm 권한과 별도 `BOOT_COMPLETED` receiver는 추가하지 않는다. WorkManager가 persistent work를 재부팅 뒤 복원한다.
+- unique work 이름과 tag는 batch/board namespace를 사용하고 교체는 `ExistingWorkPolicy.REPLACE`로 처리한다.
+- `TIME_SET`, `TIMEZONE_CHANGED` receiver는 DB를 직접 오래 읽지 않고 unique reconcile work만 enqueue한다.
+- Android 13 이상 `POST_NOTIFICATIONS` runtime permission과 API 26 이상 `deadline_reminder` channel을 사용한다.
+- Worker는 input title을 그대로 게시하지 않고 실행 직전 Room에서 해당 board/date의 현재 적격 item을 다시 조회한다.
+- 설정 OFF, 권한/channel 차단, 삭제·완료·날짜 변경, 잘못된 날짜, 다음 날 지연 실행은 stale work로 보고 `Result.success()`로 끝낸다.
+- explicit `MainActivity` pending intent에 `FLAG_UPDATE_CURRENT | FLAG_IMMUTABLE`을 사용한다.
+- PendingIntent extras는 identity가 아니므로 explicit intent에 고정 action `com.nexters.bandalart.action.OPEN_DEADLINE`과 batch ID를 포함한 고유 internal data URI를 설정한다. 같은 requestCode를 사용해도 data가 다른 여러 batch의 board ID가 서로 덮이지 않아야 한다.
+- `singleTask` Activity의 cold `onCreate`와 warm `onNewIntent`를 모두 처리한다.
+- posted notification은 `NotificationManager.notify(batch.id, 0, notification)`의 String tag + 고정 Int ID 조합으로 식별해 Int hash 충돌을 피한다. replace/clear는 WorkManager 취소와 별도로 같은 tag를 `cancel(tag, 0)`해 이미 표시된 알림도 정리한다.
+
+## 7. iOS
+
+- `iosMain`에 `UNUserNotificationCenter` scheduler와 authorization adapter를 구현하고 Metro `PlatformBindings`로 주입한다.
+- identifier는 `deadline.v1.*` namespace를 사용한다. replace/remove는 다른 앱 알림을 건드리는 `removeAll`이 아니라 namespace에 속한 pending/delivered request만 대상으로 한다.
+- Gregorian calendar와 reconcile 시점의 `TimeZone.autoupdatingCurrent`를 명시한 one-shot `UNCalendarNotificationTrigger`에 year/month/day/09:00 components를 넣고 `nextTriggerDate`가 미래인지 확인한다. 오늘 09:00 이후에는 새 request를 만들지 않는다.
+- pending request와 이미 Notification Center에 표시된 delivered notification은 별도 API로 정리한다.
+- Swift `AppDelegate`가 KMP `DeadlineNotificationLaunchBridge`를 먼저 생성·강하게 소유하고 launch 완료 전에 `UNUserNotificationCenter.current().delegate`를 설정한다. 동일 bridge를 `ContentView`와 `MainViewController(bridge)`를 통해 `createIosAppGraph`에 전달한다. graph보다 먼저 도착한 cold-start response도 이 pre-graph bridge에 쌓인다.
+- foreground에서도 Android와 동일하게 banner/list와 sound를 허용한다.
+- `NSSystemTimeZoneDidChangeNotification`, `UIApplication.significantTimeChangeNotification`과 foreground 복귀에서 전체 reconcile한다. 앱이 종료된 동안 시간대가 바뀌면 기존 request는 과거 time-zone 기준으로 먼저 전달될 수 있으며, 다음 launch 전 완전한 보정은 보장하지 않는 v1 제한이다.
+- target iOS 16.6 이상이므로 시스템 설정 이동에는 `UIApplication.openNotificationSettingsURLString`을 사용한다.
+- iOS 알림 copy는 host의 한국어/영어/일본어 `Localizable.strings`에서 scheduling 시점에 해석한다. 예약 뒤 OS 언어가 바뀌면 기존 content는 유지되고 다음 reconcile에서 새 언어로 교체한다.
+
+## 8. 알림 탭 navigation
+
+현재 앱에는 외부 navigation request 경계가 없고, `recentBandalartId` 저장만으로는 실행 중인 Home이 즉시 전환되지 않는다.
+
+- buffered `DeadlineNotificationLaunchTarget` 계약을 추가한다. Android는 AppGraph 수명 인스턴스를 사용하고 iOS는 AppDelegate가 graph보다 먼저 만든 bridge를 graph에 주입한다.
+- Android `onCreate`/`onNewIntent`와 Swift notification delegate는 primitive `bandalartId`를 target에 기록한다.
+- target은 Circuit navigator가 준비되기 전 cold-start 요청을 유지한다.
+- Home Presenter는 목록 로드 뒤 target board가 존재하는지 확인하고, 존재하면 recent ID 저장과 `loadBandalart()`를 실행한 뒤 요청을 acknowledge한다.
+- 삭제된 board면 요청을 소비하고 현재 Home을 유지한다.
+- onboarding 미완료 상태에서는 요청을 Home 진입까지 보존한다.
+- public URL scheme/intent filter와 셀 bottom sheet 직접 열기는 추가하지 않는다.
+
+## 9. PR 분할
+
+### PR 1 — 조사·전략
+
+- 공식 API와 저장소 접점 조사
+- 제품 시간·집계·권한·reconcile 정책 확정
+- 구현/테스트/출시 단계를 문서화
+
+### PR 2 — 공통 foundation
+
+- main cell due date 제거 의미 수정과 DAO 회귀 테스트
+- notification preference DataStore/SettingsRepository 계약
+- reminder projection, parser, planner, batch ID와 eligibility 테스트
+- 가까운 32개 선택, overflow health와 refill 테스트
+- scheduler/authorization/reconciler 계약과 fake/no-op 구현
+- 플랫폼 UI와 실제 예약은 아직 활성화하지 않음
+
+### PR 3 — Android vertical slice
+
+- WorkManager scheduler, Worker, channel, permission effect
+- 시간·시간대 reconcile receiver
+- notification publisher와 cold/warm navigation bridge
+- host/Robolectric/WorkManager 테스트
+- permission prompt를 포함한 실제 설정 UX 검증은 PR 5로 미루고 scheduler/Worker/navigation adapter를 직접 호출하는 자동 테스트까지만 완료
+
+### PR 4 — iOS vertical slice
+
+- UserNotifications scheduler/authorization adapter
+- Swift AppDelegate delegate와 KMP launch-target bridge
+- pending/delivered replace/cancel, foreground/time-change reconcile
+- iOS compile과 scheduler/delegate bridge 계약 검증. 실제 permission prompt와 전달 수동 검증은 PR 5로 미룸
+- 공통 설정 toggle은 아직 노출하지 않음
+
+### PR 5 — UX 활성화와 배포 검증
+
+- 설정 bottom sheet 설명·toggle·권한 상태·시스템 설정 action
+- main/sub/task의 명시적 `마감일 삭제` action과 기존 `초기화` 문구 정리
+- 한국어/영어/일본어 문구와 접근성
+- Android Internal Testing과 iOS TestFlight에서 process kill, 재부팅/시간대, foreground, 탭 navigation 검증
+- #211 완료 조건 확인 후 umbrella issue close
+
+## 10. 테스트
+
+### 공통 자동 테스트
+
+- 신규/legacy/invalid due date parsing
+- 과거 날짜와 오늘 09:00 이후 신규 request 제외
+- 제목 없음·완료 셀 제외
+- 같은 board/date batch 집계와 안정적 ID
+- 날짜 변경·제거, 완료·완료 취소, sub/task reset, board 삭제 desired state
+- task 완료 뒤 parent 자동 완료 반영
+- 설정 OFF/ON clear/reconcile
+- 가까운 32개 deterministic 선택, overflow degraded 상태와 foreground refill
+- 동일 state 반복 reconcile의 idempotency
+- 서로 다른 board의 33번째 가까운 batch가 가장 먼 예약을 즉시 교체하고 overflow health를 갱신
+- 09:00 이후 foreground·mutation 반복 reconcile이 당일 알림을 재생성하지 않음
+- Room write 성공 뒤 scheduler 실패가 저장을 롤백하지 않음
+- concurrent reconcile에서 최신 desired state 유지
+
+### Android 자동·수동 테스트
+
+- unique replace/cancel/tag/initial delay
+- Worker 실행 직전 stale state 검증
+- permission 허용·거절, channel 차단
+- fresh/requestable, swipe dismiss 유지, 일반 deny+rationale 재요청, user-fixed blocked와 settings-only
+- Work 취소와 stable tag를 사용한 posted notification 취소
+- 서로 다른 batch의 PendingIntent data identity와 board routing
+- cold start와 warm `onNewIntent`
+- WorkManager TestDriver, process kill, reboot, Doze/App Standby
+- 동·서쪽 time zone과 수동 시각 변경
+
+### iOS 수동·통합 테스트
+
+- authorization 허용·거절·설정 변경
+- notDetermined/authorized/provisional/denied 매핑과 재토글 무재요청
+- 동일 identifier replace와 namespace pending/delivered 정리
+- foreground 표시와 background/종료 상태 수신
+- cold/warm notification response와 삭제된 board fallback
+- time zone, DST, significant time change
+- Gregorian/current time zone의 `nextTriggerDate` 전후 검증과 종료 중 time-zone 변경 제한
+- scheduling 뒤 OS 언어 변경과 다음 reconcile copy 교체
+- TestFlight 업데이트 후 기존 데이터의 전체 reconcile
+
+## 11. 출시·관측
+
+- 플랫폼 코드는 두 OS에 모두 준비될 때까지 설정 toggle을 노출하지 않는다.
+- Android Internal과 iOS TestFlight에서 알림 권한과 실제 전달을 각각 검증한 뒤 활성화한다.
+- scheduler/reconcile 실패는 개인정보가 없는 batch ID, platform status, error category만 기록한다. 목표 제목과 설명은 로그에 남기지 않는다.
+- 알림 content에는 목표 제목 또는 집계 count만 사용하고 description, 완료 이력은 포함하지 않는다.
+- pending request 수, reconcile 소요 시간과 플랫폼 add 실패를 수동/진단 로그로 확인한다. 별도 analytics SDK 추가는 비범위다.
+
+## 12. 비범위
+
+- FCM, APNs remote push, 서버 scheduler
+- exact alarm과 오전 9시 정각 SLA
+- 사용자 지정 알림 시각, 미리 알림, 반복 알림, snooze/action button
+- 셀 bottom sheet 직접 deep link, public URL scheme
+- 잠금 화면 내용 숨기기 옵션
+- 새로운 notification analytics SDK
+
+## 13. 완료 조건
+
+- 기능을 직접 켜기 전에는 권한 prompt가 나타나지 않는다.
+- 가까운 32개 적격 board/date batch는 두 플랫폼에서 오전 9시를 목표로 마감일 당일 best-effort 알림을 받을 수 있다.
+- 32개 초과 또는 platform add 실패는 가까운 순서, overflow count와 refill 상태로 사용자에게 드러난다.
+- DB 변경 뒤 오래된 pending/delivered 알림이 다음 reconcile에서 제거된다.
+- Android Worker는 발송 직전 DB 상태를 재검증한다.
+- 알림 탭은 cold/warm 상태 모두 올바른 반다라트를 선택한다.
+- 권한 거절과 scheduler 실패가 due date 저장을 막지 않는다.
+- Android/iOS 실제 기기와 Internal/TestFlight 체크리스트가 완료된다.


### PR DESCRIPTION
## 🔗 관련 이슈

- #211

## 📙 작업 설명

- Android WorkManager와 iOS UserNotifications 기반 로컬 알림의 공식 API·저장소 접점을 조사했습니다.
- 마감일 당일 알림, board/date 집계, 전역 top 32, 권한과 설정 상태, 전체 reconcile 정책을 문서로 고정했습니다.
- 예정 PR 1~5와 실제 main·Play Internal·TestFlight 진행률을 체크박스로 구분했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

문서 상대 링크와 `git diff --check`를 확인했습니다.

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 문서 변경 | 해당 없음 | 문서 변경 | 해당 없음 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

- 이번 PR은 조사·전략 문서만 포함하며 공통 foundation 코드는 후속 PR로 분리합니다.
- Android Internal과 iOS TestFlight 출하 여부를 로컬 구현 완료와 별도 체크박스로 관리합니다.