### PR TITLE
fix: 홈 공유 버튼 배너 간격 조정

### DIFF
--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
@@ -344,7 +344,7 @@ internal fun HomeContent(
                                         ),
                             )
                         }
-                        Spacer(modifier = Modifier.height(64.dp))
+                        Spacer(modifier = Modifier.height(16.dp))
                     }
                     Spacer(modifier = Modifier.weight(1f))
                     HomeShareButton(


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #206

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 표와 공유 버튼 사이의 비필수 간격을 64dp에서 16dp로 줄였습니다.
- 320×50 홈 배너가 있는 일반 화면에서는 공유 버튼이 더 위에 보이고, 작은 화면은 기존 스크롤을 유지합니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 일반 화면 | Internal Testing에서 확인 예정 | 작은 화면 스크롤 | Internal Testing에서 확인 예정 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 배너 sibling, 하단 32dp 안전 여백, Snackbar와 접근성 semantics는 변경하지 않았습니다.
