### PR TITLE
fix: 홈 대표 이모지 크기 확대

### DIFF
--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/HomeHeader.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/HomeHeader.kt
@@ -112,6 +112,7 @@ fun HomeHeader(
                             BandalartEmoji(
                                 unicode = bandalartData.profileEmoji.orEmpty(),
                                 contentDescription = stringResource(Res.string.edit_description),
+                                size = 36.dp,
                             )
                         }
                     }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 홈 제목 위 52dp 프로필 카드의 대표 이모지를 22dp에서 36dp로 확대했습니다.
- 카드 크기와 터치 영역은 유지해 레이아웃과 접근성 범위에는 영향을 주지 않습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 대표 이모지 | Internal 확인 예정 | 터치 영역 | 기존 52dp 유지 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- feature:home Android compile, Detekt와 git diff --check를 통과했습니다.
- 공통 BandalartEmoji 기본 크기는 변경하지 않아 다른 화면에는 영향이 없습니다.