### PR TITLE
feat: iOS 마감 알림 기능 구현

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -134,7 +134,7 @@ jobs:
                 run: ./gradlew :androidApp:lintDebug :androidApp:assembleDebug --stacktrace
 
     ios:
-        name: iOS framework build
+        name: iOS host app build
         runs-on: macos-latest
         timeout-minutes: 30
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
@@ -168,8 +168,26 @@ jobs:
                     printf 'KEY_ALIAS=%s\n' "$KEY_ALIAS" >> keystore.properties
                     printf 'KEY_PASSWORD=%s\n' "$KEY_PASSWORD" >> keystore.properties
 
-            -   name: Run iOS framework build
-                run: ./gradlew :composeApp:linkDebugFrameworkIosSimulatorArm64 --stacktrace
+            -   name: Build iOS host app
+                run: |
+                    xcodebuild \
+                        -project iosApp/iosApp.xcodeproj \
+                        -scheme iosApp \
+                        -configuration Debug \
+                        -sdk iphonesimulator \
+                        -destination 'generic/platform=iOS Simulator' \
+                        -derivedDataPath "$RUNNER_TEMP/bandalart-derived-data" \
+                        ARCHS=arm64 \
+                        CODE_SIGNING_ALLOWED=NO \
+                        build
+
+            -   name: Verify notification localizations
+                run: |
+                    APP_BUNDLE="$RUNNER_TEMP/bandalart-derived-data/Build/Products/Debug-iphonesimulator/iosApp.app"
+                    test -d "$APP_BUNDLE"
+                    for locale in en ja ko; do
+                        test -f "$APP_BUNDLE/$locale.lproj/Localizable.strings"
+                    done
 
     release_cd:
         name: Release CD validation

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/MainViewController.kt
@@ -18,11 +18,13 @@ package com.nexters.bandalart
 
 import androidx.compose.ui.window.ComposeUIViewController
 import com.nexters.bandalart.di.metro.createIosAppGraph
+import com.nexters.bandalart.notification.DeadlineNotificationLaunchBridge
 import platform.UIKit.UIViewController
 
 @Suppress("FunctionName")
