### PR TITLE
fix: 모달 바텀시트 하단 여백 정리

### DIFF
--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartBottomSheet.kt
@@ -30,7 +30,6 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -86,10 +85,8 @@ import com.nexters.bandalart.core.common.extension.toLocalDateTime
 import com.nexters.bandalart.core.common.extension.toStringLocalDateTime
 import com.nexters.bandalart.core.common.getLocale
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.ui.NavigationBarHeightDp
 import com.nexters.bandalart.core.ui.ThemeColor
 import com.nexters.bandalart.core.ui.component.emoji.BandalartEmoji
-import com.nexters.bandalart.core.ui.getNavigationBarPadding
 import com.nexters.bandalart.feature.home.model.CellType
 import com.nexters.bandalart.feature.home.model.dummy.dummyBandalartCellData
 import com.nexters.bandalart.feature.home.model.dummy.dummyBandalartData
@@ -162,7 +159,6 @@ fun BandalartBottomSheet(
             modifier =
                 Modifier
                     .background(MaterialTheme.colorScheme.surface)
-                    .navigationBarsPadding()
                     .noRippleClickable { focusManager.clearFocus() },
         ) {
             Spacer(modifier = Modifier.height(20.dp))
@@ -422,7 +418,7 @@ fun BandalartBottomSheet(
                             modifier = Modifier.weight(1f),
                         )
                     }
-                    Spacer(modifier = Modifier.height(NavigationBarHeightDp + getNavigationBarPadding()))
+                    Spacer(modifier = Modifier.height(24.dp))
                 }
 
                 if (showTopGradient) {

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartListBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartListBottomSheet.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -57,8 +56,6 @@ import bandalart.core.designsystem.generated.resources.bandalart_list_add
 import bandalart.core.designsystem.generated.resources.bandalart_list_title
 import bandalart.core.designsystem.generated.resources.clear_description
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
-import com.nexters.bandalart.core.ui.NavigationBarHeightDp
-import com.nexters.bandalart.core.ui.getNavigationBarPadding
 import com.nexters.bandalart.feature.home.model.BandalartUiModel
 import com.nexters.bandalart.feature.home.model.dummy.dummyBandalartList
 import com.nexters.bandalart.feature.home.HomeScreen
@@ -91,8 +88,7 @@ fun BandalartListBottomSheet(
         Column(
             modifier =
                 Modifier
-                    .background(MaterialTheme.colorScheme.surface)
-                    .navigationBarsPadding(),
+                    .background(MaterialTheme.colorScheme.surface),
         ) {
             Spacer(modifier = Modifier.height(20.dp))
             Box(
@@ -130,7 +126,7 @@ fun BandalartListBottomSheet(
             LazyColumn(
                 modifier = Modifier.padding(horizontal = 20.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
-                contentPadding = PaddingValues(bottom = NavigationBarHeightDp + getNavigationBarPadding()),
+                contentPadding = PaddingValues(bottom = 24.dp),
             ) {
                 items(
                     count = bandalartList.size,

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/settings/SettingsBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/settings/SettingsBottomSheet.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -134,7 +133,6 @@ internal fun SettingsBottomSheet(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .navigationBarsPadding()
                     .padding(bottom = 24.dp),
         ) {
             SettingsHeader(onCloseClick = { onHomeUiAction(HomeScreen.Event.DismissBottomSheet) })


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- Material3 ModalBottomSheet가 적용하는 하단 system inset과 중복되던 navigationBarsPadding을 제거했습니다.
- 반다라트 목표 입력, 반다라트 목록, 설정 시트의 하단 여백을 디자인 간격 24dp로 통일했습니다.
- 키보드 대응 imePadding은 유지해 입력 UX에는 영향을 주지 않습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 하단 inset 정리 | 기기 수동 확인 예정 | 설정 시트 | 기기 수동 확인 예정 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- ModalBottomSheet를 system inset의 단일 소유자로 두고 내부에는 순수 디자인 간격만 남겼습니다.
- Android compile, Home Detekt, 정적 inset 감사와 git diff --check를 통과했습니다.