### PR TITLE
feat: Android 마감일 알림 추가

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     tools:ignore="LockedOrientationActivity">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <queries>
@@ -64,6 +65,23 @@
             </intent-filter>
 
         </activity>
+
+        <activity
+            android:name="com.nexters.bandalart.DeadlineNotificationTrampolineActivity"
+            android:excludeFromRecents="true"
+            android:exported="false"
+            android:noHistory="true"
+            android:theme="@style/Theme.Bandalart" />
+
+        <receiver
+            android:name="com.nexters.bandalart.notification.DeadlineReminderTimeChangeReceiver"
+            android:enabled="true"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.TIME_SET" />
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+            </intent-filter>
+        </receiver>
 
     </application>
 

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
@@ -17,6 +17,7 @@
 package com.nexters.bandalart
 
 import android.app.Application
+import android.content.Intent
 import com.google.firebase.Firebase
 import com.google.firebase.initialize
 import com.nexters.bandalart.ads.AdsInitializer
@@ -25,6 +26,7 @@ import com.nexters.bandalart.ads.AndroidRewardedAdGateway
 import com.nexters.bandalart.ads.DelegatingRewardedAdGateway
 import com.nexters.bandalart.di.metro.AppGraph
 import com.nexters.bandalart.di.metro.createAndroidAppGraph
+import com.nexters.bandalart.di.metro.installAndroidDeadlineReminderInfrastructure
 import com.nexters.bandalart.di.metro.recordRewardedCreation
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
@@ -45,6 +47,9 @@ class BandalartApplication : Application() {
                 bannerAdHost = bannerAdHost,
                 rewardedAdGateway = rewardedAdGateway,
             )
+        installAndroidDeadlineReminderInfrastructure(appGraph) { _, _ ->
+            Intent(this, DeadlineNotificationTrampolineActivity::class.java)
+        }
         rewardedAdGateway.delegate =
             AndroidRewardedAdGateway(
                 application = this,

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/DeadlineNotificationTrampolineActivity.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/DeadlineNotificationTrampolineActivity.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import com.nexters.bandalart.di.metro.recordAndroidDeadlineNotificationLaunch
+import com.nexters.bandalart.notification.DeadlineReminderWorker
+
+class DeadlineNotificationTrampolineActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val bandalartId =
+            intent
+                .takeIf { it.action == DeadlineReminderWorker.ACTION_OPEN_DEADLINE }
+                ?.getLongExtra(DeadlineReminderWorker.EXTRA_BANDALART_ID, -1L)
+                ?: -1L
+        if (bandalartId > 0L) {
+            recordAndroidDeadlineNotificationLaunch(
+                appGraph = (application as BandalartApplication).appGraph,
+                bandalartId = bandalartId,
+            )
+        }
+        startActivity(
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            },
+        )
+        finish()
+    }
+}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -28,6 +28,8 @@ kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(libs.androidx.activity.compose)
+            implementation(libs.androidx.work.runtime.ktx)
+            implementation(libs.androidx.core)
         }
 
         androidHostTest.dependencies {
@@ -36,6 +38,7 @@ kotlin {
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.robolectric)
             implementation(libs.robolectric.junit5.extension)
+            implementation(libs.androidx.work.testing)
         }
 
         commonMain.dependencies {

--- a/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/notification/AndroidDeadlineReminderSchedulerTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/notification/AndroidDeadlineReminderSchedulerTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.notification
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.Configuration
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.testing.SynchronousExecutor
+import androidx.work.testing.WorkManagerTestInitHelper
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderBatch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.flow.first
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.datetime.toLocalDateTime
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+
+@ExtendWith(RobolectricExtension::class)
+@Config(sdk = [35])
+class AndroidDeadlineReminderSchedulerTest {
+    private lateinit var application: Application
+    private lateinit var workManager: WorkManager
+    private lateinit var scheduler: AndroidDeadlineReminderScheduler
+
+    @BeforeEach
+    fun setUp() {
+        application = ApplicationProvider.getApplicationContext()
+        WorkManagerTestInitHelper.initializeTestWorkManager(
+            application,
+            Configuration.Builder().setExecutor(SynchronousExecutor()).build(),
+        )
+        workManager = WorkManager.getInstance(application)
+        scheduler = AndroidDeadlineReminderScheduler(application, workManager)
+    }
+
+    @Test
+    fun replaceUsesStableUniqueWorkAndClearCancelsIt() =
+        runTest {
+            val dueDate =
+                Clock.System
+                    .now()
+                    .plus(2, DateTimeUnit.DAY, TimeZone.currentSystemDefault())
+                    .toLocalDateTime(TimeZone.currentSystemDefault())
+                    .date
+            val batch = DeadlineReminderBatch(bandalartId = 3, dueDate = dueDate, items = emptyList())
+
+            scheduler.replaceAll(listOf(batch))
+            scheduler.replaceAll(listOf(batch))
+
+            val active =
+                workManager
+                    .getWorkInfosByTagFlow(DeadlineReminderWork.FEATURE_TAG)
+                    .first()
+                    .filterNot { info -> info.state == WorkInfo.State.CANCELLED }
+            assertEquals(1, active.size)
+            assertTrue(active.single().tags.containsAll(setOf(DeadlineReminderWork.FEATURE_TAG, batch.id)))
+            assertTrue(active.single().nextScheduleTimeMillis > System.currentTimeMillis())
+            assertTrue(deadlineNotificationDataUri(batch.id) != deadlineNotificationDataUri("${batch.id}.other"))
+
+            scheduler.clearAll()
+
+            val afterClear = workManager.getWorkInfosByTagFlow(DeadlineReminderWork.FEATURE_TAG).first()
+            assertTrue(afterClear.all { info -> info.state == WorkInfo.State.CANCELLED })
+        }
+}

--- a/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/notification/DeadlineReminderWorkerTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/notification/DeadlineReminderWorkerTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.notification
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import androidx.work.workDataOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+
+@ExtendWith(RobolectricExtension::class)
+@Config(sdk = [35])
+class DeadlineReminderWorkerTest {
+    private lateinit var context: Context
+
+    @BeforeEach
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        AndroidDeadlineReminderDependenciesRegistry.clearForTest()
+    }
+
+    @Test
+    fun reminderWorkerRetriesWhenProcessDependenciesAreNotInstalledYet() =
+        runTest {
+            AndroidDeadlineReminderDependenciesRegistry.clearForTest()
+            val worker =
+                TestListenableWorkerBuilder<DeadlineReminderWorker>(context)
+                    .setInputData(
+                        workDataOf(
+                            DeadlineReminderWork.KEY_BATCH_ID to "deadline.v1.board.1.date.2026-08-09",
+                            DeadlineReminderWork.KEY_BANDALART_ID to 1L,
+                            DeadlineReminderWork.KEY_DUE_DATE to "2026-08-09",
+                        ),
+                    ).build()
+
+            assertTrue(worker.doWork() is ListenableWorker.Result.Retry)
+        }
+
+    @Test
+    fun reconcileWorkerRetriesWhenProcessDependenciesAreNotInstalledYet() =
+        runTest {
+            AndroidDeadlineReminderDependenciesRegistry.clearForTest()
+            val worker = TestListenableWorkerBuilder<DeadlineReminderReconcileWorker>(context).build()
+
+            assertTrue(worker.doWork() is ListenableWorker.Result.Retry)
+        }
+}

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
@@ -17,6 +17,7 @@
 package com.nexters.bandalart.di.metro
 
 import android.app.Application
+import android.content.Intent
 import com.nexters.bandalart.core.common.AndroidSupportMailLauncher
 import com.nexters.bandalart.core.common.AppVersionProvider
 import com.nexters.bandalart.core.common.BannerAdHost
@@ -24,6 +25,10 @@ import com.nexters.bandalart.core.common.ImageHandlerProvider
 import com.nexters.bandalart.core.common.RewardedAdGateway
 import com.nexters.bandalart.core.database.BandalartDatabaseFactory
 import com.nexters.bandalart.core.datastore.BandalartDataStoreFactory
