### PR TITLE
feat: 완료 셀 롱클릭 해제 지원

### DIFF
--- a/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
@@ -34,6 +34,7 @@
     <string name="home_main_cell">Main Goal</string>
     <string name="home_sub_cell">Sub Goal</string>
     <string name="home_complete_task_long_click">Complete goal</string>
+    <string name="home_uncomplete_task_long_click">Mark goal incomplete</string>
     <string name="please_input_main_goal">Please enter the main goal first.</string>
     <string name="please_input_sub_goal">Please enter the sub goal first.</string>
 

--- a/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
@@ -34,6 +34,7 @@
     <string name="home_main_cell">メイン目標</string>
     <string name="home_sub_cell">サブ目標</string>
     <string name="home_complete_task_long_click">目標を完了</string>
+    <string name="home_uncomplete_task_long_click">目標を未完了に戻す</string>
     <string name="please_input_main_goal">先にメイン目標を入力してください。</string>
     <string name="please_input_sub_goal">先にサブ目標を入力してください。</string>
 

--- a/core/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="home_main_cell">메인목표</string>
     <string name="home_sub_cell">서브목표</string>
     <string name="home_complete_task_long_click">목표 완료</string>
+    <string name="home_uncomplete_task_long_click">목표 완료 취소</string>
     <string name="please_input_main_goal">메인 목표를 먼저 입력해주세요.</string>
     <string name="please_input_sub_goal">서브 목표를 먼저 입력해주세요.</string>
 

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
@@ -35,14 +35,16 @@ internal class FakeBandalartRepository(
     private val publishCreatedBandalartImmediately: Boolean = true,
     details: Map<Long, BandalartEntity> = initialBandalarts.associateBy { it.id },
     mainCells: Map<Long, BandalartCellEntity> = emptyMap(),
-    private val childCells: Map<Long, List<BandalartCellEntity>> = emptyMap(),
+    childCells: Map<Long, List<BandalartCellEntity>> = emptyMap(),
     private val beforeTaskCellUpdate: suspend () -> Unit = {},
+    private val afterTaskCellUpdate: suspend () -> Unit = {},
     private val beforeBandalartLoad: suspend (Long) -> Unit = {},
     private val taskCellUpdateError: Throwable? = null,
 ) : BandalartRepository {
     private val bandalartFlow = MutableStateFlow(initialBandalarts)
     private val details = details.toMutableMap()
     private val mainCells = mainCells.toMutableMap()
+    private val childCells = childCells.toMutableMap()
     private var unpublishedCreatedBandalart: BandalartEntity? = null
 
     var recentBandalartId: Long = recentBandalartId
@@ -93,6 +95,10 @@ internal class FakeBandalartRepository(
             bandalartFlow.value.map { current ->
                 if (current.id == bandalart.id) bandalart else current
             }
+    }
+
+    fun publishTaskCellRevision(taskCell: BandalartCellEntity) {
+        childCells.replaceTaskCell(taskCell)
     }
 
     override fun getBandalartList(): Flow<List<BandalartEntity>> = bandalartFlow
@@ -167,6 +173,17 @@ internal class FakeBandalartRepository(
                 cellId = cellId,
                 entity = updateBandalartTaskCellEntity,
             )
+        childCells.replaceTaskCell(
+            BandalartCellEntity(
+                id = cellId,
+                title = updateBandalartTaskCellEntity.title,
+                description = updateBandalartTaskCellEntity.description,
+                dueDate = updateBandalartTaskCellEntity.dueDate,
+                isCompleted = updateBandalartTaskCellEntity.isCompleted ?: false,
+                parentId = childCells.values.flatten().firstOrNull { it.id == cellId }?.parentId,
+            ),
+        )
+        afterTaskCellUpdate()
     }
 
     override suspend fun updateBandalartEmoji(
@@ -215,4 +232,13 @@ internal class FakeBandalartRepository(
         val cellId: Long,
         val entity: UpdateBandalartEmojiEntity,
     )
+
+    private fun MutableMap<Long, List<BandalartCellEntity>>.replaceTaskCell(taskCell: BandalartCellEntity) {
+        entries.forEach { entry ->
+            if (entry.value.any { it.id == taskCell.id }) {
+                entry.setValue(entry.value.map { current -> if (current.id == taskCell.id) taskCell else current })
+                return
+            }
+        }
+    }
 }

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
@@ -180,7 +180,11 @@ internal class FakeBandalartRepository(
                 description = updateBandalartTaskCellEntity.description,
                 dueDate = updateBandalartTaskCellEntity.dueDate,
                 isCompleted = updateBandalartTaskCellEntity.isCompleted ?: false,
-                parentId = childCells.values.flatten().firstOrNull { it.id == cellId }?.parentId,
+                parentId =
+                    childCells.values
+                        .flatten()
+                        .firstOrNull { it.id == cellId }
+                        ?.parentId,
             ),
         )
         afterTaskCellUpdate()

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterQuickCompletionTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterQuickCompletionTest.kt
@@ -49,7 +49,7 @@ class HomePresenterQuickCompletionTest {
 
             presenter(repository).test {
                 var state = awaitLoadedBandalart()
-                state.eventSink(HomeScreen.Event.CompleteTask(taskCell))
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(taskCell))
                 do {
                     state = awaitItem()
                 } while (state.effect !is HomeScreen.Effect.PlayTaskCompletionHaptic)
@@ -77,11 +77,43 @@ class HomePresenterQuickCompletionTest {
         }
 
     @Test
-    fun invalidOrCompletedCellsAreIgnored() =
+    fun completedTaskIsUncompletedWithPreservedContentAndOneShotEffect() =
+        runTest {
+            val taskCell =
+                cell(
+                    id = 12L,
+                    title = "매일 걷기",
+                    description = "30분",
+                    dueDate = "2026-12-31",
+                    isCompleted = true,
+                )
+            val repository = repositoryWithTasks(taskCell)
+
+            presenter(repository).test {
+                var state = awaitLoadedBandalart()
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(taskCell))
+                do {
+                    state = awaitItem()
+                } while (state.effect !is HomeScreen.Effect.PlayTaskCompletionHaptic)
+
+                val update = requireNotNull(repository.taskCellUpdate)
+                assertEquals(1, repository.taskCellUpdateCalls)
+                assertEquals(1L, update.bandalartId)
+                assertEquals(taskCell.id, update.cellId)
+                assertEquals(taskCell.title, update.entity.title)
+                assertEquals(taskCell.description, update.entity.description)
+                assertEquals(taskCell.dueDate, update.entity.dueDate)
+                assertFalse(update.entity.isCompleted == true)
+                assertFalse(state.taskCell(taskCell.id).isCompleted)
+                assertEquals(taskCell.id, state.effect.taskCellId)
+            }
+        }
+
+    @Test
+    fun invalidCellsAreIgnored() =
         runTest {
             val emptyTask = cell(id = 12L, title = null)
-            val completedTask = cell(id = 13L, title = "완료", isCompleted = true)
-            val repository = repositoryWithTasks(emptyTask, completedTask)
+            val repository = repositoryWithTasks(emptyTask)
 
             presenter(repository).test {
                 val state = awaitLoadedBandalart()
@@ -90,14 +122,12 @@ class HomePresenterQuickCompletionTest {
                 val mainCell = requireNotNull(state.bandalartCellData)
                 val subCell = mainCell.children.single()
 
-                state.eventSink(HomeScreen.Event.CompleteTask(emptyTask))
-                state.eventSink(HomeScreen.Event.CompleteTask(completedTask))
-                state.eventSink(HomeScreen.Event.CompleteTask(mainCell))
-                state.eventSink(HomeScreen.Event.CompleteTask(subCell))
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(emptyTask))
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(mainCell))
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(subCell))
                 yield()
 
                 assertEquals(0, repository.taskCellUpdateCalls)
