### PR TITLE
fix: 광고 안내 팝업 추가 아이콘 개선

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -12,10 +12,10 @@ The generated WebP comparison assets under `tools/fluent-emoji/generated/color/`
 ## Google Material Symbols
 
 - Source: `https://fonts.gstatic.com/s/i/short-term/release/materialsymbolsoutlined/{icon}/default/24px.svg`
-- Retrieved: 2026-08-09
-- Icons: `apps`, `history`, `sentiment_satisfied`, `groups`, `pets`, `restaurant`, `flight`, `sports_soccer`, `lightbulb`, `tag`, `outlined_flag`
+- Retrieved: 2026-08-09 (category navigation icons); 2026-08-10 (`add_circle`)
+- Icons: `apps`, `history`, `sentiment_satisfied`, `groups`, `pets`, `restaurant`, `flight`, `sports_soccer`, `lightbulb`, `tag`, `outlined_flag`, `add_circle`
 - License: Apache License 2.0 ([local license text](licenses/Apache-2.0.txt))
 - Licensing reference: [Google Fonts — Material Icons licensing](https://developers.google.com/fonts/docs/material_icons#licensing)
 - Copyright: Google LLC
 
-The category navigation vectors under `core/designsystem/src/commonMain/composeResources/drawable/emoji_category_nav_*.xml` are adapted from the listed 24px Material Symbols Outlined SVG paths. The SVG view box origin is represented with an equivalent vector group translation; the icon geometry is otherwise unchanged. The application does not download Material Symbols resources at runtime.
+The category navigation vectors under `core/designsystem/src/commonMain/composeResources/drawable/emoji_category_nav_*.xml` and the rewarded-create dialog vector `core/designsystem/src/commonMain/composeResources/drawable/ic_add_circle_outlined.xml` are adapted from the listed 24px Material Symbols Outlined SVG paths. The SVG view box origin is represented with an equivalent vector group translation; the icon geometry is otherwise unchanged. The application does not download Material Symbols resources at runtime.

--- a/core/designsystem/src/commonMain/composeResources/drawable/ic_add_circle_outlined.xml
+++ b/core/designsystem/src/commonMain/composeResources/drawable/ic_add_circle_outlined.xml
@@ -1,0 +1,15 @@
+<!--
+  Adapted from the Google Material Symbol "add_circle" 24px Outlined SVG to Android/Compose vector XML.
+  Copyright Google LLC. Licensed under the Apache License 2.0.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <group android:translateY="960">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M440,-280h80v-160h160v-80H520v-160h-80v160H280v80h160v160Zm40,200q-83,0 -156,-31.5T197,-197q-54,-54 -85.5,-127T80,-480q0,-83 31.5,-156T197,-763q54,-54 127,-85.5T480,-880q83,0 156,31.5T763,-763q54,54 85.5,127T880,-480q0,83 -31.5,156T763,-197q-54,54 -127,85.5T480,-80Zm0,-80q134,0 227,-93t93,-227q0,-134 -93,-227t-227,-93q-134,0 -227,93t-93,227q0,134 93,227t227,93Zm0,-320Z" />
+  </group>
+</vector>

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/RewardedBandalartAlertDialog.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/RewardedBandalartAlertDialog.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
@@ -41,7 +42,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import bandalart.core.designsystem.generated.resources.Res
 import bandalart.core.designsystem.generated.resources.add_description
-import bandalart.core.designsystem.generated.resources.ic_add
+import bandalart.core.designsystem.generated.resources.ic_add_circle_outlined
 import bandalart.core.designsystem.generated.resources.rewarded_create_dialog_cancel
 import bandalart.core.designsystem.generated.resources.rewarded_create_dialog_confirm
 import bandalart.core.designsystem.generated.resources.rewarded_create_dialog_message
@@ -67,11 +68,11 @@ fun RewardedBandalartAlertDialog(
                         .padding(top = 24.dp),
             ) {
                 Icon(
-                    imageVector = vectorResource(Res.drawable.ic_add),
+                    imageVector = vectorResource(Res.drawable.ic_add_circle_outlined),
                     contentDescription = stringResource(Res.string.add_description),
                     modifier =
                         Modifier
-                            .height(28.dp)
+                            .size(28.dp)
                             .align(Alignment.CenterHorizontally),
                     tint = MaterialTheme.colorScheme.primary,
                 )


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #206

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 광고 안내 팝업 상단 아이콘을 원형 테두리가 있는 Material Symbols `add_circle`로 교체했습니다.
- Android/iOS 공통 Compose vector와 Apache-2.0 출처 고지를 추가했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 광고 안내 아이콘 | Internal Testing에서 확인 예정 | iOS 공통 리소스 | TestFlight에서 확인 예정 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 기존 28dp 크기, primary tint, 접근성 설명과 다이얼로그 배치는 유지했습니다.