+import com.nexters.bandalart.notification.AndroidDeadlineNotificationAuthorization
+import com.nexters.bandalart.notification.AndroidDeadlineReminderScheduler
+import com.nexters.bandalart.notification.AndroidDeadlineReminderDependencies
+import com.nexters.bandalart.notification.AndroidDeadlineReminderDependenciesRegistry
 
 private class AndroidPlatformBindings(
     application: Application,
@@ -35,6 +40,8 @@ private class AndroidPlatformBindings(
     override val appVersionProvider = AppVersionProvider(application)
     override val imageHandlerProvider = ImageHandlerProvider(application)
     override val supportMailLauncher = AndroidSupportMailLauncher(application)
+    override val deadlineReminderScheduler = AndroidDeadlineReminderScheduler(application)
+    override val deadlineNotificationAuthorization = AndroidDeadlineNotificationAuthorization(application)
 }
 
 fun createAndroidAppGraph(
@@ -42,6 +49,40 @@ fun createAndroidAppGraph(
     bannerAdHost: BannerAdHost,
     rewardedAdGateway: RewardedAdGateway,
 ): AppGraph = createAppGraph(AndroidPlatformBindings(application, bannerAdHost, rewardedAdGateway))
+
+fun installAndroidDeadlineReminderInfrastructure(
+    appGraph: AppGraph,
+    launchIntentFactory: (batchId: String, bandalartId: Long) -> Intent,
+) {
+    AndroidDeadlineReminderDependenciesRegistry.install(
+        object : AndroidDeadlineReminderDependencies {
+            override val deadlineReminderProjectionRepository
+                get() = appGraph.deadlineReminderProjectionRepository
+            override val settingsRepository
+                get() = appGraph.settingsRepository
+            override val deadlineNotificationAuthorization
+                get() = appGraph.deadlineNotificationAuthorization
+            override val deadlineReminderReconciler
+                get() = appGraph.deadlineReminderReconciler
+
+            override fun createDeadlineNotificationLaunchIntent(
+                batchId: String,
+                bandalartId: Long,
+            ): Intent = launchIntentFactory(batchId, bandalartId)
+        },
+    )
+}
+
+suspend fun reconcileAndroidDeadlineReminders(appGraph: AppGraph) {
+    appGraph.deadlineReminderReconciler.reconcileAll()
+}
+
+fun recordAndroidDeadlineNotificationLaunch(
+    appGraph: AppGraph,
+    bandalartId: Long,
+) {
+    appGraph.deadlineNotificationLaunchTarget.record(bandalartId)
+}
 
 suspend fun recordRewardedCreation(
     appGraph: AppGraph,

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/notification/AndroidDeadlineNotificationAuthorization.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/notification/AndroidDeadlineNotificationAuthorization.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.notification
+
+import android.Manifest
+import android.app.Application
+import android.app.NotificationManager
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.Settings
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.nexters.bandalart.core.common.DeadlineNotificationPermissionHistory
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorization
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorizationStatus
+
+class AndroidDeadlineNotificationAuthorization(
+    private val application: Application,
+) : DeadlineNotificationAuthorization {
+    override suspend fun getStatus(): DeadlineNotificationAuthorizationStatus {
+        if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(application, Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_DENIED
+        ) {
+            return if (DeadlineNotificationPermissionHistory.isBlocked(application)) {
+                DeadlineNotificationAuthorizationStatus.BLOCKED
+            } else {
+                DeadlineNotificationAuthorizationStatus.REQUESTABLE
+            }
+        }
+        if (!NotificationManagerCompat.from(application).areNotificationsEnabled()) {
+            return DeadlineNotificationAuthorizationStatus.BLOCKED
+        }
+        val channel =
+            application
+                .getSystemService(NotificationManager::class.java)
+                .getNotificationChannel(DeadlineReminderWork.CHANNEL_ID)
+        return if (channel?.importance == NotificationManager.IMPORTANCE_NONE) {
+            DeadlineNotificationAuthorizationStatus.BLOCKED
+        } else {
+            DeadlineNotificationAuthorizationStatus.GRANTED
+        }
+    }
+
+    override suspend fun requestAuthorization(): DeadlineNotificationAuthorizationStatus = getStatus()
+
+    override suspend fun openSettings() {
+        val intent =
+            Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+                .putExtra(Settings.EXTRA_APP_PACKAGE, application.packageName)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        application.startActivity(intent)
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/notification/AndroidDeadlineReminderScheduler.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/notification/AndroidDeadlineReminderScheduler.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.notification
+
+import android.app.Application
+import android.app.NotificationManager
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.await
+import androidx.work.workDataOf
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderBatch
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderScheduler
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingErrorCategory
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingResult
+import kotlinx.coroutines.CancellationException
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.toJavaDuration
+
+class AndroidDeadlineReminderScheduler(
+    private val application: Application,
+    private val configuredWorkManager: WorkManager? = null,
+) : DeadlineReminderScheduler {
+    private val workManager: WorkManager
+        get() = configuredWorkManager ?: WorkManager.getInstance(application)
+
+    override suspend fun replaceAll(batches: List<DeadlineReminderBatch>): DeadlineReminderSchedulingResult {
+        clearFeatureState()
+
+        var scheduledCount = 0
+        return try {
+            batches.forEach { batch ->
+                val target =
+                    LocalDateTime(batch.dueDate, LocalTime(hour = 9, minute = 0))
+                        .toInstant(TimeZone.currentSystemDefault())
+                val delay = target - Clock.System.now()
+                if (delay.isPositive()) {
+                    val request =
+                        OneTimeWorkRequestBuilder<DeadlineReminderWorker>()
+                            .setInitialDelay(delay.inWholeMilliseconds.milliseconds.toJavaDuration())
+                            .setInputData(
+                                workDataOf(
+                                    DeadlineReminderWork.KEY_BATCH_ID to batch.id,
+                                    DeadlineReminderWork.KEY_BANDALART_ID to batch.bandalartId,
+                                    DeadlineReminderWork.KEY_DUE_DATE to batch.dueDate.toString(),
+                                ),
+                            ).addTag(DeadlineReminderWork.FEATURE_TAG)
+                            .addTag(batch.id)
+                            .build()
+                    workManager
+                        .enqueueUniqueWork(
+                            DeadlineReminderWork.uniqueWorkName(batch.id),
+                            ExistingWorkPolicy.REPLACE,
+                            request,
+                        ).await()
+                    scheduledCount += 1
+                }
+            }
+            DeadlineReminderSchedulingResult(scheduledCount = scheduledCount)
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (_: Exception) {
+            DeadlineReminderSchedulingResult(
+                scheduledCount = scheduledCount,
+                lastErrorCategory = DeadlineReminderSchedulingErrorCategory.SCHEDULING,
+            )
+        }
+    }
+
+    override suspend fun clearAll(): DeadlineReminderSchedulingResult =
+        try {
+            clearFeatureState()
+            DeadlineReminderSchedulingResult(scheduledCount = 0)
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (_: Exception) {
+            DeadlineReminderSchedulingResult(
+                scheduledCount = 0,
+                lastErrorCategory = DeadlineReminderSchedulingErrorCategory.CANCELLATION,
+            )
+        }
+
+    private suspend fun clearFeatureState() {
+        workManager.cancelAllWorkByTag(DeadlineReminderWork.FEATURE_TAG).await()
+        val notificationManager = application.getSystemService(NotificationManager::class.java)
+        notificationManager.activeNotifications
+            .asSequence()
+            .mapNotNull { notification -> notification.tag }
+            .filter(DeadlineReminderWork::isFeatureBatchId)
+            .forEach { tag -> notificationManager.cancel(tag, DeadlineReminderWork.NOTIFICATION_ID) }
+    }
+}
+
+internal object DeadlineReminderWork {
+    const val FEATURE_TAG = "deadline.v1"
+    const val RECONCILE_WORK_NAME = "deadline.v1.reconcile"
+    const val KEY_BATCH_ID = "batch_id"
+    const val KEY_BANDALART_ID = "bandalart_id"
+    const val KEY_DUE_DATE = "due_date"
+    const val NOTIFICATION_ID = 0
+    const val CHANNEL_ID = "deadline_reminder"
+
+    fun uniqueWorkName(batchId: String): String = "deadline.v1.work.$batchId"
+
+    fun isFeatureBatchId(value: String): Boolean = value.startsWith("deadline.v1.board.")
+}

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/notification/DeadlineReminderTimeChangeReceiver.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/notification/DeadlineReminderTimeChangeReceiver.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.notification
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+
+class DeadlineReminderTimeChangeReceiver : BroadcastReceiver() {
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        if (intent.action != Intent.ACTION_TIME_CHANGED && intent.action != Intent.ACTION_TIMEZONE_CHANGED) return
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            DeadlineReminderWork.RECONCILE_WORK_NAME,
+            ExistingWorkPolicy.REPLACE,
+            OneTimeWorkRequestBuilder<DeadlineReminderReconcileWorker>().build(),
+        )
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/notification/DeadlineReminderWorker.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/notification/DeadlineReminderWorker.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.notification
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.app.NotificationCompat
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorizationStatus
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderDueDateParser
+import com.nexters.bandalart.shared.R
+import kotlinx.coroutines.flow.first
+import kotlinx.datetime.Clock
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+interface AndroidDeadlineReminderDependencies {
+    val deadlineReminderProjectionRepository:
+        com.nexters.bandalart.core.domain.repository.DeadlineReminderProjectionRepository
+    val settingsRepository: com.nexters.bandalart.core.domain.repository.SettingsRepository
+    val deadlineNotificationAuthorization:
+        com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorization
+    val deadlineReminderReconciler:
+        com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
+
+    fun createDeadlineNotificationLaunchIntent(
+        batchId: String,
+        bandalartId: Long,
+    ): Intent
+}
+
+object AndroidDeadlineReminderDependenciesRegistry {
+    private var dependencies: AndroidDeadlineReminderDependencies? = null
+
+    fun install(dependencies: AndroidDeadlineReminderDependencies) {
+        this.dependencies = dependencies
+    }
+
+    internal fun get(): AndroidDeadlineReminderDependencies? = dependencies
+
+    internal fun clearForTest() {
+        dependencies = null
+    }
+}
+
+class DeadlineReminderWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val batchId = inputData.getString(DeadlineReminderWork.KEY_BATCH_ID) ?: return Result.success()
+        val bandalartId = inputData.getLong(DeadlineReminderWork.KEY_BANDALART_ID, -1L)
+        val dueDate = inputData.getString(DeadlineReminderWork.KEY_DUE_DATE)?.let(LocalDate::parse) ?: return Result.success()
+        if (bandalartId <= 0L || !DeadlineReminderWork.isFeatureBatchId(batchId)) return Result.success()
+
+        val dependencies = AndroidDeadlineReminderDependenciesRegistry.get() ?: return Result.retry()
+        if (!dependencies.settingsRepository.deadlineReminderEnabled.first()) return Result.success()
+        if (
+            dependencies.deadlineNotificationAuthorization.getStatus() !=
+            DeadlineNotificationAuthorizationStatus.GRANTED
+        ) {
+            return Result.success()
+        }
+
+        val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
+        if (now.date != dueDate || now.hour < 9) return Result.success()
+        val items =
+            dependencies.deadlineReminderProjectionRepository
+                .getCandidates()
+                .asSequence()
+                .filter { candidate ->
+                    candidate.bandalartId == bandalartId &&
+                        !candidate.isCompleted &&
+                        !candidate.title.isNullOrBlank() &&
+                        DeadlineReminderDueDateParser.parse(candidate.dueDate) == dueDate
+                }.map { candidate -> candidate.title.orEmpty().trim() }
+                .sorted()
+                .toList()
+        if (items.isEmpty()) return Result.success()
+
+        publishNotification(
+            batchId = batchId,
+            bandalartId = bandalartId,
+            items = items,
+            dependencies = dependencies,
+        )
+        return Result.success()
+    }
+
+    private fun publishNotification(
+        batchId: String,
+        bandalartId: Long,
+        items: List<String>,
+        dependencies: AndroidDeadlineReminderDependencies,
+    ) {
+        val notificationManager = applicationContext.getSystemService(NotificationManager::class.java)
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                DeadlineReminderWork.CHANNEL_ID,
+                applicationContext.getString(R.string.deadline_reminder_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            ).apply {
+                description = applicationContext.getString(R.string.deadline_reminder_channel_description)
+            },
+        )
+        val launchIntent =
+            dependencies
+                .createDeadlineNotificationLaunchIntent(batchId, bandalartId)
+                .setAction(ACTION_OPEN_DEADLINE)
+                .setData(deadlineNotificationDataUri(batchId))
+                .putExtra(EXTRA_BANDALART_ID, bandalartId)
+        val contentIntent =
+            PendingIntent.getActivity(
+                applicationContext,
+                0,
+                launchIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+            )
+        val content =
+            if (items.size == 1) {
+                applicationContext.getString(R.string.deadline_reminder_single_body, items.single())
+            } else {
+                applicationContext.getString(R.string.deadline_reminder_multiple_body, items.size)
+            }
+        val notification =
+            NotificationCompat
+                .Builder(applicationContext, DeadlineReminderWork.CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.ic_dialog_info)
+                .setContentTitle(applicationContext.getString(R.string.deadline_reminder_title))
+                .setContentText(content)
+                .setStyle(NotificationCompat.BigTextStyle().bigText(content))
+                .setContentIntent(contentIntent)
+                .setAutoCancel(true)
+                .build()
+        notificationManager.notify(batchId, DeadlineReminderWork.NOTIFICATION_ID, notification)
+    }
+
+    companion object {
+        const val ACTION_OPEN_DEADLINE = "com.nexters.bandalart.action.OPEN_DEADLINE"
+        const val EXTRA_BANDALART_ID = "deadline_bandalart_id"
+    }
+}
+
+class DeadlineReminderReconcileWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val dependencies = AndroidDeadlineReminderDependenciesRegistry.get() ?: return Result.retry()
+        dependencies.deadlineReminderReconciler.reconcileAll()
+        return Result.success()
+    }
+}
+
+internal fun deadlineNotificationDataUri(batchId: String): Uri = Uri.parse("bandalart://deadline/$batchId")

--- a/composeApp/src/androidMain/res/values-ja/strings.xml
+++ b/composeApp/src/androidMain/res/values-ja/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="deadline_reminder_channel_name">締切日リマインダー</string>
+    <string name="deadline_reminder_channel_description">今日が締切の目標をお知らせします</string>
+    <string name="deadline_reminder_title">今日が締め切りの目標があります</string>
+    <string name="deadline_reminder_single_body">%1$sを完了する時間です。</string>
+    <string name="deadline_reminder_multiple_body">%1$d個の目標が今日締切です。</string>
+</resources>

--- a/composeApp/src/androidMain/res/values-ko/strings.xml
+++ b/composeApp/src/androidMain/res/values-ko/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="deadline_reminder_channel_name">마감일 알림</string>
+    <string name="deadline_reminder_channel_description">오늘 마감인 목표를 알려드려요</string>
+    <string name="deadline_reminder_title">오늘 마감인 목표가 있어요</string>
+    <string name="deadline_reminder_single_body">%1$s을(를) 완료할 시간이에요.</string>
+    <string name="deadline_reminder_multiple_body">%1$d개의 목표가 오늘 마감이에요.</string>
+</resources>

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="deadline_reminder_channel_name">Deadline reminders</string>
+    <string name="deadline_reminder_channel_description">Notifies you about goals due today</string>
+    <string name="deadline_reminder_title">You have goals due today</string>
+    <string name="deadline_reminder_single_body">Time to complete %1$s.</string>
+    <string name="deadline_reminder_multiple_body">%1$d goals are due today.</string>
+</resources>

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/AppGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/AppGraph.kt
@@ -32,6 +32,11 @@ import com.nexters.bandalart.core.domain.repository.BandalartSlotRepository
 import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
 import com.nexters.bandalart.core.domain.repository.OnboardingRepository
 import com.nexters.bandalart.core.domain.repository.SettingsRepository
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorization
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationLaunchTarget
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderScheduler
+import com.nexters.bandalart.core.domain.repository.DeadlineReminderProjectionRepository
 import com.slack.circuit.foundation.Circuit
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.DependencyGraph
@@ -46,6 +51,8 @@ interface PlatformBindings {
     val imageHandlerProvider: ImageHandlerProvider
     val supportMailLauncher: SupportMailLauncher
     val rewardedAdGateway: RewardedAdGateway
+    val deadlineReminderScheduler: DeadlineReminderScheduler
+    val deadlineNotificationAuthorization: DeadlineNotificationAuthorization
 }
 
 @DependencyGraph(
@@ -71,6 +78,11 @@ interface AppGraph {
     val inAppUpdateRepository: InAppUpdateRepository
     val onboardingRepository: OnboardingRepository
     val settingsRepository: SettingsRepository
+    val deadlineNotificationAuthorization: DeadlineNotificationAuthorization
+    val deadlineReminderScheduler: DeadlineReminderScheduler
+    val deadlineReminderProjectionRepository: DeadlineReminderProjectionRepository
+    val deadlineReminderReconciler: DeadlineReminderReconciler
+    val deadlineNotificationLaunchTarget: DeadlineNotificationLaunchTarget
     val circuit: Circuit
 
     @DependencyGraph.Factory

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
@@ -106,5 +106,10 @@ object RepositoryBindings {
 }
 
 private object SystemDeadlineReminderClock : Clock {
-    override fun now(): Instant = Instant.fromEpochMilliseconds(kotlin.time.Clock.System.now().toEpochMilliseconds())
+    override fun now(): Instant =
+        Instant.fromEpochMilliseconds(
+            kotlin.time.Clock.System
+                .now()
+                .toEpochMilliseconds(),
+        )
 }

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
@@ -43,8 +43,8 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
-import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
+import kotlin.time.Clock
 
 @BindingContainer
 object RepositoryBindings {

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
@@ -18,6 +18,8 @@ package com.nexters.bandalart.di.metro
 
 import com.nexters.bandalart.core.data.repository.DefaultBandalartRepository
 import com.nexters.bandalart.core.data.repository.DefaultBandalartSlotRepository
+import com.nexters.bandalart.core.data.notification.DefaultDeadlineReminderReconciler
+import com.nexters.bandalart.core.data.repository.DefaultDeadlineReminderProjectionRepository
 import com.nexters.bandalart.core.data.repository.DefaultInAppUpdateRepository
 import com.nexters.bandalart.core.data.repository.DefaultOnboardingRepository
 import com.nexters.bandalart.core.data.repository.DefaultSettingsRepository
@@ -29,10 +31,20 @@ import com.nexters.bandalart.core.domain.repository.BandalartSlotRepository
 import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
 import com.nexters.bandalart.core.domain.repository.OnboardingRepository
 import com.nexters.bandalart.core.domain.repository.SettingsRepository
+import com.nexters.bandalart.core.domain.notification.BufferedDeadlineNotificationLaunchTarget
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorization
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationLaunchTarget
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderPlanner
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderScheduler
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderTimeZoneProvider
+import com.nexters.bandalart.core.domain.repository.DeadlineReminderProjectionRepository
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
+import kotlinx.datetime.Clock
+import kotlinx.datetime.TimeZone
 
 @BindingContainer
 object RepositoryBindings {
@@ -41,7 +53,8 @@ object RepositoryBindings {
     fun provideBandalartRepository(
         bandalartDataStore: BandalartDataStore,
         bandalartDao: BandalartDao,
-    ): BandalartRepository = DefaultBandalartRepository(bandalartDataStore, bandalartDao)
+        deadlineReminderReconciler: DeadlineReminderReconciler,
+    ): BandalartRepository = DefaultBandalartRepository(bandalartDataStore, bandalartDao, deadlineReminderReconciler)
 
     @Provides
     @SingleIn(AppScope::class)
@@ -60,4 +73,33 @@ object RepositoryBindings {
     @Provides
     @SingleIn(AppScope::class)
     fun provideSettingsRepository(bandalartDataStore: BandalartDataStore): SettingsRepository = DefaultSettingsRepository(bandalartDataStore)
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideDeadlineReminderProjectionRepository(bandalartDao: BandalartDao): DeadlineReminderProjectionRepository =
+        DefaultDeadlineReminderProjectionRepository(bandalartDao)
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideDeadlineReminderReconciler(
+        settingsRepository: SettingsRepository,
+        projectionRepository: DeadlineReminderProjectionRepository,
+        scheduler: DeadlineReminderScheduler,
+        authorization: DeadlineNotificationAuthorization,
+    ): DeadlineReminderReconciler =
+        DefaultDeadlineReminderReconciler(
+            settingsRepository = settingsRepository,
+            projectionRepository = projectionRepository,
+            planner =
+                DeadlineReminderPlanner(
+                    clock = Clock.System,
+                    timeZoneProvider = DeadlineReminderTimeZoneProvider(TimeZone::currentSystemDefault),
+                ),
+            scheduler = scheduler,
+            authorization = authorization,
+        )
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideDeadlineNotificationLaunchTarget(): DeadlineNotificationLaunchTarget = BufferedDeadlineNotificationLaunchTarget()
 }

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
@@ -43,8 +43,9 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
-import kotlin.time.Clock
 
 @BindingContainer
 object RepositoryBindings {
@@ -92,7 +93,7 @@ object RepositoryBindings {
             projectionRepository = projectionRepository,
             planner =
                 DeadlineReminderPlanner(
-                    clock = Clock.System,
+                    clock = SystemDeadlineReminderClock,
                     timeZoneProvider = DeadlineReminderTimeZoneProvider(TimeZone::currentSystemDefault),
                 ),
             scheduler = scheduler,
@@ -102,4 +103,8 @@ object RepositoryBindings {
     @Provides
     @SingleIn(AppScope::class)
     fun provideDeadlineNotificationLaunchTarget(): DeadlineNotificationLaunchTarget = BufferedDeadlineNotificationLaunchTarget()
+}
+
+private object SystemDeadlineReminderClock : Clock {
+    override fun now(): Instant = Instant.fromEpochMilliseconds(kotlin.time.Clock.System.now().toEpochMilliseconds())
 }

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/di/metro/IosAppGraph.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/di/metro/IosAppGraph.kt
@@ -23,6 +23,8 @@ import com.nexters.bandalart.core.common.NoOpBannerAdHost
 import com.nexters.bandalart.core.common.NoOpRewardedAdGateway
 import com.nexters.bandalart.core.database.BandalartDatabaseFactory
 import com.nexters.bandalart.core.datastore.BandalartDataStoreFactory
+import com.nexters.bandalart.core.domain.notification.NoOpDeadlineNotificationAuthorization
+import com.nexters.bandalart.core.domain.notification.NoOpDeadlineReminderScheduler
 
 private object IosPlatformBindings : PlatformBindings {
     override val databaseFactory = BandalartDatabaseFactory()
@@ -32,6 +34,8 @@ private object IosPlatformBindings : PlatformBindings {
     override val imageHandlerProvider = ImageHandlerProvider()
     override val supportMailLauncher = IosSupportMailLauncher()
     override val rewardedAdGateway = NoOpRewardedAdGateway
+    override val deadlineReminderScheduler = NoOpDeadlineReminderScheduler
+    override val deadlineNotificationAuthorization = NoOpDeadlineNotificationAuthorization
 }
 
 internal fun createIosAppGraph(): AppGraph = createAppGraph(IosPlatformBindings)

--- a/core/common/src/androidMain/kotlin/com/nexters/bandalart/core/common/DeadlineNotificationPermissionHistory.kt
+++ b/core/common/src/androidMain/kotlin/com/nexters/bandalart/core/common/DeadlineNotificationPermissionHistory.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.common
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+
+object DeadlineNotificationPermissionHistory {
+    fun isBlocked(context: Context): Boolean = preferences(context).getBoolean(KEY_BLOCKED, false)
+
+    fun recordPromptResult(activity: Activity) {
+        val granted =
+            ContextCompat.checkSelfPermission(activity, Manifest.permission.POST_NOTIFICATIONS) ==
+                PackageManager.PERMISSION_GRANTED
+        val preferences = preferences(activity)
+        if (granted) {
+            preferences.edit().clear().apply()
+            return
+        }
+
+        val canShowRationale = ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.POST_NOTIFICATIONS)
+        val hadRequestableDenial = preferences.getBoolean(KEY_REQUESTABLE_DENIAL, false)
+        preferences
+            .edit()
+            .apply {
+                when {
+                    canShowRationale -> putBoolean(KEY_REQUESTABLE_DENIAL, true)
+                    hadRequestableDenial -> putBoolean(KEY_BLOCKED, true)
+                }
+            }.apply()
+    }
+
+    private fun preferences(context: Context) = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+
+    private const val PREFERENCES_NAME = "deadline_notification_permission"
+    private const val KEY_REQUESTABLE_DENIAL = "requestable_denial"
+    private const val KEY_BLOCKED = "blocked"
+}

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
         androidHostTest.dependencies {
             implementation(libs.bundles.android.unit.test)
             implementation(libs.kotlinx.coroutines.test)
+            implementation(libs.kotlinx.datetime)
         }
     }
 }

--- a/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/notification/DefaultDeadlineReminderReconcilerTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/notification/DefaultDeadlineReminderReconcilerTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.data.notification
+
+import com.nexters.bandalart.core.domain.entity.ThemeMode
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorization
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorizationStatus
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderBatch
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderCandidate
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderPlanner
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderScheduler
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingErrorCategory
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingResult
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderTimeZoneProvider
+import com.nexters.bandalart.core.domain.repository.DeadlineReminderProjectionRepository
+import com.nexters.bandalart.core.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DefaultDeadlineReminderReconcilerTest {
+    private val settings = FakeSettingsRepository()
+    private val projection =
+        object : DeadlineReminderProjectionRepository {
+            override suspend fun getCandidates() = listOf(DeadlineReminderCandidate(1, 7, "launch", "2026-08-10T00:00", false))
+        }
+    private val scheduler = RecordingScheduler()
+    private val authorization = FakeAuthorization()
+    private val reconciler =
+        DefaultDeadlineReminderReconciler(
+            settingsRepository = settings,
+            projectionRepository = projection,
+            planner =
+                DeadlineReminderPlanner(
+                    clock =
+                        object : Clock {
+                            override fun now(): Instant = Instant.parse("2026-08-09T00:00:00Z")
+                        },
+                    timeZoneProvider = DeadlineReminderTimeZoneProvider { TimeZone.UTC },
+                ),
+            scheduler = scheduler,
+            authorization = authorization,
+        )
+
+    @Test
+    fun disabledPreferenceClearsAllPlatformState() =
+        runTest {
+            reconciler.reconcileAll()
+
+            assertEquals(1, scheduler.clearCalls)
+            assertTrue(scheduler.replacedBatches.isEmpty())
+        }
+
+    @Test
+    fun enabledAndAuthorizedPreferenceSchedulesDesiredBatches() =
+        runTest {
+            settings.setDeadlineReminderEnabled(true)
+            authorization.status = DeadlineNotificationAuthorizationStatus.GRANTED
+
+            reconciler.reconcileAll()
+
+            assertEquals(listOf("deadline.v1.board.7.date.2026-08-10"), scheduler.replacedBatches.map { it.id })
+            assertEquals(1, reconciler.schedulingHealth.value.scheduledCount)
+        }
+
+    @Test
+    fun blockedAuthorizationClearsPlatformStateWithoutLosingUserPreference() =
+        runTest {
+            settings.setDeadlineReminderEnabled(true)
+            authorization.status = DeadlineNotificationAuthorizationStatus.BLOCKED
+
+            reconciler.reconcileAll()
+
+            assertEquals(1, scheduler.clearCalls)
+            assertTrue(settings.deadlineReminderEnabled.value)
+            assertEquals(
+                DeadlineReminderSchedulingErrorCategory.AUTHORIZATION,
+                reconciler.schedulingHealth.value.lastErrorCategory,
+            )
+        }
+
+    @Test
+    fun partialPlatformSchedulingIsIncludedInOverflowHealth() =
+        runTest {
+            settings.setDeadlineReminderEnabled(true)
+            authorization.status = DeadlineNotificationAuthorizationStatus.GRANTED
+            scheduler.scheduledCount = 0
+            scheduler.lastErrorCategory = DeadlineReminderSchedulingErrorCategory.SCHEDULING
+
+            reconciler.reconcileAll()
+
+            assertEquals(1, reconciler.schedulingHealth.value.overflowCount)
+            assertEquals(
+                DeadlineReminderSchedulingErrorCategory.SCHEDULING,
+                reconciler.schedulingHealth.value.lastErrorCategory,
+            )
+        }
+
+    private class RecordingScheduler : DeadlineReminderScheduler {
+        var clearCalls = 0
+        var replacedBatches = emptyList<DeadlineReminderBatch>()
+        var scheduledCount: Int? = null
+        var lastErrorCategory: DeadlineReminderSchedulingErrorCategory? = null
+
+        override suspend fun replaceAll(batches: List<DeadlineReminderBatch>): DeadlineReminderSchedulingResult {
+            replacedBatches = batches
+            return DeadlineReminderSchedulingResult(
+                scheduledCount = scheduledCount ?: batches.size,
+                lastErrorCategory = lastErrorCategory,
+            )
+        }
+
+        override suspend fun clearAll(): DeadlineReminderSchedulingResult {
+            clearCalls += 1
+            return DeadlineReminderSchedulingResult(scheduledCount = 0)
+        }
+    }
+
+    private class FakeAuthorization : DeadlineNotificationAuthorization {
+        var status = DeadlineNotificationAuthorizationStatus.REQUESTABLE
+
+        override suspend fun getStatus() = status
+
+        override suspend fun requestAuthorization() = status
+
+        override suspend fun openSettings() = Unit
+    }
+
+    private class FakeSettingsRepository : SettingsRepository {
+        override val themeMode: Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
+        override val recentEmojis: Flow<List<String>> = MutableStateFlow(emptyList())
+        override val deadlineReminderEnabled = MutableStateFlow(false)
+
+        override suspend fun setThemeMode(themeMode: ThemeMode) = Unit
+
+        override suspend fun addRecentEmoji(emoji: String) = Unit
+
+        override suspend fun setDeadlineReminderEnabled(enabled: Boolean) {
+            deadlineReminderEnabled.value = enabled
+        }
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/notification/DefaultDeadlineReminderReconciler.kt
+++ b/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/notification/DefaultDeadlineReminderReconciler.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.data.notification
+
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorization
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorizationStatus
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderPlanner
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderScheduler
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingErrorCategory
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingHealth
+import com.nexters.bandalart.core.domain.repository.DeadlineReminderProjectionRepository
+import com.nexters.bandalart.core.domain.repository.SettingsRepository
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class DefaultDeadlineReminderReconciler(
+    private val settingsRepository: SettingsRepository,
+    private val projectionRepository: DeadlineReminderProjectionRepository,
+    private val planner: DeadlineReminderPlanner,
+    private val scheduler: DeadlineReminderScheduler,
+    private val authorization: DeadlineNotificationAuthorization,
+) : DeadlineReminderReconciler {
+    private val mutex = Mutex()
+    private val mutableSchedulingHealth = MutableStateFlow(DeadlineReminderSchedulingHealth())
+
+    override val schedulingHealth: StateFlow<DeadlineReminderSchedulingHealth> = mutableSchedulingHealth.asStateFlow()
+
+    override suspend fun reconcileAll() {
+        mutex.withLock {
+            try {
+                val enabled = settingsRepository.deadlineReminderEnabled.first()
+                if (!enabled) {
+                    val result = scheduler.clearAll()
+                    mutableSchedulingHealth.value =
+                        DeadlineReminderSchedulingHealth(
+                            scheduledCount = result.scheduledCount,
+                            lastErrorCategory = result.lastErrorCategory,
+                        )
+                    return@withLock
+                }
+
+                val authorizationStatus = authorization.getStatus()
+                if (
+                    authorizationStatus != DeadlineNotificationAuthorizationStatus.GRANTED &&
+                    authorizationStatus != DeadlineNotificationAuthorizationStatus.QUIET
+                ) {
+                    scheduler.clearAll()
+                    mutableSchedulingHealth.value =
+                        DeadlineReminderSchedulingHealth(
+                            lastErrorCategory = DeadlineReminderSchedulingErrorCategory.AUTHORIZATION,
+                        )
+                    return@withLock
+                }
+
+                val plan = planner.plan(projectionRepository.getCandidates(), isEnabled = true)
+                val result = scheduler.replaceAll(plan.batches)
+                mutableSchedulingHealth.value =
+                    DeadlineReminderSchedulingHealth(
+                        scheduledCount = result.scheduledCount,
+                        overflowCount =
+                            plan.overflowCount +
+                                (plan.batches.size - result.scheduledCount).coerceAtLeast(0),
+                        lastErrorCategory = result.lastErrorCategory,
+                    )
+            } catch (exception: CancellationException) {
+                throw exception
+            } catch (_: Exception) {
+                mutableSchedulingHealth.value =
+                    mutableSchedulingHealth.value.copy(
+                        lastErrorCategory = DeadlineReminderSchedulingErrorCategory.UNKNOWN,
+                    )
+            }
+        }
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/repository/DefaultBandalartRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/repository/DefaultBandalartRepository.kt
@@ -26,6 +26,8 @@ import com.nexters.bandalart.core.domain.entity.UpdateBandalartEmojiEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
+import com.nexters.bandalart.core.domain.notification.NoOpDeadlineReminderReconciler
 import com.nexters.bandalart.core.domain.repository.BandalartRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -33,10 +35,13 @@ import kotlinx.coroutines.flow.map
 class DefaultBandalartRepository(
     private val bandalartDataStore: BandalartDataStore,
     private val bandalartDao: BandalartDao,
+    private val deadlineReminderReconciler: DeadlineReminderReconciler = NoOpDeadlineReminderReconciler,
 ) : BandalartRepository {
     override suspend fun createBandalart(): BandalartEntity {
         val bandalartId = bandalartDao.createEmptyBandalart()
-        return bandalartDao.getBandalart(bandalartId).toEntity()
+        return bandalartDao.getBandalart(bandalartId).toEntity().also {
+            deadlineReminderReconciler.reconcileAll()
+        }
     }
 
     override fun getBandalartList(): Flow<List<BandalartEntity>> =
@@ -51,6 +56,7 @@ class DefaultBandalartRepository(
         mainCell.id?.let { cellId ->
             bandalartDao.deleteCellOrReset(cellId)
         }
+        deadlineReminderReconciler.reconcileAll()
     }
 
     override suspend fun getBandalartMainCell(bandalartId: Long): BandalartCellEntity = bandalartDao.getBandalartMainCell(bandalartId).cell.toEntity()
@@ -66,6 +72,7 @@ class DefaultBandalartRepository(
         updateBandalartMainCellEntity: UpdateBandalartMainCellEntity,
     ) {
         bandalartDao.updateMainCellWithDto(cellId, updateBandalartMainCellEntity.toDto())
+        deadlineReminderReconciler.reconcileAll()
     }
 
     override suspend fun updateBandalartSubCell(
@@ -74,6 +81,7 @@ class DefaultBandalartRepository(
         updateBandalartSubCellEntity: UpdateBandalartSubCellEntity,
     ) {
         bandalartDao.updateSubCellWithDto(cellId, updateBandalartSubCellEntity.toDto())
+        deadlineReminderReconciler.reconcileAll()
     }
 
     override suspend fun updateBandalartTaskCell(
@@ -82,6 +90,7 @@ class DefaultBandalartRepository(
         updateBandalartTaskCellEntity: UpdateBandalartTaskCellEntity,
     ) {
         bandalartDao.updateTaskCellWithDto(cellId, updateBandalartTaskCellEntity.toDto())
+        deadlineReminderReconciler.reconcileAll()
     }
 
     override suspend fun updateBandalartEmoji(
@@ -94,6 +103,7 @@ class DefaultBandalartRepository(
 
     override suspend fun deleteBandalartCell(cellId: Long) {
         bandalartDao.deleteCellOrReset(cellId)
+        deadlineReminderReconciler.reconcileAll()
     }
 
     override suspend fun setRecentBandalartId(recentBandalartId: Long) {

--- a/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
@@ -173,6 +173,18 @@
     <string name="server_error_dialog_message">Please try again.</string>
     <string name="server_error_retry_message">Retry</string>
 
+    <!-- deadline reminder -->
+    <string name="settings_deadline_reminder_section">Notifications</string>
+    <string name="settings_deadline_reminder">Deadline reminders</string>
+    <string name="settings_deadline_reminder_body">Get a reminder from 9 AM on the due date.</string>
+    <string name="settings_deadline_reminder_blocked">System notifications are off. Tap to open settings.</string>
+    <string name="settings_deadline_reminder_overflow">%1$d reminders for later dates are not scheduled yet.</string>
+    <string name="settings_deadline_reminder_degraded">Some reminders could not be scheduled. We’ll retry when you reopen the app.</string>
+    <string name="settings_deadline_reminder_dialog_title">Turn on deadline reminders?</string>
+    <string name="settings_deadline_reminder_dialog_body">Goal titles may appear on your lock screen. Reminders are delivered from 9 AM on the due date depending on device conditions.</string>
+    <string name="settings_deadline_reminder_confirm">Turn on</string>
+    <string name="settings_deadline_reminder_cancel">Cancel</string>
+
     <!-- in-app update -->
     <string name="update_ready_to_install">App update is ready to install.</string>
     <string name="update_action_restart">Restart</string>

--- a/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
@@ -174,6 +174,18 @@
     <!--  label -->
     <string name="skeleton_trans_animate_label">メニューアイコン</string>
 
+    <!-- deadline reminder -->
+    <string name="settings_deadline_reminder_section">通知</string>
+    <string name="settings_deadline_reminder">締切日リマインダー</string>
+    <string name="settings_deadline_reminder_body">締切日当日の午前9時以降にお知らせします。</string>
+    <string name="settings_deadline_reminder_blocked">システム通知がオフです。タップして設定を開きます。</string>
+    <string name="settings_deadline_reminder_overflow">先の日付のリマインダー%1$d件はまだ予約されていません。</string>
+    <string name="settings_deadline_reminder_degraded">一部の通知を予約できませんでした。アプリを再度開いたときに再試行します。</string>
+    <string name="settings_deadline_reminder_dialog_title">締切日リマインダーをオンにしますか？</string>
+    <string name="settings_deadline_reminder_dialog_body">目標のタイトルがロック画面に表示される場合があります。締切日当日の午前9時以降、端末の状態に応じて通知されます。</string>
+    <string name="settings_deadline_reminder_confirm">オンにする</string>
+    <string name="settings_deadline_reminder_cancel">キャンセル</string>
+
     <!-- in-app update -->
     <string name="update_ready_to_install">アプリのアップデートのインストール準備が完了しました。</string>
     <string name="update_action_restart">再起動</string>

--- a/core/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -175,6 +175,18 @@
     <!--  label -->
     <string name="skeleton_trans_animate_label">Hamburger Icon</string>
 
+    <!-- deadline reminder -->
+    <string name="settings_deadline_reminder_section">알림</string>
+    <string name="settings_deadline_reminder">마감일 알림</string>
+    <string name="settings_deadline_reminder_body">마감일 당일 오전 9시부터 알려드려요.</string>
+    <string name="settings_deadline_reminder_blocked">시스템 알림이 꺼져 있어요. 누르면 설정으로 이동해요.</string>
+    <string name="settings_deadline_reminder_overflow">먼 날짜 알림 %1$d개는 아직 예약되지 않았어요.</string>
+    <string name="settings_deadline_reminder_degraded">일부 알림을 예약하지 못했어요. 앱을 다시 열면 다시 시도해요.</string>
+    <string name="settings_deadline_reminder_dialog_title">마감일 알림을 켤까요?</string>
+    <string name="settings_deadline_reminder_dialog_body">목표 제목이 잠금 화면에 보일 수 있으며, 마감일 당일 오전 9시부터 기기 상태에 따라 알림이 전달돼요.</string>
+    <string name="settings_deadline_reminder_confirm">알림 켜기</string>
+    <string name="settings_deadline_reminder_cancel">취소</string>
+
     <!-- in-app update -->
     <string name="update_ready_to_install">앱의 업데이트 설치 준비가 완료되었습니다.</string>
     <string name="update_action_restart">재시작</string>

--- a/core/domain/src/androidHostTest/kotlin/com/nexters/bandalart/core/domain/notification/DeadlineNotificationLaunchTargetTest.kt
+++ b/core/domain/src/androidHostTest/kotlin/com/nexters/bandalart/core/domain/notification/DeadlineNotificationLaunchTargetTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.domain.notification
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class DeadlineNotificationLaunchTargetTest {
+    @Test
+    fun latestValidTargetIsBufferedUntilMatchingAcknowledgement() {
+        val target = BufferedDeadlineNotificationLaunchTarget()
+
+        target.record(-1)
+        assertNull(target.pendingBandalartId.value)
+
+        target.record(10)
+        target.record(20)
+        target.acknowledge(10)
+        assertEquals(20L, target.pendingBandalartId.value)
+
+        target.acknowledge(20)
+        assertNull(target.pendingBandalartId.value)
+    }
+}

--- a/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/notification/DeadlineNotificationLaunchTarget.kt
+++ b/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/notification/DeadlineNotificationLaunchTarget.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.domain.notification
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+interface DeadlineNotificationLaunchTarget {
+    val pendingBandalartId: StateFlow<Long?>
+
+    fun record(bandalartId: Long)
+
+    fun acknowledge(bandalartId: Long)
+}
+
+class BufferedDeadlineNotificationLaunchTarget : DeadlineNotificationLaunchTarget {
+    private val mutablePendingBandalartId = MutableStateFlow<Long?>(null)
+
+    override val pendingBandalartId: StateFlow<Long?> = mutablePendingBandalartId.asStateFlow()
+
+    override fun record(bandalartId: Long) {
+        if (bandalartId > 0L) mutablePendingBandalartId.value = bandalartId
+    }
+
+    override fun acknowledge(bandalartId: Long) {
+        mutablePendingBandalartId.compareAndSet(expect = bandalartId, update = null)
+    }
+}

--- a/docs/features/notifications/LOCAL_DEADLINE_NOTIFICATION_STRATEGY.md
+++ b/docs/features/notifications/LOCAL_DEADLINE_NOTIFICATION_STRATEGY.md
@@ -19,12 +19,16 @@
 
 - [x] main cell due date의 full-snapshot 삭제 의미, notification preference, reminder projection·parser·planner·batch와 scheduler/authorization/reconciler 계약을 로컬에서 구현했다.
 - [x] 공통 foundation 변경을 로컬 리뷰하고 관련 테스트를 통과시켰다.
-- [ ] 공통 foundation을 commit하고 PR을 생성해 CI 통과 후 `main`에 병합한다.
+- [x] 공통 foundation을 commit했다.
+- [x] 공통 foundation PR #250을 CI 통과 후 `main`에 병합했다.
 
 ### 예정 PR 3 — Android vertical slice
 
-- [ ] WorkManager scheduler·Worker·channel·permission adapter를 구현한다.
-- [ ] 시간 변경 reconcile과 cold/warm notification navigation을 구현·검증한다.
+- [x] WorkManager scheduler·Worker·channel·permission adapter를 로컬에서 구현했다.
+- [x] 시간 변경 reconcile과 cold/warm notification navigation을 로컬에서 구현했다. buffered target·Presenter 소비는 host test로 검증했고 실제 Activity 전달은 수동 검증 전이다.
+- [x] Android에서만 노출되는 설정 ON/OFF·권한·시스템 설정 동선을 로컬에서 구현했다. 권한 상태별 실제 OS 동선은 Internal 설치본 검증 전이다.
+- [x] Android vertical slice를 독립 리뷰하고 관련 host test·Detekt를 통과시켰다.
+- [ ] Android vertical slice를 commit하고 PR·CI·merge한다.
 - [ ] Android Internal 설치본에서 실제 권한과 전달을 검증한다.
 
 ### 예정 PR 4 — iOS vertical slice
@@ -33,9 +37,9 @@
 - [ ] AppDelegate delegate, launch-target bridge와 pending/delivered reconcile을 구현·검증한다.
 - [ ] TestFlight 설치본에서 실제 권한과 전달을 검증한다.
 
-### 예정 PR 5 — UX 활성화·배포 검증
+### 예정 PR 5 — 공통 UX 마무리·배포 검증
 
-- [ ] 설정 toggle·권한 상태·시스템 설정 action과 명시적 마감일 삭제 UX를 구현한다.
+- [ ] iOS 권한 연동 후 공통 설정 노출과 명시적 마감일 삭제 UX를 마무리한다.
 - [ ] 한국어·영어·일본어 문구와 접근성을 검증한다.
 - [ ] Android Internal과 iOS TestFlight의 전체 acceptance checklist를 완료한다.
 - [ ] #211 완료 조건 확인 뒤 umbrella issue를 닫는다.
@@ -166,7 +170,7 @@ DataStore의 `deadlineReminderEnabled`는 사용자의 의사이며 OS authoriza
 
 권한 prompt는 Presenter의 app-scoped service에서 임의로 띄우지 않는다. Android는 화면 lifecycle을 가진 Compose effect/Activity Result API가 담당하고 iOS는 설정 action이 호출한 permission adapter가 담당한다.
 
-- Android 13 이상은 `checkSelfPermission`, `shouldShowRequestPermissionRationale`과 `PackageManager`의 public `FLAG_PERMISSION_USER_SET`/`FLAG_PERMISSION_USER_FIXED`를 함께 사용한다. permission이 있으면 `Granted`, user flag가 없으면 fresh install 또는 swipe dismiss로 보고 `Requestable`, rationale이 true인 일반 거절도 설명 뒤 명시적 재요청이 가능한 `Requestable`, user-fixed 또는 user-set 상태에서 rationale이 false면 `Blocked`다. Activity Result의 false만으로 Blocked를 확정하지 않는다. API 32 이하는 앱 전체 알림과 channel 상태로 `Granted`/`Blocked`를 판정한다.
+- Android 13 이상은 `checkSelfPermission`과 `shouldShowRequestPermissionRationale`를 사용한다. self permission의 user-set/user-fixed flag는 일반 앱에 공개된 SDK API가 아니므로, 앱 내에는 rationale이 true인 1차 거절 여부만 제목과 분리해 저장한다. fresh install과 swipe dismiss는 `Requestable`, rationale이 true인 일반 거절도 `Requestable`, 이후 반복 거절에서 rationale이 false면 `Blocked`로 판정한다. Activity Result의 false만으로 Blocked를 확정하지 않는다. API 32 이하는 앱 전체 알림과 channel 상태로 `Granted`/`Blocked`를 판정한다.
 - Android `Requestable` 재토글은 rationale을 먼저 보여 준 뒤 사용자가 다시 동의한 경우에만 prompt를 요청한다. `Blocked` 재토글은 prompt 없이 시스템 설정을 연다.
 - iOS `notDetermined`는 `Requestable`, `authorized`는 `Granted`, `provisional`/`ephemeral` 또는 alert가 조용한 설정은 `Quiet`, `denied`는 `Blocked`로 매핑한다. sound/alert 설정은 설명 상태에 반영하되 authorization이 허용된 request 자체는 유지한다.
 - 설정 복귀 때 effective 상태를 다시 읽어 `Granted`/`Quiet`이면 reconcile하고 `Blocked`면 pending 상태를 정리한다.
@@ -202,7 +206,7 @@ DataStore의 `deadlineReminderEnabled`는 사용자의 의사이며 OS authoriza
 현재 앱에는 외부 navigation request 경계가 없고, `recentBandalartId` 저장만으로는 실행 중인 Home이 즉시 전환되지 않는다.
 
 - buffered `DeadlineNotificationLaunchTarget` 계약을 추가한다. Android는 AppGraph 수명 인스턴스를 사용하고 iOS는 AppDelegate가 graph보다 먼저 만든 bridge를 graph에 주입한다.
-- Android `onCreate`/`onNewIntent`와 Swift notification delegate는 primitive `bandalartId`를 target에 기록한다.
+- Android는 non-exported notification trampoline이 primitive `bandalartId`를 target에 기록한 뒤 explicit `MainActivity`를 열고, Swift notification delegate도 primitive `bandalartId`를 기록한다.
 - target은 Circuit navigator가 준비되기 전 cold-start 요청을 유지한다.
 - Home Presenter는 목록 로드 뒤 target board가 존재하는지 확인하고, 존재하면 recent ID 저장과 `loadBandalart()`를 실행한 뒤 요청을 acknowledge한다.
 - 삭제된 board면 요청을 소비하고 현재 Home을 유지한다.
@@ -232,7 +236,7 @@ DataStore의 `deadlineReminderEnabled`는 사용자의 의사이며 OS authoriza
 - 시간·시간대 reconcile receiver
 - notification publisher와 cold/warm navigation bridge
 - host/Robolectric/WorkManager 테스트
-- permission prompt를 포함한 실제 설정 UX 검증은 PR 5로 미루고 scheduler/Worker/navigation adapter를 직접 호출하는 자동 테스트까지만 완료
+- Android 설정 ON/OFF, 설명 confirmation, permission prompt, blocked settings 동선을 함께 활성화하고 Presenter/scheduler 경계는 host test로 검증. 실제 OS 권한 prompt/settings 복귀는 Internal 설치본에서 수동 검증
 
 ### PR 4 — iOS vertical slice
 
@@ -294,7 +298,7 @@ DataStore의 `deadlineReminderEnabled`는 사용자의 의사이며 OS authoriza
 
 ## 11. 출시·관측
 
-- 플랫폼 코드는 두 OS에 모두 준비될 때까지 설정 toggle을 노출하지 않는다.
+- Android는 vertical slice가 사용 가능한 상태로 검증되면 Android에서만 설정 toggle을 노출한다. iOS는 `Unsupported`를 유지해 거짓 기능을 노출하지 않는다.
 - Android Internal과 iOS TestFlight에서 알림 권한과 실제 전달을 각각 검증한 뒤 활성화한다.
 - scheduler/reconcile 실패는 개인정보가 없는 batch ID, platform status, error category만 기록한다. 목표 제목과 설명은 로그에 남기지 않는다.
 - 알림 content에는 목표 제목 또는 집계 count만 사용하고 description, 완료 이력은 포함하지 않는다.

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
     sourceSets {
         androidMain.dependencies {
             implementation(libs.androidx.activity.compose)
+            implementation(libs.androidx.core)
             implementation(libs.androidx.lifecycle.runtime.compose)
             implementation(libs.app.update)
             implementation(libs.app.update.ktx)

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
@@ -34,13 +34,15 @@ internal class FakeBandalartRepository(
     private val createdBandalart: BandalartEntity? = null,
     private val publishCreatedBandalartImmediately: Boolean = true,
     details: Map<Long, BandalartEntity> = initialBandalarts.associateBy { it.id },
-    private val mainCells: Map<Long, BandalartCellEntity> = emptyMap(),
+    mainCells: Map<Long, BandalartCellEntity> = emptyMap(),
     private val childCells: Map<Long, List<BandalartCellEntity>> = emptyMap(),
     private val beforeTaskCellUpdate: suspend () -> Unit = {},
+    private val beforeBandalartLoad: suspend (Long) -> Unit = {},
     private val taskCellUpdateError: Throwable? = null,
 ) : BandalartRepository {
     private val bandalartFlow = MutableStateFlow(initialBandalarts)
     private val details = details.toMutableMap()
+    private val mainCells = mainCells.toMutableMap()
     private var unpublishedCreatedBandalart: BandalartEntity? = null
 
     var recentBandalartId: Long = recentBandalartId
@@ -81,9 +83,24 @@ internal class FakeBandalartRepository(
         bandalartFlow.value = bandalartFlow.value + bandalart
     }
 
+    fun publishBandalartRevision(
+        bandalart: BandalartEntity,
+        mainCell: BandalartCellEntity? = null,
+    ) {
+        details[bandalart.id] = bandalart
+        if (mainCell != null) mainCells[bandalart.id] = mainCell
+        bandalartFlow.value =
+            bandalartFlow.value.map { current ->
+                if (current.id == bandalart.id) bandalart else current
+            }
+    }
+
     override fun getBandalartList(): Flow<List<BandalartEntity>> = bandalartFlow
 
-    override suspend fun getBandalart(bandalartId: Long): BandalartEntity = requireNotNull(details[bandalartId])
+    override suspend fun getBandalart(bandalartId: Long): BandalartEntity {
+        beforeBandalartLoad(bandalartId)
+        return requireNotNull(details[bandalartId])
+    }
 
     override suspend fun getBandalartMainCell(bandalartId: Long): BandalartCellEntity? = mainCells[bandalartId]
 

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeSettingsRepository.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeSettingsRepository.kt
@@ -23,11 +23,12 @@ import kotlinx.coroutines.flow.asStateFlow
 
 class FakeSettingsRepository(
     initialThemeMode: ThemeMode = ThemeMode.SYSTEM,
+    initialDeadlineReminderEnabled: Boolean = false,
     private val beforeRecentEmojiSave: suspend (String) -> Unit = {},
 ) : SettingsRepository {
     private val themeModeState = MutableStateFlow(initialThemeMode)
     private val recentEmojisState = MutableStateFlow<List<String>>(emptyList())
-    private val deadlineReminderEnabledState = MutableStateFlow(false)
+    private val deadlineReminderEnabledState = MutableStateFlow(initialDeadlineReminderEnabled)
 
     override val themeMode = themeModeState.asStateFlow()
     override val recentEmojis = recentEmojisState.asStateFlow()

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterDeadlineReminderTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterDeadlineReminderTest.kt
@@ -1,0 +1,432 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home.presenter
+
+import com.nexters.bandalart.core.domain.entity.BandalartEntity
+import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
+import com.nexters.bandalart.core.domain.notification.BufferedDeadlineNotificationLaunchTarget
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorization
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorizationStatus
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingHealth
+import com.nexters.bandalart.feature.home.HomeScreen
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuit.test.test
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomePresenterDeadlineReminderTest {
+    @Test
+    fun notificationLaunchSelectsBufferedBandalartAfterHomeIsReady() =
+        runTest {
+            val launchTarget = BufferedDeadlineNotificationLaunchTarget().apply { record(2) }
+            val repository = repository()
+            val presenter = presenter(repository, launchTarget = launchTarget)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != 2L || state.isLoading) state = awaitItem()
+
+                assertEquals(2L, repository.recentBandalartId)
+                assertEquals(null, launchTarget.pendingBandalartId.value)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun warmNotificationLaunchSelectsAndConsumesBandalart() =
+        runTest {
+            val launchTarget = BufferedDeadlineNotificationLaunchTarget()
+            val repository = repository()
+            val presenter = presenter(repository, launchTarget = launchTarget)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData == null || state.isLoading) state = awaitItem()
+
+                launchTarget.record(2)
+                while (state.bandalartData?.id != 2L || state.isLoading) state = awaitItem()
+
+                assertEquals(2L, repository.recentBandalartId)
+                assertEquals(null, launchTarget.pendingBandalartId.value)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun notificationTargetCancelsDelayedInitialSelectionAndWins() =
+        runTest {
+            val initialLoadStarted = CompletableDeferred<Unit>()
+            val releaseInitialLoad = CompletableDeferred<Unit>()
+            val launchTarget = BufferedDeadlineNotificationLaunchTarget()
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1), bandalart(2)),
+                    recentBandalartId = 1,
+                    beforeBandalartLoad = { id ->
+                        if (id == 1L) {
+                            initialLoadStarted.complete(Unit)
+                            releaseInitialLoad.await()
+                        }
+                    },
+                )
+            val presenter = presenter(repository, launchTarget = launchTarget)
+
+            presenter.test {
+                var state = awaitItem()
+                initialLoadStarted.await()
+
+                launchTarget.record(2)
+                while (state.bandalartData?.id != 2L || state.isLoading) state = awaitItem()
+
+                assertEquals(2L, repository.recentBandalartId)
+                assertEquals(null, launchTarget.pendingBandalartId.value)
+                releaseInitialLoad.complete(Unit)
+                advanceUntilIdle()
+                state = expectMostRecentItem()
+                assertEquals(2L, state.bandalartData?.id)
+                assertEquals(2L, repository.recentBandalartId)
+                assertEquals(null, launchTarget.pendingBandalartId.value)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun notificationTargetWinsDelayedManualSelection() =
+        runTest {
+            val manualLoadStarted = CompletableDeferred<Unit>()
+            val releaseManualLoad = CompletableDeferred<Unit>()
+            val launchTarget = BufferedDeadlineNotificationLaunchTarget()
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1), bandalart(2)),
+                    recentBandalartId = 1,
+                    mainCells = mapOf(1L to mainCell(101, "one"), 2L to mainCell(201, "two")),
+                    beforeBandalartLoad = { id ->
+                        if (id == 2L) {
+                            manualLoadStarted.complete(Unit)
+                            releaseManualLoad.await()
+                        }
+                    },
+                )
+            val presenter = presenter(repository, launchTarget = launchTarget)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != 1L || state.isLoading) state = awaitItem()
+
+                state.eventSink(HomeScreen.Event.SelectBandalart(2))
+                manualLoadStarted.await()
+                launchTarget.record(1)
+                while (
+                    launchTarget.pendingBandalartId.value != null ||
+                    repository.recentBandalartId != 1L ||
+                    state.isLoading
+                ) {
+                    state = awaitItem()
+                }
+
+                assertEquals(1L, state.bandalartData?.id)
+                assertEquals(101L, state.bandalartCellData?.id)
+                assertEquals(1L, repository.recentBandalartId)
+                assertEquals(null, launchTarget.pendingBandalartId.value)
+
+                releaseManualLoad.complete(Unit)
+                advanceUntilIdle()
+                state = expectMostRecentItem()
+                assertEquals(1L, state.bandalartData?.id)
+                assertEquals(101L, state.bandalartCellData?.id)
+                assertEquals(1L, repository.recentBandalartId)
+                assertEquals(null, launchTarget.pendingBandalartId.value)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun notificationTargetWinsDelayedCompletionRefreshWithoutMixingCellTree() =
+        runTest {
+            var boardOneLoadCount = 0
+            val completionLoadStarted = CompletableDeferred<Unit>()
+            val releaseCompletionLoad = CompletableDeferred<Unit>()
+            val launchTarget = BufferedDeadlineNotificationLaunchTarget()
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1), bandalart(2)),
+                    recentBandalartId = 1,
+                    mainCells = mapOf(1L to mainCell(101, "one"), 2L to mainCell(201, "two")),
+                    beforeBandalartLoad = { id ->
+                        if (id == 1L && ++boardOneLoadCount == 2) {
+                            completionLoadStarted.complete(Unit)
+                            releaseCompletionLoad.await()
+                        }
+                    },
+                )
+            val presenter = presenter(repository, launchTarget = launchTarget)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != 1L || state.isLoading) state = awaitItem()
+                repository.publishBandalartRevision(bandalart(1).copy(isCompleted = true))
+                completionLoadStarted.await()
+
+                launchTarget.record(2)
+                while (state.bandalartData?.id != 2L || state.isLoading) state = awaitItem()
+
+                assertEquals(201L, state.bandalartCellData?.id)
+                assertEquals(null, launchTarget.pendingBandalartId.value)
+                releaseCompletionLoad.complete(Unit)
+                advanceUntilIdle()
+                state = expectMostRecentItem()
+                assertEquals(2L, state.bandalartData?.id)
+                assertEquals(201L, state.bandalartCellData?.id)
+                assertEquals(null, launchTarget.pendingBandalartId.value)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun listRevisionRefreshesCurrentBoardAndCellTree() =
+        runTest {
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1), bandalart(2)),
+                    recentBandalartId = 1,
+                    mainCells = mapOf(1L to mainCell(101, "before"), 2L to mainCell(201, "two")),
+                )
+            val presenter = presenter(repository)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != 1L || state.isLoading) state = awaitItem()
+
+                repository.publishBandalartRevision(
+                    bandalart = bandalart(1).copy(title = "edited"),
+                    mainCell = mainCell(101, "edited"),
+                )
+                while (
+                    state.bandalartData?.titleText != "edited" ||
+                    state.bandalartCellData?.title != "edited" ||
+                    state.isLoading
+                ) {
+                    state = awaitItem()
+                }
+
+                assertEquals(1L, state.bandalartData?.id)
+                assertEquals(101L, state.bandalartCellData?.id)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun deletingCurrentBoardSelectsRemainingBoardAndUpdatesRecentId() =
+        runTest {
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1), bandalart(2)),
+                    recentBandalartId = 1,
+                    mainCells = mapOf(1L to mainCell(101, "one"), 2L to mainCell(201, "two")),
+                )
+            val presenter = presenter(repository)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != 1L || state.isLoading) state = awaitItem()
+
+                state.eventSink(HomeScreen.Event.DeleteBandalart(1))
+                while (state.bandalartData?.id != 2L || state.isLoading) state = awaitItem()
+
+                assertEquals(2L, repository.recentBandalartId)
+                assertEquals(201L, state.bandalartCellData?.id)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun invalidNotificationLaunchIsExplicitlyConsumedWithoutChangingSelection() =
+        runTest {
+            val launchTarget = BufferedDeadlineNotificationLaunchTarget().apply { record(999) }
+            val repository = repository()
+            val presenter = presenter(repository, launchTarget = launchTarget)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData == null || state.isLoading) state = awaitItem()
+                while (launchTarget.pendingBandalartId.value != null) state = awaitItem()
+
+                assertEquals(1L, state.bandalartData?.id)
+                assertEquals(1L, repository.recentBandalartId)
+            }
+        }
+
+    @Test
+    fun grantedPermissionPersistsPreferenceAndReconciles() =
+        runTest {
+            val settings = FakeSettingsRepository()
+            val authorization = FakeAuthorization(DeadlineNotificationAuthorizationStatus.GRANTED)
+            val reconciler = RecordingReconciler()
+            val presenter =
+                presenter(
+                    repository = repository(),
+                    settings = settings,
+                    authorization = authorization,
+                    reconciler = reconciler,
+                )
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData == null || state.isLoading) state = awaitItem()
+                state.eventSink(HomeScreen.Event.OpenSettings)
+                state.eventSink(HomeScreen.Event.ConfirmDeadlineReminderPermission)
+                do {
+                    state = awaitItem()
+                } while (!state.deadlineReminderEnabled)
+
+                assertTrue(reconciler.reconcileCalls > 0)
+            }
+        }
+
+    @Test
+    fun blockedEnabledReminderCanBeTurnedOff() =
+        runTest {
+            val settings = FakeSettingsRepository(initialDeadlineReminderEnabled = true)
+            val presenter =
+                presenter(
+                    repository = repository(),
+                    settings = settings,
+                    authorization = FakeAuthorization(DeadlineNotificationAuthorizationStatus.BLOCKED),
+                )
+
+            presenter.test {
+                var state = awaitItem()
+                while (!state.deadlineReminderEnabled) state = awaitItem()
+                state.eventSink(HomeScreen.Event.SetDeadlineReminderEnabled(false))
+                while (state.deadlineReminderEnabled) state = awaitItem()
+
+                assertEquals(false, state.deadlineReminderEnabled)
+            }
+        }
+
+    @Test
+    fun foregroundAfterSystemSettingsRefreshesGrantAndReconcilesEnabledPreference() =
+        runTest {
+            val settings = FakeSettingsRepository(initialDeadlineReminderEnabled = true)
+            val authorization = FakeAuthorization(DeadlineNotificationAuthorizationStatus.BLOCKED)
+            val reconciler = RecordingReconciler()
+            val presenter =
+                presenter(
+                    repository = repository(),
+                    settings = settings,
+                    authorization = authorization,
+                    reconciler = reconciler,
+                )
+
+            presenter.test {
+                var state = awaitItem()
+                state.eventSink(HomeScreen.Event.OpenSettings)
+                while (
+                    state.deadlineNotificationAuthorizationStatus !=
+                    DeadlineNotificationAuthorizationStatus.BLOCKED
+                ) {
+                    state = awaitItem()
+                }
+                authorization.status = DeadlineNotificationAuthorizationStatus.GRANTED
+                state.eventSink(HomeScreen.Event.DeadlineReminderForegrounded)
+                while (
+                    state.deadlineNotificationAuthorizationStatus !=
+                    DeadlineNotificationAuthorizationStatus.GRANTED
+                ) {
+                    state = awaitItem()
+                }
+
+                assertTrue(reconciler.reconcileCalls > 0)
+            }
+        }
+
+    private fun presenter(
+        repository: FakeBandalartRepository,
+        settings: FakeSettingsRepository = FakeSettingsRepository(),
+        authorization: DeadlineNotificationAuthorization =
+            FakeAuthorization(DeadlineNotificationAuthorizationStatus.REQUESTABLE),
+        reconciler: DeadlineReminderReconciler = RecordingReconciler(),
+        launchTarget: BufferedDeadlineNotificationLaunchTarget = BufferedDeadlineNotificationLaunchTarget(),
+    ) = HomePresenter(
+        navigator = FakeNavigator(HomeScreen),
+        bandalartRepository = repository,
+        bandalartSlotRepository = FakeBandalartSlotRepository(),
+        inAppUpdateRepository = FakeInAppUpdateRepository(),
+        settingsRepository = settings,
+        deadlineNotificationAuthorization = authorization,
+        deadlineReminderReconciler = reconciler,
+        deadlineNotificationLaunchTarget = launchTarget,
+    )
+
+    private fun repository() =
+        FakeBandalartRepository(
+            initialBandalarts = listOf(bandalart(1), bandalart(2)),
+            recentBandalartId = 1,
+        )
+
+    private fun bandalart(id: Long) =
+        BandalartEntity(
+            id = id,
+            mainColor = "#3FFFBA",
+            subColor = "#111827",
+            profileEmoji = "🎯",
+            title = "반다라트 $id",
+            description = null,
+            dueDate = null,
+            isCompleted = false,
+            completionRatio = 0,
+        )
+
+    private fun mainCell(
+        id: Long,
+        title: String,
+    ) = BandalartCellEntity(
+        id = id,
+        title = title,
+        parentId = null,
+    )
+
+    private class FakeAuthorization(
+        var status: DeadlineNotificationAuthorizationStatus,
+    ) : DeadlineNotificationAuthorization {
+        override suspend fun getStatus() = status
+
+        override suspend fun requestAuthorization() = status
+
+        override suspend fun openSettings() = Unit
+    }
+
+    private class RecordingReconciler : DeadlineReminderReconciler {
+        override val schedulingHealth: StateFlow<DeadlineReminderSchedulingHealth> =
+            MutableStateFlow(DeadlineReminderSchedulingHealth())
+        var reconcileCalls = 0
+
+        override suspend fun reconcileAll() {
+            reconcileCalls += 1
+        }
+    }
+}

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterEditTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterEditTest.kt
@@ -64,6 +64,7 @@ class HomePresenterEditTest {
                 assertEquals(created.id, repository.recentBandalartId)
                 assertTrue(repository.completionUpdates.contains(created.id to false))
                 assertNull(state.bottomSheet)
+                cancelAndIgnoreRemainingEvents()
             }
         }
 
@@ -213,7 +214,7 @@ class HomePresenterEditTest {
                     state = awaitItem()
                 } while (state.dialog !is HomeScreen.DialogState.CellDelete)
 
-                val dialog = state.dialog as HomeScreen.DialogState.CellDelete
+                val dialog = state.dialog
                 assertEquals(taskCell.id, dialog.cellId)
                 assertEquals(CellType.TASK, dialog.cellType)
                 assertEquals(taskCell.title, dialog.cellTitle)
@@ -259,6 +260,7 @@ class HomePresenterEditTest {
                 assertFalse(state.isDropDownMenuOpened)
                 assertNull(state.dialog)
                 assertNull(state.bottomSheet)
+                cancelAndIgnoreRemainingEvents()
             }
         }
 

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterQuickCompletionTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterQuickCompletionTest.kt
@@ -23,6 +23,8 @@ import com.nexters.bandalart.feature.home.HomeScreen
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -31,6 +33,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class HomePresenterQuickCompletionTest {
     @Test
     fun validTaskIsCompletedWithPreservedContentAndOneShotEffect() =
@@ -82,6 +85,8 @@ class HomePresenterQuickCompletionTest {
 
             presenter(repository).test {
                 val state = awaitLoadedBandalart()
+                advanceUntilIdle()
+                expectMostRecentItem()
                 val mainCell = requireNotNull(state.bandalartCellData)
                 val subCell = mainCell.children.single()
 
@@ -94,6 +99,7 @@ class HomePresenterQuickCompletionTest {
                 assertEquals(0, repository.taskCellUpdateCalls)
                 assertTrue(state.taskCell(completedTask.id).isCompleted)
                 expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
             }
         }
 
@@ -177,6 +183,8 @@ class HomePresenterQuickCompletionTest {
 
             presenter(repository).test {
                 val state = awaitLoadedBandalart()
+                advanceUntilIdle()
+                expectMostRecentItem()
                 state.eventSink(HomeScreen.Event.CompleteTask(taskCell))
                 updateAttempted.await()
                 yield()
@@ -185,6 +193,7 @@ class HomePresenterQuickCompletionTest {
                 assertNull(repository.taskCellUpdate)
                 assertFalse(state.taskCell(taskCell.id).isCompleted)
                 expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
             }
         }
 

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterRewardedAdTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterRewardedAdTest.kt
@@ -218,6 +218,7 @@ class HomePresenterRewardedAdTest {
                 assertEquals(1, repository.createCalls)
                 repository.publishCreatedBandalart()
                 awaitItem()
+                cancelAndIgnoreRemainingEvents()
             }
         }
 
@@ -241,6 +242,7 @@ class HomePresenterRewardedAdTest {
 
                 assertEquals(1, repository.createCalls)
                 assertNull(slotRepository.pendingRewardedCreation)
+                cancelAndIgnoreRemainingEvents()
             }
         }
 

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterRuntimeTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterRuntimeTest.kt
@@ -22,12 +22,15 @@ import com.nexters.bandalart.feature.complete.CompleteScreen
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class HomePresenterRuntimeTest {
     @Test
     fun shareAndSaveRequestsAreClearedAfterUiHandling() =
@@ -163,6 +166,8 @@ class HomePresenterRuntimeTest {
 
             presenter.test {
                 var state = awaitLoadedBandalart()
+                advanceUntilIdle()
+                expectMostRecentItem()
                 state.eventSink(HomeScreen.Event.CheckForUpdate(20206))
                 expectNoEvents()
 
@@ -177,6 +182,7 @@ class HomePresenterRuntimeTest {
                 } while (state.updateVersionCode != null)
 
                 assertEquals(listOf(20207), updateRepository.rejectedVersionCodes)
+                cancelAndIgnoreRemainingEvents()
             }
         }
 

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
@@ -54,7 +54,7 @@ class HomePresenterTest {
                 }
 
                 assertEquals(2, state.bandalartList.size)
-                assertEquals(2L, state.bandalartData?.id)
+                assertEquals(2L, state.bandalartData.id)
                 assertEquals(mainCell.id, state.bandalartCellData?.id)
                 assertEquals(
                     subCell.id,
@@ -72,6 +72,7 @@ class HomePresenterTest {
                         ?.single()
                         ?.id,
                 )
+                cancelAndIgnoreRemainingEvents()
             }
         }
 
@@ -91,7 +92,8 @@ class HomePresenterTest {
                     state = awaitItem()
                 }
 
-                assertEquals(1L, state.bandalartData?.id)
+                assertEquals(1L, state.bandalartData.id)
+                cancelAndIgnoreRemainingEvents()
             }
         }
 