-                assertTrue(state.taskCell(completedTask.id).isCompleted)
                 expectNoEvents()
                 cancelAndIgnoreRemainingEvents()
             }
@@ -112,8 +142,8 @@ class HomePresenterQuickCompletionTest {
 
             presenter(repository).test {
                 var state = awaitLoadedBandalart()
-                state.eventSink(HomeScreen.Event.CompleteTask(firstTask))
-                state.eventSink(HomeScreen.Event.CompleteTask(secondTask))
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(firstTask))
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(secondTask))
 
                 do {
                     state = awaitItem()
@@ -154,10 +184,10 @@ class HomePresenterQuickCompletionTest {
 
             presenter(repository).test {
                 var state = awaitLoadedBandalart()
-                state.eventSink(HomeScreen.Event.CompleteTask(taskCell))
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(taskCell))
                 updateStarted.await()
 
-                state.eventSink(HomeScreen.Event.CompleteTask(taskCell))
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(taskCell))
                 yield()
                 assertEquals(1, repository.taskCellUpdateCalls)
 
@@ -166,6 +196,161 @@ class HomePresenterQuickCompletionTest {
                     state = awaitItem()
                 } while (state.effect !is HomeScreen.Effect.PlayTaskCompletionHaptic)
                 assertEquals(1, repository.taskCellUpdateCalls)
+            }
+        }
+
+    @Test
+    fun selectionDuringToggleDoesNotReplaceNewBandalartCells() =
+        runTest {
+            val updateStarted = CompletableDeferred<Unit>()
+            val allowUpdate = CompletableDeferred<Unit>()
+            val firstMain = cell(id = 10L, title = "첫 메인", parentId = null)
+            val firstSub = cell(id = 11L, title = "첫 서브", parentId = firstMain.id)
+            val firstTask = cell(id = 12L, title = "첫 목표", parentId = firstSub.id)
+            val secondMain = cell(id = 20L, title = "둘째 메인", parentId = null)
+            val secondSub = cell(id = 21L, title = "둘째 서브", parentId = secondMain.id)
+            val secondTask = cell(id = 22L, title = "둘째 목표", parentId = secondSub.id)
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1L), bandalart(2L)),
+                    recentBandalartId = 1L,
+                    mainCells = mapOf(1L to firstMain, 2L to secondMain),
+                    childCells =
+                        mapOf(
+                            firstMain.id to listOf(firstSub),
+                            firstSub.id to listOf(firstTask),
+                            secondMain.id to listOf(secondSub),
+                            secondSub.id to listOf(secondTask),
+                        ),
+                    beforeTaskCellUpdate = {
+                        updateStarted.complete(Unit)
+                        allowUpdate.await()
+                    },
+                )
+
+            presenter(repository).test {
+                var state = awaitLoadedBandalart(1L)
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(firstTask))
+                updateStarted.await()
+
+                state.eventSink(HomeScreen.Event.SelectBandalart(2L))
+                state = awaitLoadedBandalart(2L)
+                assertEquals("둘째 목표", state.taskCell(secondTask.id).title)
+
+                allowUpdate.complete(Unit)
+                advanceUntilIdle()
+                state = expectMostRecentItem()
+
+                assertEquals(1, repository.taskCellUpdateCalls)
+                assertEquals(2L, state.bandalartData?.id)
+                assertEquals("둘째 목표", state.taskCell(secondTask.id).title)
+                assertEquals(2L, repository.recentBandalartId)
+                assertNull(state.effect)
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun roomRefreshDuringTogglePreservesLatestParentCompletion() =
+        runTest {
+            val updateStarted = CompletableDeferred<Unit>()
+            val allowUpdate = CompletableDeferred<Unit>()
+            val taskCell = cell(id = 12L, title = "목표")
+            val repository =
+                repositoryWithTasks(
+                    taskCell,
+                    beforeTaskCellUpdate = {
+                        updateStarted.complete(Unit)
+                        allowUpdate.await()
+                    },
+                )
+
+            presenter(repository).test {
+                var state = awaitLoadedBandalart()
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(taskCell))
+                updateStarted.await()
+
+                repository.publishBandalartRevision(
+                    bandalart = bandalart().copy(completionRatio = 1),
+                    mainCell = requireNotNull(state.bandalartCellData).copy(isCompleted = true),
+                )
+                do {
+                    state = awaitItem()
+                } while (state.bandalartCellData?.isCompleted != true || state.isLoading)
+
+                allowUpdate.complete(Unit)
+                do {
+                    state = awaitItem()
+                } while (state.effect !is HomeScreen.Effect.PlayTaskCompletionHaptic)
+
+                assertTrue(state.bandalartCellData?.isCompleted == true)
+                assertTrue(state.taskCell(taskCell.id).isCompleted)
+            }
+        }
+
+    @Test
+    fun taskResetDuringTogglePreservesLatestRoomStateWithoutHaptic() =
+        runTest {
+            val updatePersisted = CompletableDeferred<Unit>()
+            val allowUpdateReturn = CompletableDeferred<Unit>()
+            val taskCell = cell(id = 12L, title = "삭제될 목표")
+            val repository =
+                repositoryWithTasks(
+                    taskCell,
+                    afterTaskCellUpdate = {
+                        updatePersisted.complete(Unit)
+                        allowUpdateReturn.await()
+                    },
+                )
+
+            presenter(repository).test {
+                var state = awaitLoadedBandalart()
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(taskCell))
+                updatePersisted.await()
+
+                repository.publishTaskCellRevision(taskCell.copy(title = null, isCompleted = false))
+                repository.publishBandalartRevision(bandalart().copy(completionRatio = 2))
+                do {
+                    state = awaitItem()
+                } while (state.taskCell(taskCell.id).title != null || state.isLoading)
+
+                allowUpdateReturn.complete(Unit)
+                advanceUntilIdle()
+
+                assertNull(state.taskCell(taskCell.id).title)
+                assertFalse(state.taskCell(taskCell.id).isCompleted)
+                assertNull(state.effect)
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun authoritativeRefreshFailureDoesNotCrashOrEmitHaptic() =
+        runTest {
+            var failBandalartLoad = false
+            val taskCell = cell(id = 12L, title = "저장은 성공")
+            val repository =
+                repositoryWithTasks(
+                    taskCell,
+                    afterTaskCellUpdate = { failBandalartLoad = true },
+                    beforeBandalartLoad = {
+                        if (failBandalartLoad) error("refresh failed")
+                    },
+                )
+
+            presenter(repository).test {
+                val state = awaitLoadedBandalart()
+                advanceUntilIdle()
+                expectMostRecentItem()
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(taskCell))
+                advanceUntilIdle()
+
+                assertEquals(1, repository.taskCellUpdateCalls)
+                assertFalse(state.taskCell(taskCell.id).isCompleted)
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
             }
         }
 