-fun MainViewController(): UIViewController {
+fun MainViewController(notificationLaunchBridge: DeadlineNotificationLaunchBridge): UIViewController {
     val appGraph = createIosAppGraph()
+    notificationLaunchBridge.attach(appGraph.deadlineNotificationLaunchTarget)
 
     return ComposeUIViewController {
         BandalartApp(appGraph = appGraph)

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/di/metro/IosAppGraph.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/di/metro/IosAppGraph.kt
@@ -23,8 +23,8 @@ import com.nexters.bandalart.core.common.NoOpBannerAdHost
 import com.nexters.bandalart.core.common.NoOpRewardedAdGateway
 import com.nexters.bandalart.core.database.BandalartDatabaseFactory
 import com.nexters.bandalart.core.datastore.BandalartDataStoreFactory
-import com.nexters.bandalart.core.domain.notification.NoOpDeadlineNotificationAuthorization
-import com.nexters.bandalart.core.domain.notification.NoOpDeadlineReminderScheduler
+import com.nexters.bandalart.notification.IosDeadlineNotificationAuthorization
+import com.nexters.bandalart.notification.IosDeadlineReminderScheduler
 
 private object IosPlatformBindings : PlatformBindings {
     override val databaseFactory = BandalartDatabaseFactory()
@@ -34,8 +34,8 @@ private object IosPlatformBindings : PlatformBindings {
     override val imageHandlerProvider = ImageHandlerProvider()
     override val supportMailLauncher = IosSupportMailLauncher()
     override val rewardedAdGateway = NoOpRewardedAdGateway
-    override val deadlineReminderScheduler = NoOpDeadlineReminderScheduler
-    override val deadlineNotificationAuthorization = NoOpDeadlineNotificationAuthorization
+    override val deadlineReminderScheduler = IosDeadlineReminderScheduler()
+    override val deadlineNotificationAuthorization = IosDeadlineNotificationAuthorization()
 }
 
 internal fun createIosAppGraph(): AppGraph = createAppGraph(IosPlatformBindings)

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/notification/DeadlineNotificationLaunchBridge.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/notification/DeadlineNotificationLaunchBridge.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.notification
+
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationLaunchTarget
+
+class DeadlineNotificationLaunchBridge {
+    private var launchTarget: DeadlineNotificationLaunchTarget? = null
+    private var bufferedBandalartId: Long? = null
+
+    fun record(bandalartId: Long) {
+        if (bandalartId <= 0L) return
+        val target = launchTarget
+        if (target == null) {
+            bufferedBandalartId = bandalartId
+        } else {
+            target.record(bandalartId)
+        }
+    }
+
+    internal fun attach(target: DeadlineNotificationLaunchTarget) {
+        launchTarget = target
+        bufferedBandalartId?.let(target::record)
+        bufferedBandalartId = null
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/notification/IosDeadlineNotificationAuthorization.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/notification/IosDeadlineNotificationAuthorization.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.notification
+
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorization
+import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorizationStatus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationOpenNotificationSettingsURLString
+import platform.UserNotifications.UNAuthorizationOptionAlert
+import platform.UserNotifications.UNAuthorizationOptionSound
+import platform.UserNotifications.UNAuthorizationStatusAuthorized
+import platform.UserNotifications.UNAuthorizationStatusDenied
+import platform.UserNotifications.UNAuthorizationStatusEphemeral
+import platform.UserNotifications.UNAuthorizationStatusNotDetermined
+import platform.UserNotifications.UNAuthorizationStatusProvisional
+import platform.UserNotifications.UNNotificationSettingEnabled
+import platform.UserNotifications.UNNotificationSettings
+import platform.UserNotifications.UNUserNotificationCenter
+
+class IosDeadlineNotificationAuthorization(
+    private val notificationCenter: UNUserNotificationCenter = UNUserNotificationCenter.currentNotificationCenter(),
+) : DeadlineNotificationAuthorization {
+    override suspend fun getStatus(): DeadlineNotificationAuthorizationStatus = notificationCenter.settings().toStatus()
+
+    override suspend fun requestAuthorization(): DeadlineNotificationAuthorizationStatus {
+        awaitUserNotificationCallback<Unit> { resume ->
+            notificationCenter.requestAuthorizationWithOptions(
+                options = UNAuthorizationOptionAlert or UNAuthorizationOptionSound,
+            ) { _, _ ->
+                resume(Unit)
+            }
+        }
+        return getStatus()
+    }
+
+    override suspend fun openSettings() {
+        withContext(Dispatchers.Main.immediate) {
+            val url = NSURL.URLWithString(UIApplicationOpenNotificationSettingsURLString) ?: return@withContext
+            UIApplication.sharedApplication.openURL(
+                url = url,
+                options = emptyMap<Any?, Any?>(),
+                completionHandler = null,
+            )
+        }
+    }
+}
+
+private suspend fun UNUserNotificationCenter.settings(): UNNotificationSettings =
+    checkNotNull(
+        awaitUserNotificationCallback<UNNotificationSettings?> { resume ->
+            getNotificationSettingsWithCompletionHandler(resume)
+        },
+    )
+
+private fun UNNotificationSettings.toStatus(): DeadlineNotificationAuthorizationStatus =
+    when (authorizationStatus) {
+        UNAuthorizationStatusNotDetermined -> DeadlineNotificationAuthorizationStatus.REQUESTABLE
+        UNAuthorizationStatusDenied -> DeadlineNotificationAuthorizationStatus.BLOCKED
+        UNAuthorizationStatusProvisional,
+        UNAuthorizationStatusEphemeral,
+        -> DeadlineNotificationAuthorizationStatus.QUIET
+        UNAuthorizationStatusAuthorized ->
+            if (alertSetting == UNNotificationSettingEnabled) {
+                DeadlineNotificationAuthorizationStatus.GRANTED
+            } else {
+                DeadlineNotificationAuthorizationStatus.QUIET
+            }
+        else -> DeadlineNotificationAuthorizationStatus.BLOCKED
+    }

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/notification/IosDeadlineReminderScheduler.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/notification/IosDeadlineReminderScheduler.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.notification
+
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderBatch
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderScheduler
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingErrorCategory
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingResult
+import kotlinx.datetime.number
+import platform.Foundation.NSBundle
+import platform.Foundation.NSCalendar
+import platform.Foundation.NSCalendarIdentifierGregorian
+import platform.Foundation.NSDateComponents
+import platform.Foundation.NSError
+import platform.Foundation.NSTimeZone
+import platform.Foundation.localTimeZone
+import platform.Foundation.timeIntervalSinceNow
+import platform.UserNotifications.UNCalendarNotificationTrigger
+import platform.UserNotifications.UNErrorCodeNotificationInvalidNoContent
+import platform.UserNotifications.UNErrorCodeNotificationInvalidNoDate
+import platform.UserNotifications.UNErrorCodeNotificationsNotAllowed
+import platform.UserNotifications.UNErrorDomain
+import platform.UserNotifications.UNMutableNotificationContent
+import platform.UserNotifications.UNNotification
+import platform.UserNotifications.UNNotificationRequest
+import platform.UserNotifications.UNNotificationSound
+import platform.UserNotifications.UNUserNotificationCenter
+
+class IosDeadlineReminderScheduler(
+    private val notificationCenter: UNUserNotificationCenter = UNUserNotificationCenter.currentNotificationCenter(),
+) : DeadlineReminderScheduler {
+    override suspend fun replaceAll(batches: List<DeadlineReminderBatch>): DeadlineReminderSchedulingResult {
+        clearFeatureNotifications()
+        var scheduledCount = 0
+        batches.forEach { batch ->
+            val request =
+                batch.toNotificationRequest()
+                    ?: return DeadlineReminderSchedulingResult(
+                        scheduledCount = scheduledCount,
+                        lastErrorCategory = DeadlineReminderSchedulingErrorCategory.SCHEDULING,
+                    )
+            val error = notificationCenter.add(request)
+            if (error != null) {
+                return DeadlineReminderSchedulingResult(
+                    scheduledCount = scheduledCount,
+                    lastErrorCategory = error.toSchedulingErrorCategory(),
+                )
+            }
+            scheduledCount += 1
+        }
+        return DeadlineReminderSchedulingResult(scheduledCount = scheduledCount)
+    }
+
+    override suspend fun clearAll(): DeadlineReminderSchedulingResult {
+        clearFeatureNotifications()
+        return DeadlineReminderSchedulingResult(scheduledCount = 0)
+    }
+
+    private suspend fun clearFeatureNotifications() {
+        val pendingIdentifiers =
+            notificationCenter
+                .pendingRequests()
+                .map { request -> request.identifier() }
+                .filter(::isDeadlineReminderIdentifier)
+        if (pendingIdentifiers.isNotEmpty()) {
+            notificationCenter.removePendingNotificationRequestsWithIdentifiers(pendingIdentifiers)
+        }
+        val deliveredIdentifiers =
+            notificationCenter
+                .deliveredNotifications()
+                .map { notification -> notification.request.identifier }
+                .filter(::isDeadlineReminderIdentifier)
+        if (deliveredIdentifiers.isNotEmpty()) {
+            notificationCenter.removeDeliveredNotificationsWithIdentifiers(deliveredIdentifiers)
+        }
+    }
+}
+
+private fun DeadlineReminderBatch.toNotificationRequest(): UNNotificationRequest? {
+    // NSTimeZone.localTimeZone is Foundation's auto-updating local-time-zone proxy.
+    val autoupdatingTimeZone = NSTimeZone.localTimeZone()
+    val calendar = NSCalendar(calendarIdentifier = NSCalendarIdentifierGregorian)
+    calendar.timeZone = autoupdatingTimeZone
+    val components =
+        NSDateComponents().apply {
+            this.calendar = calendar
+            timeZone = autoupdatingTimeZone
+            year = dueDate.year.toLong()
+            month = dueDate.month.number.toLong()
+            day = dueDate.day.toLong()
+            hour = DEADLINE_REMINDER_HOUR
+            minute = 0
+            second = 0
+        }
+    val trigger = UNCalendarNotificationTrigger.triggerWithDateMatchingComponents(components, repeats = false)
+    val nextTriggerDate = trigger.nextTriggerDate() ?: return null
+    if (nextTriggerDate.timeIntervalSinceNow() <= 0.0) return null
+
+    val content =
+        UNMutableNotificationContent().apply {
+            setTitle(localized(DEADLINE_REMINDER_TITLE_KEY))
+            setBody(
+                if (items.size == 1) {
+                    localized(DEADLINE_REMINDER_SINGLE_BODY_KEY).replace("%@", items.single().title)
+                } else {
+                    localized(DEADLINE_REMINDER_MULTIPLE_BODY_KEY).replace("%ld", items.size.toString())
+                },
+            )
+            setSound(UNNotificationSound.defaultSound)
+            setUserInfo(mapOf(DEADLINE_BANDALART_ID_KEY to bandalartId.toString()))
+        }
+    return UNNotificationRequest.requestWithIdentifier(id, content, trigger)
+}
+
+private suspend fun UNUserNotificationCenter.pendingRequests(): List<UNNotificationRequest> =
+    awaitUserNotificationCallback<List<*>?> { resume ->
+        getPendingNotificationRequestsWithCompletionHandler(resume)
+    }.orEmpty().filterIsInstance<UNNotificationRequest>()
+
+private suspend fun UNUserNotificationCenter.deliveredNotifications(): List<UNNotification> =
+    awaitUserNotificationCallback<List<*>?> { resume ->
+        getDeliveredNotificationsWithCompletionHandler(resume)
+    }.orEmpty().filterIsInstance<UNNotification>()
+
+private suspend fun UNUserNotificationCenter.add(request: UNNotificationRequest): NSError? =
+    awaitUserNotificationCallback { resume ->
+        addNotificationRequest(request, resume)
+    }
+
+private fun NSError.toSchedulingErrorCategory(): DeadlineReminderSchedulingErrorCategory {
+    if (domain != UNErrorDomain) return DeadlineReminderSchedulingErrorCategory.UNKNOWN
+    return when (code) {
+        UNErrorCodeNotificationsNotAllowed -> DeadlineReminderSchedulingErrorCategory.AUTHORIZATION
+        UNErrorCodeNotificationInvalidNoDate,
+        UNErrorCodeNotificationInvalidNoContent,
+        -> DeadlineReminderSchedulingErrorCategory.SCHEDULING
+        else -> DeadlineReminderSchedulingErrorCategory.UNKNOWN
+    }
+}
+
+private fun localized(key: String): String = NSBundle.mainBundle.localizedStringForKey(key, value = null, table = null)
+
+private fun isDeadlineReminderIdentifier(identifier: String): Boolean = identifier.startsWith(DEADLINE_REMINDER_IDENTIFIER_PREFIX)
+
+internal const val DEADLINE_BANDALART_ID_KEY = "deadline_bandalart_id"
+private const val DEADLINE_REMINDER_IDENTIFIER_PREFIX = "deadline.v1."
+private const val DEADLINE_REMINDER_HOUR = 9L
+private const val DEADLINE_REMINDER_TITLE_KEY = "deadline_reminder_title"
+private const val DEADLINE_REMINDER_SINGLE_BODY_KEY = "deadline_reminder_single_body"
+private const val DEADLINE_REMINDER_MULTIPLE_BODY_KEY = "deadline_reminder_multiple_body"

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/notification/UserNotificationCoroutineBridge.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/notification/UserNotificationCoroutineBridge.kt
@@ -14,17 +14,14 @@
  * limitations under the License.
  */
 
-package com.nexters.bandalart.feature.home
+package com.nexters.bandalart.notification
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import kotlinx.coroutines.suspendCancellableCoroutine
 
-@Composable
-internal actual fun DeadlineReminderPermissionEffect(
-    requestId: Long?,
-    onResult: () -> Unit,
-) {
-    LaunchedEffect(requestId) {
-        if (requestId != null) onResult()
+internal suspend fun <T> awaitUserNotificationCallback(register: (resume: (T) -> Unit) -> Unit): T =
+    suspendCancellableCoroutine { continuation ->
+        register { value ->
+            // UserNotifications completion handlers are single-shot and expose no cancellation handle.
+            continuation.resume(value) { _, _, _ -> }
+        }
     }
-}

--- a/docs/features/notifications/LOCAL_DEADLINE_NOTIFICATION_STRATEGY.md
+++ b/docs/features/notifications/LOCAL_DEADLINE_NOTIFICATION_STRATEGY.md
@@ -7,7 +7,7 @@
 
 ## 현재 진행률 체크리스트
 
-2026-08-09 기준 로컬 구현, `main` 병합, 실제 스토어 출하를 분리해 기록한다. Android 구현은 PR #249~#251로 `main`에 병합됐지만 아직 Android Internal 설치본에는 포함되지 않았다. iOS 구현과 TestFlight 검증도 아직이다.
+2026-08-10 기준 로컬 구현, `main` 병합, 실제 스토어 출하를 분리해 기록한다. Android 구현은 PR #249~#251로 `main`에 병합됐지만 아직 Android Internal 설치본에는 포함되지 않았다. iOS vertical slice는 별도 worktree에서 로컬 구현·Kotlin/Native compile과 Presenter host test까지 완료했으며 아직 commit·PR·TestFlight 검증 전이다.
 
 ### PR #249 — 조사·전략
 
@@ -33,13 +33,13 @@
 
 ### 예정 PR 4 — iOS vertical slice
 
-- [ ] UserNotifications scheduler·authorization adapter를 구현한다.
-- [ ] AppDelegate delegate, launch-target bridge와 pending/delivered reconcile을 구현·검증한다.
+- [x] UserNotifications scheduler·authorization adapter를 로컬 구현하고 Kotlin/Native iOS simulator compile을 통과시켰다.
+- [x] AppDelegate delegate, graph 이전 buffered launch-target bridge, pending/delivered namespace reconcile과 foreground/time-change 신호를 로컬 구현했다. Swift 포함 Xcode build는 Firebase SPM artifact 압축 해제 중 디스크 부족으로 source compile 전에 중단됐다.
 - [ ] TestFlight 설치본에서 실제 권한과 전달을 검증한다.
 
 ### 예정 PR 5 — 공통 UX 마무리·배포 검증
 
-- [ ] iOS 권한 연동 후 공통 설정 노출과 명시적 마감일 삭제 UX를 마무리한다.
+- [ ] 로컬 구현된 iOS 권한·공통 설정 노출을 설치본에서 검증하고 명시적 마감일 삭제 UX를 마무리한다.
 - [ ] 한국어·영어·일본어 문구와 접근성을 검증한다.
 - [ ] Android Internal과 iOS TestFlight의 전체 acceptance checklist를 완료한다.
 - [ ] #211 완료 조건 확인 뒤 umbrella issue를 닫는다.
@@ -244,7 +244,7 @@ DataStore의 `deadlineReminderEnabled`는 사용자의 의사이며 OS authoriza
 - Swift AppDelegate delegate와 KMP launch-target bridge
 - pending/delivered replace/cancel, foreground/time-change reconcile
 - iOS compile과 scheduler/delegate bridge 계약 검증. 실제 permission prompt와 전달 수동 검증은 PR 5로 미룸
-- 공통 설정 toggle은 아직 노출하지 않음
+- 공통 설정 toggle은 실제 iOS authorization adapter 상태를 사용해 노출하고, 실제 permission prompt/settings 복귀는 설치본에서 검증
 
 ### PR 5 — UX 활성화와 배포 검증
 
@@ -298,7 +298,7 @@ DataStore의 `deadlineReminderEnabled`는 사용자의 의사이며 OS authoriza
 
 ## 11. 출시·관측
 
-- Android는 vertical slice가 사용 가능한 상태로 검증되면 Android에서만 설정 toggle을 노출한다. iOS는 `Unsupported`를 유지해 거짓 기능을 노출하지 않는다.
+- 각 플랫폼은 실제 scheduler·authorization adapter가 연결된 뒤에만 공통 설정 toggle을 노출한다. Android는 `main`에 연결됐고 iOS는 로컬 vertical slice에서 `Unsupported`를 실제 상태로 교체했지만, iOS 설정 동선은 TestFlight 검증 전이다.
 - Android Internal과 iOS TestFlight에서 알림 권한과 실제 전달을 각각 검증한 뒤 활성화한다.
 - scheduler/reconcile 실패는 개인정보가 없는 batch ID, platform status, error category만 기록한다. 목표 제목과 설명은 로그에 남기지 않는다.
 - 알림 content에는 목표 제목 또는 집계 count만 사용하고 description, 완료 이력은 포함하지 않는다.

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterDeadlineReminderTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterDeadlineReminderTest.kt
@@ -308,6 +308,39 @@ class HomePresenterDeadlineReminderTest {
         }
 
     @Test
+    fun requestableAuthorizationThatBecomesQuietEnablesAndReconcilesWithoutPlatformEffect() =
+        runTest {
+            val settings = FakeSettingsRepository()
+            val authorization =
+                FakeAuthorization(
+                    status = DeadlineNotificationAuthorizationStatus.REQUESTABLE,
+                    requestedStatus = DeadlineNotificationAuthorizationStatus.QUIET,
+                )
+            val reconciler = RecordingReconciler()
+            val presenter =
+                presenter(
+                    repository = repository(),
+                    settings = settings,
+                    authorization = authorization,
+                    reconciler = reconciler,
+                )
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData == null || state.isLoading) state = awaitItem()
+                state.eventSink(HomeScreen.Event.OpenSettings)
+                state.eventSink(HomeScreen.Event.ConfirmDeadlineReminderPermission)
+                while (!state.deadlineReminderEnabled) state = awaitItem()
+
+                assertEquals(1, authorization.requestCalls)
+                assertEquals(DeadlineNotificationAuthorizationStatus.QUIET, state.deadlineNotificationAuthorizationStatus)
+                assertEquals(null, state.deadlinePermissionRequestId)
+                assertTrue(reconciler.reconcileCalls > 0)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun blockedEnabledReminderCanBeTurnedOff() =
         runTest {
             val settings = FakeSettingsRepository(initialDeadlineReminderEnabled = true)
@@ -412,10 +445,17 @@ class HomePresenterDeadlineReminderTest {
 
     private class FakeAuthorization(
         var status: DeadlineNotificationAuthorizationStatus,
+        private val requestedStatus: DeadlineNotificationAuthorizationStatus = status,
     ) : DeadlineNotificationAuthorization {
+        var requestCalls = 0
+
         override suspend fun getStatus() = status
 
-        override suspend fun requestAuthorization() = status
+        override suspend fun requestAuthorization(): DeadlineNotificationAuthorizationStatus {
+            requestCalls += 1
+            status = requestedStatus
+            return status
+        }
 
         override suspend fun openSettings() = Unit
     }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -921,8 +921,28 @@ class HomePresenter(
                             }
 
                             DeadlineNotificationAuthorizationStatus.REQUESTABLE -> {
-                                nextDeadlinePermissionRequestId += 1
-                                deadlinePermissionRequestId = nextDeadlinePermissionRequestId
+                                deadlineNotificationAuthorizationStatus =
+                                    deadlineNotificationAuthorization.requestAuthorization()
+                                when (deadlineNotificationAuthorizationStatus) {
+                                    DeadlineNotificationAuthorizationStatus.GRANTED,
+                                    DeadlineNotificationAuthorizationStatus.QUIET,
+                                    -> {
+                                        settingsRepository.setDeadlineReminderEnabled(true)
+                                        deadlineReminderReconciler.reconcileAll()
+                                    }
+
+                                    DeadlineNotificationAuthorizationStatus.REQUESTABLE -> {
+                                        nextDeadlinePermissionRequestId += 1
+                                        deadlinePermissionRequestId = nextDeadlinePermissionRequestId
+                                    }
+
+                                    DeadlineNotificationAuthorizationStatus.BLOCKED -> {
+                                        settingsRepository.setDeadlineReminderEnabled(false)
+                                        deadlineReminderReconciler.reconcileAll()
+                                    }
+
+                                    DeadlineNotificationAuthorizationStatus.UNSUPPORTED -> Unit
+                                }
                             }
 
                             DeadlineNotificationAuthorizationStatus.BLOCKED -> {

--- a/feature/home/src/iosMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderForegroundEffect.ios.kt
+++ b/feature/home/src/iosMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderForegroundEffect.ios.kt
@@ -17,6 +17,41 @@
 package com.nexters.bandalart.feature.home
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberUpdatedState
+import platform.Foundation.NSNotificationCenter
+import platform.Foundation.NSOperationQueue
+import platform.Foundation.NSSystemTimeZoneDidChangeNotification
+import platform.UIKit.UIApplicationDidBecomeActiveNotification
+import platform.UIKit.UIApplicationSignificantTimeChangeNotification
 
 @Composable
-internal actual fun DeadlineReminderForegroundEffect(onForeground: () -> Unit) = Unit
+internal actual fun DeadlineReminderForegroundEffect(onForeground: () -> Unit) {
+    val currentOnForeground = rememberUpdatedState(onForeground)
+    LaunchedEffect(Unit) {
+        currentOnForeground.value()
+    }
+    DisposableEffect(Unit) {
+        val center = NSNotificationCenter.defaultCenter
+        val names =
+            listOf(
+                UIApplicationDidBecomeActiveNotification,
+                UIApplicationSignificantTimeChangeNotification,
+                NSSystemTimeZoneDidChangeNotification,
+            )
+        val observers =
+            names.map { name ->
+                center.addObserverForName(
+                    name = name,
+                    `object` = null,
+                    queue = NSOperationQueue.mainQueue,
+                ) {
+                    currentOnForeground.value()
+                }
+            }
+        onDispose {
+            observers.forEach(center::removeObserver)
+        }
+    }
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -10,16 +10,20 @@ import SwiftUI
 import ComposeApp
 
 struct ComposeView: UIViewControllerRepresentable {
+    let notificationLaunchBridge: DeadlineNotificationLaunchBridge
+
     func makeUIViewController(context: Context) -> UIViewController {
-        MainViewControllerKt.MainViewController()
+        MainViewControllerKt.MainViewController(notificationLaunchBridge: notificationLaunchBridge)
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
 }
 
 struct ContentView: View {
+    let notificationLaunchBridge: DeadlineNotificationLaunchBridge
+
     var body: some View {
-        ComposeView()
+        ComposeView(notificationLaunchBridge: notificationLaunchBridge)
                 .ignoresSafeArea(edges: .all)
                 .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
     }

--- a/iosApp/iosApp/en.lproj/Localizable.strings
+++ b/iosApp/iosApp/en.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"deadline_reminder_title" = "You have goals due today";
+"deadline_reminder_single_body" = "Time to complete %@.";
+"deadline_reminder_multiple_body" = "%ld goals are due today.";

--- a/iosApp/iosApp/iosApp.swift
+++ b/iosApp/iosApp/iosApp.swift
@@ -9,14 +9,62 @@ import SwiftUI
 import UIKit
 import ComposeApp
 import Firebase
+import UserNotifications
 
-private final class AppDelegate: NSObject, UIApplicationDelegate {
+private let deadlineReminderIdentifierPrefix = "deadline.v1."
+private let deadlineBandalartIdKey = "deadline_bandalart_id"
+
+final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+    let notificationLaunchBridge = DeadlineNotificationLaunchBridge()
+
     func application(
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         FirebaseApp.configure()
+        UNUserNotificationCenter.current().delegate = self
         return true
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        guard notification.request.identifier.hasPrefix(deadlineReminderIdentifierPrefix) else {
+            completionHandler([])
+            return
+        }
+        completionHandler([.banner, .list, .sound])
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        defer { completionHandler() }
+
+        let request = response.notification.request
+        guard response.actionIdentifier == UNNotificationDefaultActionIdentifier,
+              request.identifier.hasPrefix(deadlineReminderIdentifierPrefix) else {
+            return
+        }
+
+        let value = request.content.userInfo[deadlineBandalartIdKey]
+        let bandalartId: Int64?
+        if let stringValue = value as? String {
+            bandalartId = Int64(stringValue)
+        } else if let numberValue = value as? NSNumber {
+            bandalartId = numberValue.int64Value
+        } else {
+            bandalartId = nil
+        }
+        if let bandalartId, bandalartId > 0 {
+            DispatchQueue.main.async { [notificationLaunchBridge] in
+                notificationLaunchBridge.record(bandalartId: bandalartId)
+            }
+        }
     }
 }
 
@@ -26,7 +74,7 @@ struct iosApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(notificationLaunchBridge: appDelegate.notificationLaunchBridge)
         }
     }
 }

--- a/iosApp/iosApp/ja.lproj/Localizable.strings
+++ b/iosApp/iosApp/ja.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"deadline_reminder_title" = "今日が締め切りの目標があります";
+"deadline_reminder_single_body" = "%@を完了する時間です。";
+"deadline_reminder_multiple_body" = "%ld個の目標が今日締切です。";

--- a/iosApp/iosApp/ko.lproj/Localizable.strings
+++ b/iosApp/iosApp/ko.lproj/Localizable.strings
@@ -1,0 +1,3 @@
+"deadline_reminder_title" = "오늘 마감인 목표가 있어요";
+"deadline_reminder_single_body" = "%@을(를) 완료할 시간이에요.";
+"deadline_reminder_multiple_body" = "%ld개의 목표가 오늘 마감이에요.";


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #211

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- iOS UserNotifications 기반 마감 알림 예약·취소와 권한 상태를 구현했습니다.
- 앱 시작 전 알림 탭을 버퍼링해 해당 반다라트를 정확히 여는 경로를 연결했습니다.
- foreground·시간대 변경 재조정과 한국어·영어·일본어 알림 문구를 추가했습니다.
- iOS host app과 로컬라이즈 리소스를 검증하도록 CI를 강화했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| iOS 알림 설정 | TestFlight에서 확인 예정 | 알림 탭 이동 | TestFlight에서 확인 예정 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- `deadline.v1.*` namespace만 정리해 다른 알림에 영향을 주지 않습니다.
- 로컬 전체 Xcode host build는 디스크 제약으로 완료하지 못했으며 PR CI에서 unsigned host build와 번들 리소스를 최종 검증합니다.