@@ -115,6 +117,7 @@ class HomePresenterTest {
                 assertEquals(1, repository.createCalls)
                 assertEquals(created.id, repository.recentBandalartId)
                 assertTrue(repository.completionUpdates.contains(created.id to false))
+                cancelAndIgnoreRemainingEvents()
             }
         }
 
@@ -141,6 +144,7 @@ class HomePresenterTest {
 
                 assertTrue(state.isBandalartCompleted)
                 assertTrue(repository.completionUpdates.isEmpty())
+                cancelAndIgnoreRemainingEvents()
             }
         }
 
@@ -167,6 +171,7 @@ class HomePresenterTest {
 
                 assertEquals(2L, repository.recentBandalartId)
                 assertFalse(state.isBandalartCompleted)
+                cancelAndIgnoreRemainingEvents()
             }
         }
 

--- a/feature/home/src/androidMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderForegroundEffect.android.kt
+++ b/feature/home/src/androidMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderForegroundEffect.android.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+
+@Composable
+internal actual fun DeadlineReminderForegroundEffect(onForeground: () -> Unit) {
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME, onEvent = onForeground)
+}

--- a/feature/home/src/androidMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderPermissionEffect.android.kt
+++ b/feature/home/src/androidMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderPermissionEffect.android.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
+import com.nexters.bandalart.core.common.DeadlineNotificationPermissionHistory
+
+@Composable
+internal actual fun DeadlineReminderPermissionEffect(
+    requestId: Long?,
+    onResult: () -> Unit,
+) {
+    val activity = LocalContext.current.findActivity()
+    val launcher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+            activity?.let(DeadlineNotificationPermissionHistory::recordPromptResult)
+            onResult()
+        }
+    LaunchedEffect(requestId) {
+        if (requestId != null) launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
+    }
+}
+
+private tailrec fun Context.findActivity(): Activity? =
+    when (this) {
+        is Activity -> this
+        is ContextWrapper -> baseContext.findActivity()
+        else -> null
+    }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderForegroundEffect.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderForegroundEffect.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal expect fun DeadlineReminderForegroundEffect(onForeground: () -> Unit)

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderPermissionEffect.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderPermissionEffect.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal expect fun DeadlineReminderPermissionEffect(
+    requestId: Long?,
+    onResult: () -> Unit,
+)

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeBottomSheets.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeBottomSheets.kt
@@ -66,6 +66,9 @@ internal fun HomeBottomSheets(
         HomeScreen.BottomSheetState.Settings -> {
             SettingsBottomSheet(
                 themeMode = state.themeMode,
+                deadlineReminderEnabled = state.deadlineReminderEnabled,
+                deadlineNotificationAuthorizationStatus = state.deadlineNotificationAuthorizationStatus,
+                deadlineReminderSchedulingHealth = state.deadlineReminderSchedulingHealth,
                 appVersion = appVersion,
                 onHomeUiAction = eventSink,
             )

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
@@ -20,6 +20,8 @@ import com.nexters.bandalart.core.common.Language
 import com.nexters.bandalart.core.common.RewardedAdResult
 import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
 import com.nexters.bandalart.core.domain.entity.ThemeMode
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorizationStatus
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingHealth
 import com.nexters.bandalart.core.navigation.CommonParcelize
 import com.nexters.bandalart.feature.home.model.BandalartUiModel
 import com.nexters.bandalart.feature.home.model.CellType
@@ -46,6 +48,11 @@ data object HomeScreen : ParcelableScreen, StaticScreen {
         val themeMode: ThemeMode = ThemeMode.SYSTEM,
         val recentEmojis: ImmutableList<String> = persistentListOf(),
         val rewardedAdRequestId: Long? = null,
+        val deadlineReminderEnabled: Boolean = false,
+        val deadlineNotificationAuthorizationStatus: DeadlineNotificationAuthorizationStatus =
+            DeadlineNotificationAuthorizationStatus.UNSUPPORTED,
+        val deadlineReminderSchedulingHealth: DeadlineReminderSchedulingHealth = DeadlineReminderSchedulingHealth(),
+        val deadlinePermissionRequestId: Long? = null,
         val effect: Effect? = null,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
@@ -211,6 +218,16 @@ data object HomeScreen : ParcelableScreen, StaticScreen {
         data class SelectThemeMode(
             val themeMode: ThemeMode,
         ) : Event
+
+        data class SetDeadlineReminderEnabled(
+            val enabled: Boolean,
+        ) : Event
+
+        data object ConfirmDeadlineReminderPermission : Event
+
+        data object DeadlineReminderPermissionResult : Event
+
+        data object DeadlineReminderForegrounded : Event
 
         data object ContactSupport : Event
 

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
@@ -135,6 +135,14 @@ internal fun Home(
         },
     )
 
+    DeadlineReminderPermissionEffect(
+        requestId = state.deadlinePermissionRequestId,
+        onResult = { state.eventSink(HomeScreen.Event.DeadlineReminderPermissionResult) },
+    )
+    DeadlineReminderForegroundEffect {
+        state.eventSink(HomeScreen.Event.DeadlineReminderForegrounded)
+    }
+
     HandleHomeEffects(
         state = state,
         homeGraphicsLayer = homeGraphicsLayer,

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshots.Snapshot
 import com.nexters.bandalart.core.common.Language
 import com.nexters.bandalart.core.common.RewardedAdResult
 import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
@@ -32,6 +33,13 @@ import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
 import com.nexters.bandalart.core.domain.entity.ThemeMode
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorization
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorizationStatus
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationLaunchTarget
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
+import com.nexters.bandalart.core.domain.notification.BufferedDeadlineNotificationLaunchTarget
+import com.nexters.bandalart.core.domain.notification.NoOpDeadlineNotificationAuthorization
+import com.nexters.bandalart.core.domain.notification.NoOpDeadlineReminderReconciler
 import com.nexters.bandalart.core.domain.repository.BandalartRepository
 import com.nexters.bandalart.core.domain.repository.BandalartSlotRepository
 import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
@@ -55,6 +63,7 @@ import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.yield
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -66,14 +75,24 @@ class HomePresenter(
     private val bandalartSlotRepository: BandalartSlotRepository,
     private val inAppUpdateRepository: InAppUpdateRepository,
     private val settingsRepository: SettingsRepository,
+    private val deadlineNotificationAuthorization: DeadlineNotificationAuthorization =
+        NoOpDeadlineNotificationAuthorization,
+    private val deadlineReminderReconciler: DeadlineReminderReconciler = NoOpDeadlineReminderReconciler,
+    private val deadlineNotificationLaunchTarget: DeadlineNotificationLaunchTarget =
+        BufferedDeadlineNotificationLaunchTarget(),
 ) : Presenter<HomeScreen.State> {
     @Composable
     override fun present(): HomeScreen.State {
         var bandalartList by remember { mutableStateOf(persistentListOf<BandalartUiModel>()) }
-        var bandalartData by remember { mutableStateOf<BandalartUiModel?>(null) }
-        var bandalartCellData by remember { mutableStateOf<BandalartCellEntity?>(null) }
+        var loadedBandalart by remember { mutableStateOf<LoadedBandalart?>(null) }
+        val bandalartData = loadedBandalart?.bandalartData
+        val bandalartCellData = loadedBandalart?.bandalartCellData
+        val isBandalartCompleted = loadedBandalart?.isCompleted ?: false
+        var newlyCompletedTargetId by remember { mutableStateOf<Long?>(null) }
+        var explicitSelectionTargetId by remember { mutableStateOf<Long?>(null) }
+        var isExplicitSelectionTargetPending by remember { mutableStateOf(false) }
+        var bandalartListRevision by remember { mutableStateOf(0L) }
         var isLoading by remember { mutableStateOf(true) }
-        var isBandalartCompleted by remember { mutableStateOf(false) }
         var isCreatingEmptyBandalart by remember { mutableStateOf(false) }
         val rewardedCreateCoordinator = rememberRetained { RewardedCreateCoordinator() }
         var isUpdatingBandalartEmoji by remember { mutableStateOf(false) }
@@ -90,8 +109,18 @@ class HomePresenter(
         val pendingEffects = remember { ArrayDeque<HomeScreen.Effect>() }
         val themeMode by settingsRepository.themeMode.collectAsState(initial = ThemeMode.SYSTEM)
         val recentEmojis by settingsRepository.recentEmojis.collectAsState(initial = emptyList())
+        val deadlineReminderEnabled by settingsRepository.deadlineReminderEnabled.collectAsState(initial = false)
+        val deadlineReminderSchedulingHealth by deadlineReminderReconciler.schedulingHealth.collectAsState()
+        val pendingDeadlineLaunchId by deadlineNotificationLaunchTarget.pendingBandalartId.collectAsState()
+        var deadlineNotificationAuthorizationStatus by remember {
+            mutableStateOf(DeadlineNotificationAuthorizationStatus.UNSUPPORTED)
+        }
+        var deadlinePermissionRequestId by remember { mutableStateOf<Long?>(null) }
+        var nextDeadlinePermissionRequestId by remember { mutableStateOf(0L) }
         val scope = rememberCoroutineScope()
         val recentEmojiSaveJobs = remember { mutableListOf<kotlinx.coroutines.Job>() }
+        val selectionLoadGeneration = remember { longArrayOf(0L) }
+        val handledCompletionRevision = remember { longArrayOf(-1L) }
 
         fun recordRecentEmoji(emoji: String) {
             val previousJob = recentEmojiSaveJobs.lastOrNull()
@@ -120,9 +149,10 @@ class HomePresenter(
         suspend fun loadBandalart(
             bandalartId: Long,
             isCompleted: Boolean = false,
+            canCommit: () -> Boolean = { true },
         ) {
             isLoading = true
-            bandalartData = bandalartRepository.getBandalart(bandalartId).toUiModel()
+            val loadedBandalartData = bandalartRepository.getBandalart(bandalartId).toUiModel()
 
             val mainCell = bandalartRepository.getBandalartMainCell(bandalartId)
             val subCells = bandalartRepository.getChildCells(mainCell?.id ?: 0L)
@@ -151,7 +181,7 @@ class HomePresenter(
                     )
                 }
 
-            bandalartCellData =
+            val loadedBandalartCellData =
                 BandalartCellEntity(
                     id = mainCell?.id ?: 0L,
                     title = mainCell?.title,
@@ -161,27 +191,69 @@ class HomePresenter(
                     parentId = mainCell?.parentId,
                     children = children,
                 )
-            isBandalartCompleted = isCompleted
+            if (!canCommit()) return
+            loadedBandalart =
+                LoadedBandalart(
+                    bandalartData = loadedBandalartData,
+                    bandalartCellData = loadedBandalartCellData,
+                    isCompleted = isCompleted,
+                )
+            yield()
             isLoading = false
+        }
+
+        fun beginSelectionRequest(): Long = ++selectionLoadGeneration[0]
+
+        suspend fun selectBandalart(
+            requestGeneration: Long,
+            bandalartId: Long,
+            isCompleted: Boolean = false,
+            persistRecent: Boolean = true,
+        ): Boolean {
+            if (selectionLoadGeneration[0] != requestGeneration) return false
+            if (persistRecent) {
+                bandalartRepository.setRecentBandalartId(bandalartId)
+            }
+            if (selectionLoadGeneration[0] != requestGeneration) return false
+            loadBandalart(
+                bandalartId = bandalartId,
+                isCompleted = isCompleted,
+                canCommit = { selectionLoadGeneration[0] == requestGeneration },
+            )
+            return selectionLoadGeneration[0] == requestGeneration
         }
 
         suspend fun createInitialBandalart() {
             if (isCreatingEmptyBandalart) return
 
             isCreatingEmptyBandalart = true
-            bandalartRepository.createBandalart()?.let { bandalart ->
-                bandalartRepository.setRecentBandalartId(bandalart.id)
+            val selectionRequest = beginSelectionRequest()
+            isExplicitSelectionTargetPending = true
+            val bandalart = bandalartRepository.createBandalart()
+            Snapshot.withMutableSnapshot {
+                if (bandalart != null && selectionLoadGeneration[0] == selectionRequest) {
+                    explicitSelectionTargetId = bandalart.id
+                }
+                isExplicitSelectionTargetPending = false
+            }
+            bandalart?.let {
                 bandalartRepository.upsertBandalartId(bandalart.id, bandalart.isCompleted)
-                loadBandalart(bandalart.id)
             }
         }
 
         suspend fun createBandalart(): Boolean {
-            val bandalart = bandalartRepository.createBandalart() ?: return false
+            val selectionRequest = beginSelectionRequest()
+            isExplicitSelectionTargetPending = true
+            val bandalart = bandalartRepository.createBandalart()
+            Snapshot.withMutableSnapshot {
+                if (bandalart != null && selectionLoadGeneration[0] == selectionRequest) {
+                    explicitSelectionTargetId = bandalart.id
+                }
+                isExplicitSelectionTargetPending = false
+            }
+            bandalart ?: return false
             bottomSheet = null
-            bandalartRepository.setRecentBandalartId(bandalart.id)
             bandalartRepository.upsertBandalartId(bandalart.id, bandalart.isCompleted)
-            loadBandalart(bandalart.id)
             emitEffect(HomeScreen.Effect.ShowCreateSnackbar)
             return true
         }
@@ -465,7 +537,11 @@ class HomePresenter(
                             ),
                     )
                 }.onSuccess {
-                    bandalartCellData = bandalartCellData?.completeTask(currentCell.id)
+                    val updatedCellData = bandalartCellData.completeTask(currentCell.id)
+                    loadedBandalart =
+                        loadedBandalart?.copy(
+                            bandalartCellData = updatedCellData,
+                        )
                     emitEffect(HomeScreen.Effect.PlayTaskCompletionHaptic(currentCell.id))
                 }.onFailure { exception ->
                     if (exception is CancellationException) throw exception
@@ -507,8 +583,14 @@ class HomePresenter(
         LaunchedEffect(Unit) {
             bandalartRepository.getBandalartList().collect { entities ->
                 val currentList = entities.map { it.toUiModel() }
-                bandalartList = currentList.toPersistentList()
-
+                val previousList = bandalartRepository.getPrevBandalartList()
+                val completedTargetId =
+                    currentList
+                        .filter { bandalart ->
+                            val previous = previousList.find { it.first == bandalart.id }
+                            previous != null && !previous.second && bandalart.isCompleted
+                        }.firstOrNull()
+                        ?.id
                 val pendingRewardedCreation =
                     runRewardedOperation { bandalartSlotRepository.getPendingRewardedCreation() }
                         .onFailure { exception ->
@@ -540,7 +622,7 @@ class HomePresenter(
                             rewardedCreateCoordinator.grantFinished(
                                 wasCreated = created,
                                 expectedCount = pendingRewardedCreation.targetSlots,
-                                currentCount = bandalartList.size,
+                                currentCount = currentList.size,
                             )
                         }
                     }
@@ -549,27 +631,13 @@ class HomePresenter(
                 }
                 rewardedRecoveryChecked = true
 
-                val previousList = bandalartRepository.getPrevBandalartList()
-                val newlyCompletedIds =
-                    currentList
-                        .filter { bandalart ->
-                            val previous = previousList.find { it.first == bandalart.id }
-                            previous != null && !previous.second && bandalart.isCompleted
-                        }.map { it.id }
-
-                if (newlyCompletedIds.isNotEmpty()) {
-                    loadBandalart(
-                        bandalartId = newlyCompletedIds.first(),
-                        isCompleted = true,
-                    )
-                    return@collect
-                }
-
-                currentList.forEach { bandalart ->
-                    bandalartRepository.upsertBandalartId(
-                        bandalartId = bandalart.id,
-                        isCompleted = bandalart.isCompleted,
-                    )
+                if (completedTargetId == null) {
+                    currentList.forEach { bandalart ->
+                        bandalartRepository.upsertBandalartId(
+                            bandalartId = bandalart.id,
+                            isCompleted = bandalart.isCompleted,
+                        )
+                    }
                 }
 
                 if (currentList.isEmpty()) {
@@ -578,12 +646,70 @@ class HomePresenter(
                 }
 
                 isCreatingEmptyBandalart = false
-                val recentBandalartId = bandalartRepository.getRecentBandalartId()
-                val selectedId =
-                    recentBandalartId.takeIf { recentId ->
-                        currentList.any { it.id == recentId }
-                    } ?: currentList.first().id
-                loadBandalart(selectedId)
+                Snapshot.withMutableSnapshot {
+                    newlyCompletedTargetId = completedTargetId
+                    bandalartList = currentList.toPersistentList()
+                    bandalartListRevision += 1
+                }
+            }
+        }
+
+        LaunchedEffect(
+            pendingDeadlineLaunchId,
+            isExplicitSelectionTargetPending,
+            explicitSelectionTargetId,
+            bandalartListRevision,
+        ) {
+            if (bandalartList.isEmpty()) return@LaunchedEffect
+            val targetId = pendingDeadlineLaunchId
+            if (targetId != null) {
+                val selectionRequest = beginSelectionRequest()
+                explicitSelectionTargetId = null
+                isExplicitSelectionTargetPending = false
+                if (bandalartList.none { it.id == targetId }) {
+                    deadlineNotificationLaunchTarget.acknowledge(targetId)
+                    return@LaunchedEffect
+                }
+                val committed = selectBandalart(selectionRequest, targetId)
+                if (!committed) return@LaunchedEffect
+                handledCompletionRevision[0] = bandalartListRevision
+                bottomSheet = null
+                deadlineNotificationLaunchTarget.acknowledge(targetId)
+                return@LaunchedEffect
+            }
+            if (isExplicitSelectionTargetPending) return@LaunchedEffect
+            val explicitTargetId = explicitSelectionTargetId
+            if (explicitTargetId != null) {
+                val selectionRequest = beginSelectionRequest()
+                val committed = selectBandalart(selectionRequest, explicitTargetId)
+                if (committed) {
+                    explicitSelectionTargetId = null
+                    bottomSheet = null
+                }
+                return@LaunchedEffect
+            }
+            val selectionRequest = beginSelectionRequest()
+            val completedTargetId =
+                newlyCompletedTargetId?.takeIf { completedId ->
+                    handledCompletionRevision[0] != bandalartListRevision &&
+                        bandalartList.any { it.id == completedId }
+                }
+            val currentBandalartId = bandalartData?.id
+            val currentSelectionId =
+                currentBandalartId?.takeIf { currentId -> bandalartList.any { it.id == currentId } }
+            val recentBandalartId = bandalartRepository.getRecentBandalartId()
+            val selectedId =
+                completedTargetId ?: currentSelectionId ?: recentBandalartId.takeIf { recentId ->
+                    bandalartList.any { it.id == recentId }
+                } ?: bandalartList.first().id
+            selectBandalart(
+                requestGeneration = selectionRequest,
+                bandalartId = selectedId,
+                isCompleted = selectedId == completedTargetId,
+                persistRecent = selectedId != currentSelectionId,
+            )
+            if (selectedId == completedTargetId) {
+                handledCompletionRevision[0] = bandalartListRevision
             }
         }
 
@@ -619,15 +745,16 @@ class HomePresenter(
             themeMode = themeMode,
             recentEmojis = recentEmojis.toPersistentList(),
             rewardedAdRequestId = rewardedAdRequestId,
+            deadlineReminderEnabled = deadlineReminderEnabled,
+            deadlineNotificationAuthorizationStatus = deadlineNotificationAuthorizationStatus,
+            deadlineReminderSchedulingHealth = deadlineReminderSchedulingHealth,
+            deadlinePermissionRequestId = deadlinePermissionRequestId,
             effect = effect,
         ) { event ->
             when (event) {
                 is HomeScreen.Event.SelectBandalart -> {
-                    scope.launch {
-                        bandalartRepository.setRecentBandalartId(event.bandalartId)
-                        loadBandalart(event.bandalartId)
-                        bottomSheet = null
-                    }
+                    beginSelectionRequest()
+                    explicitSelectionTargetId = event.bandalartId
                 }
 
                 HomeScreen.Event.AddBandalart -> scope.launch { requestCreateBandalart() }
@@ -638,6 +765,9 @@ class HomePresenter(
                 HomeScreen.Event.OpenBandalartList -> openBandalartList()
                 HomeScreen.Event.OpenSettings -> {
                     bottomSheet = HomeScreen.BottomSheetState.Settings
+                    scope.launch {
+                        deadlineNotificationAuthorizationStatus = deadlineNotificationAuthorization.getStatus()
+                    }
                 }
                 HomeScreen.Event.OpenEmoji -> {
                     if (!isUpdatingBandalartEmoji) openEmoji()
@@ -746,6 +876,61 @@ class HomePresenter(
                     scope.launch { settingsRepository.setThemeMode(event.themeMode) }
                 }
 
+                is HomeScreen.Event.SetDeadlineReminderEnabled -> {
+                    if (!event.enabled) {
+                        scope.launch {
+                            settingsRepository.setDeadlineReminderEnabled(false)
+                            deadlineReminderReconciler.reconcileAll()
+                        }
+                    }
+                }
+
+                HomeScreen.Event.ConfirmDeadlineReminderPermission -> {
+                    scope.launch {
+                        deadlineNotificationAuthorizationStatus = deadlineNotificationAuthorization.getStatus()
+                        when (deadlineNotificationAuthorizationStatus) {
+                            DeadlineNotificationAuthorizationStatus.GRANTED,
+                            DeadlineNotificationAuthorizationStatus.QUIET,
+                            -> {
+                                settingsRepository.setDeadlineReminderEnabled(true)
+                                deadlineReminderReconciler.reconcileAll()
+                            }
+
+                            DeadlineNotificationAuthorizationStatus.REQUESTABLE -> {
+                                nextDeadlinePermissionRequestId += 1
+                                deadlinePermissionRequestId = nextDeadlinePermissionRequestId
+                            }
+
+                            DeadlineNotificationAuthorizationStatus.BLOCKED -> {
+                                deadlineNotificationAuthorization.openSettings()
+                            }
+
+                            DeadlineNotificationAuthorizationStatus.UNSUPPORTED -> Unit
+                        }
+                    }
+                }
+
+                HomeScreen.Event.DeadlineReminderPermissionResult -> {
+                    deadlinePermissionRequestId = null
+                    scope.launch {
+                        deadlineNotificationAuthorizationStatus = deadlineNotificationAuthorization.getStatus()
+                        val granted =
+                            deadlineNotificationAuthorizationStatus == DeadlineNotificationAuthorizationStatus.GRANTED ||
+                                deadlineNotificationAuthorizationStatus == DeadlineNotificationAuthorizationStatus.QUIET
+                        settingsRepository.setDeadlineReminderEnabled(granted)
+                        deadlineReminderReconciler.reconcileAll()
+                    }
+                }
+
+                HomeScreen.Event.DeadlineReminderForegrounded -> {
+                    scope.launch {
+                        deadlineNotificationAuthorizationStatus = deadlineNotificationAuthorization.getStatus()
+                        if (deadlineReminderEnabled) {
+                            deadlineReminderReconciler.reconcileAll()
+                        }
+                    }
+                }
+
                 HomeScreen.Event.ContactSupport -> emitEffect(HomeScreen.Effect.OpenSupportMail)
                 HomeScreen.Event.RequestShare -> imageRequest = HomeScreen.ImageRequest.Share
                 HomeScreen.Event.RequestSave -> {
@@ -758,7 +943,7 @@ class HomePresenter(
                     val request = imageRequest as? HomeScreen.ImageRequest.Complete
                     if (request != null) {
                         imageRequest = null
-                        isBandalartCompleted = false
+                        loadedBandalart = loadedBandalart?.copy(isCompleted = false)
                         navigator.goTo(
                             CompleteScreen(
                                 bandalartId = request.bandalartId,
@@ -802,6 +987,12 @@ class HomePresenter(
         const val MAX_DESCRIPTION_LENGTH = 1000
     }
 }
+
+private data class LoadedBandalart(
+    val bandalartData: BandalartUiModel,
+    val bandalartCellData: BandalartCellEntity,
+    val isCompleted: Boolean,
+)
 
 @Suppress("TooGenericExceptionCaught")
 private inline fun <T> runRewardedOperation(block: () -> T): Result<T> =

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/settings/SettingsBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/settings/SettingsBottomSheet.kt
@@ -36,6 +36,7 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -43,9 +44,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.material3.Switch
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -55,6 +62,16 @@ import bandalart.core.designsystem.generated.resources.Res
 import bandalart.core.designsystem.generated.resources.clear_description
 import bandalart.core.designsystem.generated.resources.settings_app_info
 import bandalart.core.designsystem.generated.resources.settings_appearance
+import bandalart.core.designsystem.generated.resources.settings_deadline_reminder
+import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_body
+import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_blocked
+import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_cancel
+import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_confirm
+import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_degraded
+import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_dialog_body
+import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_dialog_title
+import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_overflow
+import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_section
 import bandalart.core.designsystem.generated.resources.settings_contact
 import bandalart.core.designsystem.generated.resources.settings_theme_dark
 import bandalart.core.designsystem.generated.resources.settings_theme_light
@@ -64,6 +81,8 @@ import bandalart.core.designsystem.generated.resources.settings_version
 import bandalart.core.designsystem.generated.resources.settings_version_value
 import com.nexters.bandalart.core.designsystem.theme.pretendardFontFamily
 import com.nexters.bandalart.core.domain.entity.ThemeMode
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorizationStatus
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingHealth
 import com.nexters.bandalart.feature.home.HomeScreen
 import org.jetbrains.compose.resources.stringResource
 
@@ -71,11 +90,38 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 internal fun SettingsBottomSheet(
     themeMode: ThemeMode,
+    deadlineReminderEnabled: Boolean,
+    deadlineNotificationAuthorizationStatus: DeadlineNotificationAuthorizationStatus,
+    deadlineReminderSchedulingHealth: DeadlineReminderSchedulingHealth,
     appVersion: String,
     onHomeUiAction: (HomeScreen.Event) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val bottomSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var showDeadlineReminderConfirmation by remember { mutableStateOf(false) }
+
+    if (showDeadlineReminderConfirmation) {
+        AlertDialog(
+            onDismissRequest = { showDeadlineReminderConfirmation = false },
+            title = { Text(stringResource(Res.string.settings_deadline_reminder_dialog_title)) },
+            text = { Text(stringResource(Res.string.settings_deadline_reminder_dialog_body)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeadlineReminderConfirmation = false
+                        onHomeUiAction(HomeScreen.Event.ConfirmDeadlineReminderPermission)
+                    },
+                ) {
+                    Text(stringResource(Res.string.settings_deadline_reminder_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeadlineReminderConfirmation = false }) {
+                    Text(stringResource(Res.string.settings_deadline_reminder_cancel))
+                }
+            },
+        )
+    }
 
     ModalBottomSheet(
         onDismissRequest = { onHomeUiAction(HomeScreen.Event.DismissBottomSheet) },
@@ -110,6 +156,31 @@ internal fun SettingsBottomSheet(
                 color = MaterialTheme.colorScheme.outlineVariant,
                 modifier = Modifier.padding(horizontal = 20.dp),
             )
+            if (deadlineNotificationAuthorizationStatus != DeadlineNotificationAuthorizationStatus.UNSUPPORTED) {
+                SettingsSectionTitle(text = stringResource(Res.string.settings_deadline_reminder_section))
+                DeadlineReminderRow(
+                    enabled = deadlineReminderEnabled,
+                    authorizationStatus = deadlineNotificationAuthorizationStatus,
+                    schedulingHealth = deadlineReminderSchedulingHealth,
+                    onToggle = { enabled ->
+                        if (!enabled) {
+                            onHomeUiAction(HomeScreen.Event.SetDeadlineReminderEnabled(false))
+                        } else if (
+                            deadlineNotificationAuthorizationStatus ==
+                            DeadlineNotificationAuthorizationStatus.BLOCKED
+                        ) {
+                            onHomeUiAction(HomeScreen.Event.ConfirmDeadlineReminderPermission)
+                        } else {
+                            showDeadlineReminderConfirmation = true
+                        }
+                    },
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                )
+            }
             SettingsSectionTitle(text = stringResource(Res.string.settings_app_info))
             SettingsContactRow(
                 onClick = { onHomeUiAction(HomeScreen.Event.ContactSupport) },
@@ -141,6 +212,57 @@ internal fun SettingsBottomSheet(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun DeadlineReminderRow(
+    enabled: Boolean,
+    authorizationStatus: DeadlineNotificationAuthorizationStatus,
+    schedulingHealth: DeadlineReminderSchedulingHealth,
+    onToggle: (Boolean) -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable { onToggle(!enabled) }
+                .padding(horizontal = 24.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(Res.string.settings_deadline_reminder),
+                color = MaterialTheme.colorScheme.onSurface,
+                fontSize = 15.sp,
+                fontFamily = pretendardFontFamily(),
+                fontWeight = FontWeight.W600,
+            )
+            Text(
+                text =
+                    when {
+                        authorizationStatus == DeadlineNotificationAuthorizationStatus.BLOCKED ->
+                            stringResource(Res.string.settings_deadline_reminder_blocked)
+                        schedulingHealth.lastErrorCategory != null ->
+                            stringResource(Res.string.settings_deadline_reminder_degraded)
+                        schedulingHealth.overflowCount > 0 ->
+                            stringResource(
+                                Res.string.settings_deadline_reminder_overflow,
+                                schedulingHealth.overflowCount,
+                            )
+                        else -> stringResource(Res.string.settings_deadline_reminder_body)
+                    },
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 13.sp,
+                fontFamily = pretendardFontFamily(),
+                lineHeight = 18.sp,
+                modifier = Modifier.padding(top = 4.dp, end = 12.dp),
+            )
+        }
+        Switch(
+            checked = enabled,
+            onCheckedChange = onToggle,
+        )
     }
 }
 

--- a/feature/home/src/iosMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderForegroundEffect.ios.kt
+++ b/feature/home/src/iosMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderForegroundEffect.ios.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun DeadlineReminderForegroundEffect(onForeground: () -> Unit) = Unit

--- a/feature/home/src/iosMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderPermissionEffect.ios.kt
+++ b/feature/home/src/iosMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderPermissionEffect.ios.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal actual fun DeadlineReminderPermissionEffect(
+    requestId: Long?,
+    onResult: () -> Unit,
+) = Unit

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ androidx-lifecycle-runtime = "2.9.0-beta01"
 androidx-splash = "1.0.1"
 androidx-startup = "1.2.0"
 androidx-activity-compose = "1.10.1"
+androidx-work = "2.11.2"
 androidx-fragment = "1.8.9"
 androidx-compose-bom = "2025.04.00"
 androidx-compose-material3 = "1.3.2"
@@ -129,6 +130,8 @@ app-update-ktx = { group = "com.google.android.play", name = "app-update-ktx", v
 compose-material-iconsCore = { group = "org.jetbrains.compose.material", name = "material-icons-core", version.ref = "compose-material-icons" }
 compose-ui-toolingPreview = { group = "org.jetbrains.compose.ui", name = "ui-tooling-preview", version.ref = "compose-multiplatform" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activity-compose" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidx-work" }
+androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "androidx-work" }
 androidx-fragment = { group = "androidx.fragment", name = "fragment", version.ref = "androidx-fragment" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle-runtime" }
 androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle-runtime" }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #211

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- 설정에서 사용자가 직접 켤 수 있는 Android 마감일 알림 토글과 권한·시스템 설정 동선을 추가했습니다.
- WorkManager 기반으로 반다라트·마감일별 알림을 예약하고 DB 변경, 앱 시작·foreground, 시간·타임존 변경 시 전역 reconcile합니다.
- 알림을 누르면 non-exported trampoline과 buffered launch target을 거쳐 cold/warm 상태 모두 해당 반다라트를 선택합니다.
- 알림 대상이 수동 선택·생성·완료 refresh와 겹쳐도 최종 대상이 유지되도록 Home 선택 경로를 단일 generation arbiter로 직렬화했습니다.
- iOS는 이번 PR에서 `Unsupported`/no-op으로 유지하며 UI를 노출하지 않습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `:feature:home:testAndroidHostTest` — Home Presenter 43개 통과
- `:feature:home:detekt`, `:composeApp:detekt` 통과
- scheduler, Worker retry/stale 검증, reconciler 부분 실패, launch target 테스트 통과
- 독립 Standards·Spec 리뷰 승인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 설정 알림 토글 | Internal 설치본에서 확인 예정 | 알림 탭 이동 | Internal 설치본에서 확인 예정 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- 실제 Android OS의 fresh/dismiss/deny/blocked 권한 동선, 09:00 예약·전달, 종료·warm 알림 탭은 merge 후 Internal 설치본에서 검증합니다.
- #211은 iOS 구현과 양 플랫폼 acceptance가 남아 있으므로 이 PR에서 닫지 않습니다.