@@ -185,7 +370,7 @@ class HomePresenterQuickCompletionTest {
                 val state = awaitLoadedBandalart()
                 advanceUntilIdle()
                 expectMostRecentItem()
-                state.eventSink(HomeScreen.Event.CompleteTask(taskCell))
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(taskCell))
                 updateAttempted.await()
                 yield()
 
@@ -197,9 +382,39 @@ class HomePresenterQuickCompletionTest {
             }
         }
 
+    @Test
+    fun failedSaveDoesNotUncompleteCellOrEmitHaptic() =
+        runTest {
+            val updateAttempted = CompletableDeferred<Unit>()
+            val taskCell = cell(id = 12L, title = "실패", isCompleted = true)
+            val repository =
+                repositoryWithTasks(
+                    taskCell,
+                    beforeTaskCellUpdate = { updateAttempted.complete(Unit) },
+                    taskCellUpdateError = IllegalStateException("save failed"),
+                )
+
+            presenter(repository).test {
+                val state = awaitLoadedBandalart()
+                advanceUntilIdle()
+                expectMostRecentItem()
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(taskCell))
+                updateAttempted.await()
+                yield()
+
+                assertEquals(1, repository.taskCellUpdateCalls)
+                assertNull(repository.taskCellUpdate)
+                assertTrue(state.taskCell(taskCell.id).isCompleted)
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     private fun repositoryWithTasks(
         vararg taskCells: BandalartCellEntity,
         beforeTaskCellUpdate: suspend () -> Unit = {},
+        afterTaskCellUpdate: suspend () -> Unit = {},
+        beforeBandalartLoad: suspend (Long) -> Unit = {},
         taskCellUpdateError: Throwable? = null,
     ): FakeBandalartRepository {
         val mainCell = cell(id = 10L, title = "메인")
@@ -214,6 +429,8 @@ class HomePresenterQuickCompletionTest {
                     subCell.id to taskCells.toList(),
                 ),
             beforeTaskCellUpdate = beforeTaskCellUpdate,
+            afterTaskCellUpdate = afterTaskCellUpdate,
+            beforeBandalartLoad = beforeBandalartLoad,
             taskCellUpdateError = taskCellUpdateError,
         )
     }
