### PR TITLE
fix: 홈 배너 높이 축소

### DIFF
--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidBannerAdHost.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidBannerAdHost.kt
@@ -21,6 +21,7 @@ import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -28,6 +29,7 @@ import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
@@ -54,20 +56,23 @@ class AndroidBannerAdHost(
         val activity = LocalActivity.current ?: return
         val isPreviewMode = LocalInspectionMode.current
 
-        BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
-            val width = maxWidth.value.toInt().coerceAtLeast(1)
+        BoxWithConstraints(
+            modifier = modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (!supportsFixedBanner(maxWidth.value)) return@BoxWithConstraints
 
-            key(activity, width) {
-                val adSize =
-                    remember {
-                        AdSize.getLargeAnchoredAdaptiveBannerAdSize(activity, width)
-                    }
+            key(activity) {
+                val adSize = AdSize.BANNER
                 val adView = remember { AdView(activity) }
                 val released = remember { AtomicBoolean(false) }
                 var isLoaded by remember { mutableStateOf(false) }
 
                 AndroidView(
-                    modifier = Modifier.fillMaxWidth().height(adSize.height.dp),
+                    modifier =
+                        Modifier
+                            .width(FIXED_BANNER_WIDTH_DP.dp)
+                            .height(FIXED_BANNER_HEIGHT_DP.dp),
                     factory = { adView },
                     update = { view ->
                         view.visibility =
@@ -115,3 +120,8 @@ class AndroidBannerAdHost(
         }
     }
 }
+
+private const val FIXED_BANNER_WIDTH_DP = 320
+private const val FIXED_BANNER_HEIGHT_DP = 50
+
+internal fun supportsFixedBanner(availableWidthDp: Float): Boolean = availableWidthDp >= FIXED_BANNER_WIDTH_DP

--- a/androidApp/src/test/kotlin/com/nexters/bandalart/ads/FixedBannerSizePolicyTest.kt
+++ b/androidApp/src/test/kotlin/com/nexters/bandalart/ads/FixedBannerSizePolicyTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.ads
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class FixedBannerSizePolicyTest {
+    @Test
+    fun widthBelow320DpDoesNotRenderBanner() {
+        assertFalse(supportsFixedBanner(319.99f))
+    }
+
+    @Test
+    fun widthAtLeast320DpRendersBanner() {
+        assertTrue(supportsFixedBanner(320f))
+        assertTrue(supportsFixedBanner(360f))
+    }
+}

--- a/docs/features/ads/ADMOB_HOME_BANNER_STRATEGY.md
+++ b/docs/features/ads/ADMOB_HOME_BANNER_STRATEGY.md
@@ -2,12 +2,13 @@
 
 ## 배경
 
-이슈 #206의 보상형 슬롯 확장 흐름은 PR #243에서 구현됐지만, 같은 이슈의 홈 하단 Anchored Adaptive Banner는 아직 구현되지 않았다. Android 리소스에는 배너 광고 단위 ID가 있으나 이를 소비하는 UI와 lifecycle 소유자가 없어 실제 요청이 발생하지 않는다.
+이슈 #206의 보상형 슬롯 확장 흐름은 PR #243에서 구현됐고, 후속 작업에서 홈 하단 Large Anchored Adaptive Banner를 연결했다. 실제 화면에서는 배너 높이가 홈 콘텐츠를 과도하게 밀어 올리는 문제가 확인돼, 광고 영역을 더 작게 유지하는 후속 조정이 필요하다.
 
 ## 목표
 
-- Android 홈 하단에 GMA Next-Gen 1.3.0 Anchored Adaptive Banner를 고정 노출한다.
-- 광고 높이를 요청 전에 확보해 load 완료 전후로 홈 콘텐츠가 이동하지 않게 한다.
+- Android 홈 하단에 GMA Next-Gen 1.3.0의 고정형 `AdSize.BANNER`(320x50dp)를 노출한다.
+- 가용 폭이 320dp 이상일 때만 50dp 높이를 요청 전에 확보해 load 완료 전후로 홈 콘텐츠가 이동하지 않게 한다.
+- 가용 폭이 320dp 미만이면 광고를 요청·렌더링하거나 빈 공간을 예약하지 않는다.
 - 홈의 공유 버튼과 Snackbar는 배너 위에 배치하고 시스템 navigation bar safe area를 유지한다.
 - bottom sheet, dialog, 이미지 capture, 보상형 광고 표시 및 loading 중에는 배너 creative와 클릭·접근성 focus를 숨긴다.
 - iOS는 광고 SDK를 추가하지 않고 no-op host를 유지한다.
@@ -23,10 +24,11 @@
 
 ## Android lifecycle과 크기
 
-- 현재 화면 폭으로 공식 가이드의 `AdSize.getLargeAnchoredAdaptiveBannerAdSize()`를 계산한다.
-- 계산한 adaptive 높이의 container를 광고 요청 전에 렌더링해 공간을 예약한다.
+- 공식 고정형 `AdSize.BANNER`를 사용해 creative를 320x50dp로 제한한다. Large Anchored Adaptive보다 화면 점유를 줄이는 대신, 320dp보다 좁은 공간에서는 광고를 표시할 수 없다.
+- 320dp 이상인 full-width host의 중앙에 320x50dp `AdView`를 배치하고 50dp 높이를 광고 요청 전에 예약한다.
+- 가용 폭이 320dp 미만이면 `AdView`와 예약 공간을 만들지 않고 광고 요청도 보내지 않는다.
 - GMA 초기화 완료 뒤 `AdView.loadAd()`를 한 번 호출하고 SDK가 creative 표시와 refresh를 관리하게 한다.
-- Activity 또는 폭이 바뀌면 기존 `AdView`를 `destroy()`하고 새 크기로 다시 요청한다.
+- 같은 Activity composition에서는 지원 범위 안의 폭 변경만으로 다시 요청하지 않는다. Activity가 바뀌거나 폭이 320dp 경계를 벗어나 view가 composition에서 제거되면 기존 `AdView`를 `destroy()`한다.
 - 화면이 composition에서 제거되면 `AndroidView.onRelease`에서 `AdView`를 `destroy()`한다.
 - load 실패는 홈 기능을 막거나 빈 공간의 클릭 영역을 만들지 않고 로그만 남긴다.
 
@@ -36,7 +38,7 @@
 - 스크롤 콘텐츠와 공유 버튼은 배너가 차지한 실제 높이만큼 자동으로 위에 배치한다.
 - Snackbar는 콘텐츠 영역의 하단에 두어 배너를 가리지 않는다.
 - 앱 root Scaffold가 전달한 system bar inset 안에 배너를 두어 navigation bar와 겹치지 않게 한다.
-- host와 예약 공간은 Home 수명 동안 유지하되 다음 조건이 모두 참일 때만 native 광고 view를 visible로 둔다. overlay가 열릴 때마다 광고를 다시 요청하지 않으면서 클릭과 접근성 focus를 차단한다.
+- 가용 폭이 지원되는 동안 host와 예약 공간은 Home 수명 동안 유지하되 다음 조건이 모두 참일 때만 native 광고 view를 visible로 둔다. overlay가 열릴 때마다 광고를 다시 요청하지 않으면서 클릭과 접근성 focus를 차단한다.
   - Home loading이 끝남
   - bottom sheet가 닫힘
   - dialog가 닫힘
@@ -63,7 +65,7 @@
 ### Internal 수동 검증
 
 - 홈 하단에 `Test Ad` 표시가 있는 배너 creative가 실제로 노출된다.
-- 작은 화면과 Activity 재생성·가용 폭 변경 뒤에도 배너가 화면 폭에 맞고 navigation bar, 공유 버튼과 겹치지 않는다. 현재 앱은 portrait 고정이므로 orientation lock 해제는 이번 범위에 포함하지 않는다.
+- 320dp 이상 화면에서 고정형 배너가 중앙에 표시되고 navigation bar, 공유 버튼과 겹치지 않는다. 320dp 미만 가용 폭에서는 광고 요청과 빈 공간이 모두 없어야 한다. 현재 앱은 portrait 고정이므로 orientation lock 해제는 이번 범위에 포함하지 않는다.
 - Snackbar가 배너 위에 표시된다.
 - bottom sheet, dialog, 공유·저장 capture와 보상형 광고 표시 중 배너가 숨겨진다.
 - light/dark theme에서 광고 주변 container가 홈 배경과 어색하게 분리되지 않는다.
@@ -80,5 +82,5 @@
 
 ## 공식 참고
 
-- [GMA Next-Gen Anchored Adaptive Banner](https://developers.google.com/admob/android/next-gen/banner)
+- [GMA Next-Gen fixed size banner](https://developers.google.com/admob/android/next-gen/banner/fixed-size)
 - [GMA Next-Gen test ads](https://developers.google.com/admob/android/next-gen/test-ads)


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Refs #206

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 홈 하단 Large Anchored Adaptive Banner를 공식 고정형 AdSize.BANNER 320x50dp로 변경했습니다.
- 가용 폭이 320dp 미만이면 광고 요청과 빈 슬롯 생성을 모두 생략합니다.
- 지원 폭에서는 320x50 광고를 가운데 배치하고 기존 lifecycle 및 overlay 숨김 정책을 유지합니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 320x50 배너 | Internal Test Ad 확인 예정 | 320dp 미만 | 기기 확인 예정 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- Android 단위 테스트 2건, androidApp Spotless, androidApp 및 Home Detekt, Home Android compile과 git diff --check를 통과했습니다.
- 이 PR은 배너 높이만 다루며 바텀시트 inset 변경은 별도 PR #253에서 처리합니다.