@@ -227,9 +444,11 @@ class HomePresenterQuickCompletionTest {
             settingsRepository = FakeSettingsRepository(),
         )
 
-    private suspend fun ReceiveTurbine<HomeScreen.State>.awaitLoadedBandalart(): HomeScreen.State {
+    private suspend fun ReceiveTurbine<HomeScreen.State>.awaitLoadedBandalart(
+        bandalartId: Long = 1L,
+    ): HomeScreen.State {
         var state = awaitItem()
-        while (state.bandalartData?.id != 1L || state.isLoading) {
+        while (state.bandalartData?.id != bandalartId || state.isLoading) {
             state = awaitItem()
         }
         return state
@@ -243,9 +462,9 @@ class HomePresenterQuickCompletionTest {
                 ?.firstOrNull { taskCell -> taskCell.id == cellId },
         )
 
-    private fun bandalart() =
+    private fun bandalart(id: Long = 1L) =
         BandalartEntity(
-            id = 1L,
+            id = id,
             mainColor = "#3FFFBA",
             subColor = "#111827",
             profileEmoji = "🎯",

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterQuickCompletionTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterQuickCompletionTest.kt
@@ -444,9 +444,7 @@ class HomePresenterQuickCompletionTest {
             settingsRepository = FakeSettingsRepository(),
         )
 
-    private suspend fun ReceiveTurbine<HomeScreen.State>.awaitLoadedBandalart(
-        bandalartId: Long = 1L,
-    ): HomeScreen.State {
+    private suspend fun ReceiveTurbine<HomeScreen.State>.awaitLoadedBandalart(bandalartId: Long = 1L,): HomeScreen.State {
         var state = awaitItem()
         while (state.bandalartData?.id != bandalartId || state.isLoading) {
             state = awaitItem()

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
@@ -147,7 +147,7 @@ data object HomeScreen : ParcelableScreen, StaticScreen {
             val cellData: BandalartCellEntity,
         ) : Event
 
-        data class CompleteTask(
+        data class ToggleTaskCompletion(
             val cellData: BandalartCellEntity,
         ) : Event
 

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -105,7 +105,7 @@ class HomePresenter(
         var rewardedRecoveryChecked by rememberRetained { mutableStateOf(false) }
         var effect by remember { mutableStateOf<HomeScreen.Effect?>(null) }
         var requestedCompletionId by remember { mutableStateOf<Long?>(null) }
-        val completingTaskCellIds = remember { mutableSetOf<Long>() }
+        val togglingTaskCellIds = remember { mutableSetOf<Long>() }
         val pendingEffects = remember { ArrayDeque<HomeScreen.Effect>() }
         val themeMode by settingsRepository.themeMode.collectAsState(initial = ThemeMode.SYSTEM)
         val recentEmojis by settingsRepository.recentEmojis.collectAsState(initial = emptyList())
@@ -146,12 +146,10 @@ class HomePresenter(
             effect = pendingEffects.removeFirstOrNull()
         }
 
-        suspend fun loadBandalart(
+        suspend fun readBandalart(
             bandalartId: Long,
             isCompleted: Boolean = false,
-            canCommit: () -> Boolean = { true },
-        ) {
-            isLoading = true
+        ): LoadedBandalart {
             val loadedBandalartData = bandalartRepository.getBandalart(bandalartId).toUiModel()
 
             val mainCell = bandalartRepository.getBandalartMainCell(bandalartId)
@@ -191,13 +189,22 @@ class HomePresenter(
                     parentId = mainCell?.parentId,
                     children = children,
                 )
+            return LoadedBandalart(
+                bandalartData = loadedBandalartData,
+                bandalartCellData = loadedBandalartCellData,
+                isCompleted = isCompleted,
+            )
+        }
+
+        suspend fun loadBandalart(
+            bandalartId: Long,
+            isCompleted: Boolean = false,
+            canCommit: () -> Boolean = { true },
+        ) {
+            isLoading = true
+            val refreshedBandalart = readBandalart(bandalartId, isCompleted)
             if (!canCommit()) return
-            loadedBandalart =
-                LoadedBandalart(
-                    bandalartData = loadedBandalartData,
-                    bandalartCellData = loadedBandalartCellData,
-                    isCompleted = isCompleted,
-                )
+            loadedBandalart = refreshedBandalart
             yield()
             isLoading = false
         }
@@ -517,11 +524,12 @@ class HomePresenter(
             bottomSheet = null
         }
 
-        suspend fun completeTask(requestedCell: BandalartCellEntity) {
+        suspend fun toggleTaskCompletion(requestedCell: BandalartCellEntity) {
             val currentBandalart = bandalartData ?: return
             val currentCell = bandalartCellData?.findTaskCell(requestedCell.id) ?: return
-            if (currentCell.title.isNullOrBlank() || currentCell.isCompleted) return
-            if (!completingTaskCellIds.add(currentCell.id)) return
+            if (currentCell.title.isNullOrBlank()) return
+            if (!togglingTaskCellIds.add(currentCell.id)) return
+            val updatedCompletion = !currentCell.isCompleted
 
             try {
                 runCatching {
@@ -533,22 +541,38 @@ class HomePresenter(
                                 title = currentCell.title,
                                 description = currentCell.description,
                                 dueDate = currentCell.dueDate,
-                                isCompleted = true,
+                                isCompleted = updatedCompletion,
                             ),
                     )
-                }.onSuccess {
-                    val updatedCellData = bandalartCellData.completeTask(currentCell.id)
-                    loadedBandalart =
-                        loadedBandalart?.copy(
-                            bandalartCellData = updatedCellData,
-                        )
-                    emitEffect(HomeScreen.Effect.PlayTaskCompletionHaptic(currentCell.id))
+                    val activeBandalart = loadedBandalart
+                    if (activeBandalart?.bandalartData?.id != currentBandalart.id) {
+                        return@runCatching null
+                    }
+                    readBandalart(
+                        bandalartId = currentBandalart.id,
+                        isCompleted = activeBandalart.isCompleted,
+                    )
+                }.onSuccess { refreshedBandalart ->
+                    if (
+                        refreshedBandalart != null &&
+                        loadedBandalart?.bandalartData?.id == currentBandalart.id
+                    ) {
+                        val refreshedCell = refreshedBandalart.bandalartCellData.findTaskCell(currentCell.id)
+                        loadedBandalart = refreshedBandalart
+                        if (
+                            refreshedCell != null &&
+                            !refreshedCell.title.isNullOrBlank() &&
+                            refreshedCell.isCompleted == updatedCompletion
+                        ) {
+                            emitEffect(HomeScreen.Effect.PlayTaskCompletionHaptic(currentCell.id))
+                        }
+                    }
                 }.onFailure { exception ->
                     if (exception is CancellationException) throw exception
-                    Napier.e("Failed to complete task cell", exception, tag = "HomePresenter")
+                    Napier.e("Failed to toggle task cell completion", exception, tag = "HomePresenter")
                 }
             } finally {
-                completingTaskCellIds.remove(currentCell.id)
+                togglingTaskCellIds.remove(currentCell.id)
             }
         }
 
@@ -779,8 +803,8 @@ class HomePresenter(
                         cellData = event.cellData,
                     )
 
-                is HomeScreen.Event.CompleteTask -> {
-                    scope.launch { completeTask(event.cellData) }
+                is HomeScreen.Event.ToggleTaskCompletion -> {
+                    scope.launch { toggleTaskCompletion(event.cellData) }
                 }
 
                 HomeScreen.Event.OpenBandalartDeleteDialog -> {
@@ -1009,10 +1033,3 @@ private fun BandalartCellEntity.findTaskCell(cellId: Long): BandalartCellEntity?
         .asSequence()
         .flatMap { subCell -> subCell.children.asSequence() }
         .firstOrNull { taskCell -> taskCell.id == cellId }
-
-private fun BandalartCellEntity.completeTask(cellId: Long): BandalartCellEntity =
-    if (id == cellId) {
-        copy(isCompleted = true)
-    } else {
-        copy(children = children.map { child -> child.completeTask(cellId) })
-    }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartCell.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartCell.kt
@@ -43,6 +43,7 @@ import bandalart.core.designsystem.generated.resources.add_description
 import bandalart.core.designsystem.generated.resources.complete_description
 import bandalart.core.designsystem.generated.resources.home_main_cell
 import bandalart.core.designsystem.generated.resources.home_complete_task_long_click
+import bandalart.core.designsystem.generated.resources.home_uncomplete_task_long_click
 import bandalart.core.designsystem.generated.resources.home_sub_cell
 import bandalart.core.designsystem.generated.resources.ic_cell_check
 import com.nexters.bandalart.core.common.extension.toColor
@@ -88,16 +89,21 @@ fun BandalartCell(
     val onLongClick =
         if (
             cellType == CellType.TASK &&
-            !cellData.title.isNullOrBlank() &&
-            !cellData.isCompleted
+            !cellData.title.isNullOrBlank()
         ) {
-            { onHomeUiAction(HomeScreen.Event.CompleteTask(cellData)) }
+            { onHomeUiAction(HomeScreen.Event.ToggleTaskCompletion(cellData)) }
         } else {
             null
         }
     val onLongClickLabel =
         if (onLongClick != null) {
-            stringResource(Res.string.home_complete_task_long_click)
+            stringResource(
+                if (cellData.isCompleted) {
+                    Res.string.home_uncomplete_task_long_click
+                } else {
+                    Res.string.home_complete_task_long_click
+                },
+            )
         } else {
             null
         }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 미완료 TASK 셀 롱클릭은 완료, 완료된 TASK 셀 롱클릭은 완료 해제로 동작하도록 토글했습니다.
- 저장 완료 뒤 authoritative repository snapshot을 다시 읽어 부모 완료 상태와 현재 선택을 보존합니다.
- 교차 보드, 삭제, Room 갱신, read 실패 및 중복 요청 race 회귀 테스트를 추가했습니다.
- ko/en/ja 접근성 롱클릭 설명을 완료 상태에 맞게 제공합니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 완료 토글 | Internal 확인 예정 | 접근성 | ko/en/ja 적용 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- QuickCompletion 10/10, HomePresenter 48/48, Home Detekt와 git diff --check를 통과했습니다.
- 빈 셀과 MAIN/SUB 셀은 기존처럼 빠른 완료 대상이 아닙니다.