### PR TITLE
feat: 반다라트 템플릿 catalog 추가

### DIFF
--- a/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/repository/BandalartRepositoryTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/repository/BandalartRepositoryTest.kt
@@ -22,11 +22,15 @@ import com.nexters.bandalart.core.database.BandalartDao
 import com.nexters.bandalart.core.database.entity.BandalartCellDBEntity
 import com.nexters.bandalart.core.database.entity.BandalartCellWithChildrenDto
 import com.nexters.bandalart.core.database.entity.BandalartDBEntity
+import com.nexters.bandalart.core.database.entity.CreateBandalartDto
+import com.nexters.bandalart.core.database.entity.CreateBandalartSubGoalDto
 import com.nexters.bandalart.core.datastore.BandalartDataStore
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartEmojiEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
+import com.nexters.bandalart.core.domain.template.BandalartTemplateCatalog
+import com.nexters.bandalart.core.domain.template.BandalartTemplateId
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -50,6 +54,35 @@ class DefaultBandalartRepositoryTest {
         mockBandalartDataStore = mockk()
         bandalartRepository = DefaultBandalartRepository(mockBandalartDataStore, mockBandalartDao)
     }
+
+    @Test
+    @DisplayName("템플릿 ID를 원자 생성용 DB draft로 변환해야 한다")
+    fun createBandalartFromTemplate() =
+        runTest {
+            val template = BandalartTemplateCatalog.find(BandalartTemplateId.STUDY_PLAN_V1)
+            val expectedDto =
+                CreateBandalartDto(
+                    title = template.title,
+                    profileEmoji = template.profileEmoji,
+                    subGoals =
+                        template.subGoals.map { subGoal ->
+                            CreateBandalartSubGoalDto(subGoal.title, subGoal.tasks)
+                        },
+                )
+            val stored =
+                BandalartDBEntity(
+                    id = 7L,
+                    title = template.title,
+                    profileEmoji = template.profileEmoji,
+                )
+            coEvery { mockBandalartDao.createBandalartTree(expectedDto) } returns 7L
+            coEvery { mockBandalartDao.getBandalart(7L) } returns stored
+
+            val result = bandalartRepository.createBandalart(BandalartTemplateId.STUDY_PLAN_V1)
+
+            assertEquals(stored.toEntity(), result)
+            coVerify(exactly = 1) { mockBandalartDao.createBandalartTree(expectedDto) }
+        }
 
     @Nested
     @DisplayName("반다라트 셀 업데이트 테스트")

--- a/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/repository/BandalartSlotRepositoryTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/repository/BandalartSlotRepositoryTest.kt
@@ -19,6 +19,7 @@ package com.nexters.bandalart.core.data.repository
 import com.nexters.bandalart.core.datastore.BandalartDataStore
 import com.nexters.bandalart.core.datastore.StoredPendingRewardedCreation
 import com.nexters.bandalart.core.domain.repository.PendingRewardedCreation
+import com.nexters.bandalart.core.domain.template.BandalartTemplateId
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -53,17 +54,21 @@ class BandalartSlotRepositoryTest {
     @Test
     fun rewardedCreationStateIsMappedFromDataStore() =
         runTest {
-            coEvery { dataStore.prepareRewardedCreation(42L, 3) } returns
-                StoredPendingRewardedCreation(42L, 4, false)
+            coEvery { dataStore.prepareRewardedCreation(42L, 3, "study_plan_v1") } returns
+                StoredPendingRewardedCreation(42L, 4, false, "study_plan_v1")
             coEvery { dataStore.grantRewardedCreation(42L) } returns
-                StoredPendingRewardedCreation(42L, 4, true)
+                StoredPendingRewardedCreation(42L, 4, true, "study_plan_v1")
 
             assertEquals(
-                PendingRewardedCreation(42L, 4, false),
-                repository.prepareRewardedCreation(42L, currentBandalartCount = 2),
+                PendingRewardedCreation(42L, 4, false, BandalartTemplateId.STUDY_PLAN_V1),
+                repository.prepareRewardedCreation(
+                    requestId = 42L,
+                    currentBandalartCount = 2,
+                    templateId = BandalartTemplateId.STUDY_PLAN_V1,
+                ),
             )
             assertEquals(
-                PendingRewardedCreation(42L, 4, true),
+                PendingRewardedCreation(42L, 4, true, BandalartTemplateId.STUDY_PLAN_V1),
                 repository.grantRewardedCreation(42L),
             )
         }

--- a/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/repository/DefaultBandalartRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/repository/DefaultBandalartRepository.kt
@@ -19,6 +19,8 @@ package com.nexters.bandalart.core.data.repository
 import com.nexters.bandalart.core.data.mapper.toDto
 import com.nexters.bandalart.core.data.mapper.toEntity
 import com.nexters.bandalart.core.database.BandalartDao
+import com.nexters.bandalart.core.database.entity.CreateBandalartDto
+import com.nexters.bandalart.core.database.entity.CreateBandalartSubGoalDto
 import com.nexters.bandalart.core.datastore.BandalartDataStore
 import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
 import com.nexters.bandalart.core.domain.entity.BandalartEntity
@@ -29,6 +31,8 @@ import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
 import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
 import com.nexters.bandalart.core.domain.notification.NoOpDeadlineReminderReconciler
 import com.nexters.bandalart.core.domain.repository.BandalartRepository
+import com.nexters.bandalart.core.domain.template.BandalartTemplateCatalog
+import com.nexters.bandalart.core.domain.template.BandalartTemplateId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -37,8 +41,9 @@ class DefaultBandalartRepository(
     private val bandalartDao: BandalartDao,
     private val deadlineReminderReconciler: DeadlineReminderReconciler = NoOpDeadlineReminderReconciler,
 ) : BandalartRepository {
-    override suspend fun createBandalart(): BandalartEntity {
-        val bandalartId = bandalartDao.createEmptyBandalart()
+    override suspend fun createBandalart(templateId: BandalartTemplateId?): BandalartEntity {
+        val template = templateId?.let(BandalartTemplateCatalog::find)
+        val bandalartId = bandalartDao.createBandalartTree(template?.toCreateDto())
         return bandalartDao.getBandalart(bandalartId).toEntity().also {
             deadlineReminderReconciler.reconcileAll()
         }
@@ -127,3 +132,16 @@ class DefaultBandalartRepository(
         bandalartDataStore.deleteBandalartId(bandalartId)
     }
 }
+
+private fun com.nexters.bandalart.core.domain.template.BandalartTemplate.toCreateDto() =
+    CreateBandalartDto(
+        title = title,
+        profileEmoji = profileEmoji,
+        subGoals =
+            subGoals.map { subGoal ->
+                CreateBandalartSubGoalDto(
+                    title = subGoal.title,
+                    tasks = subGoal.tasks,
+                )
+            },
+    )

--- a/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/repository/DefaultBandalartSlotRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/repository/DefaultBandalartSlotRepository.kt
@@ -20,6 +20,7 @@ import com.nexters.bandalart.core.datastore.BandalartDataStore
 import com.nexters.bandalart.core.domain.policy.resolveMaxBandalartSlots
 import com.nexters.bandalart.core.domain.repository.BandalartSlotRepository
 import com.nexters.bandalart.core.domain.repository.PendingRewardedCreation
+import com.nexters.bandalart.core.domain.template.BandalartTemplateId
 
 class DefaultBandalartSlotRepository(
     private val bandalartDataStore: BandalartDataStore,
@@ -37,11 +38,13 @@ class DefaultBandalartSlotRepository(
     override suspend fun prepareRewardedCreation(
         requestId: Long,
         currentBandalartCount: Int,
+        templateId: BandalartTemplateId?,
     ): PendingRewardedCreation =
         bandalartDataStore
             .prepareRewardedCreation(
                 requestId = requestId,
                 minimumSlots = resolveMaxBandalartSlots(currentBandalartCount),
+                templateId = templateId?.storedValue,
             ).toDomain()
 
     override suspend fun grantRewardedCreation(requestId: Long): PendingRewardedCreation? =
@@ -59,4 +62,5 @@ private fun com.nexters.bandalart.core.datastore.StoredPendingRewardedCreation.t
         requestId = requestId,
         targetSlots = targetSlots,
         isGranted = isGranted,
+        templateId = BandalartTemplateId.fromStoredValue(templateId),
     )

--- a/core/database/src/androidHostTest/kotlin/com/nexters/bandalart/core/database/BandalartDaoTest.kt
+++ b/core/database/src/androidHostTest/kotlin/com/nexters/bandalart/core/database/BandalartDaoTest.kt
@@ -20,6 +20,8 @@ import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.test
+import com.nexters.bandalart.core.database.entity.CreateBandalartDto
+import com.nexters.bandalart.core.database.entity.CreateBandalartSubGoalDto
 import com.nexters.bandalart.core.database.entity.UpdateBandalartMainCellDto
 import com.nexters.bandalart.core.database.entity.UpdateBandalartSubCellDto
 import com.nexters.bandalart.core.database.entity.UpdateBandalartTaskCellDto
@@ -92,7 +94,88 @@ class BandalartDaoTest {
                     assertEquals(5, taskCells.size)
                 }
             }
+
+        @Test
+        @DisplayName("부분 템플릿도 25칸 구조를 유지하며 새 반다라트로 생성되어야 한다")
+        fun templateCreatesCompleteGridWithoutFillingEveryCell() =
+            runTest {
+                val bandalartId =
+                    bandalartDao.createBandalartTree(
+                        CreateBandalartDto(
+                            title = "운동 습관",
+                            profileEmoji = "💪",
+                            subGoals =
+                                listOf(
+                                    CreateBandalartSubGoalDto(
+                                        title = "운동 계획",
+                                        tasks = listOf("주간 횟수 정하기", "운동 시간 확보"),
+                                    ),
+                                ),
+                        ),
+                    )
+
+                val bandalart = bandalartDao.getBandalart(bandalartId)
+                val mainCell = bandalartDao.getBandalartMainCell(bandalartId)
+                val firstSubTasks = bandalartDao.getChildCells(mainCell.children.first().id!!)
+
+                assertEquals("운동 습관", bandalart.title)
+                assertEquals("💪", bandalart.profileEmoji)
+                assertEquals("운동 습관", mainCell.cell.title)
+                assertEquals(4, mainCell.children.size)
+                assertEquals("운동 계획", mainCell.children.first().title)
+                assertEquals(5, firstSubTasks.size)
+                assertEquals(listOf("주간 횟수 정하기", "운동 시간 확보"), firstSubTasks.take(2).map { it.title })
+                assertTrue(firstSubTasks.drop(2).all { it.title == null })
+                assertEquals(25, bandalartDao.getAllCellsInBandalart(bandalartId).size)
+            }
+
+        @Test
+        @DisplayName("템플릿 셀 삽입에 실패하면 반다라트와 셀을 모두 롤백해야 한다")
+        fun templateCreationRollsBackTheWholeTreeWhenACellInsertFails() =
+            runTest {
+                bandalartDao.createEmptyBandalart()
+                val initialBandalartCount = rowCount("bandalarts")
+                val initialCellCount = rowCount("bandalart_cells")
+                db.openHelper.writableDatabase.execSQL(
+                    """
+                    CREATE TRIGGER fail_template_cell_insert
+                    BEFORE INSERT ON bandalart_cells
+                    WHEN NEW.title = '강제 실패'
+                    BEGIN
+                        SELECT RAISE(ABORT, 'forced template insert failure');
+                    END
+                    """.trimIndent(),
+                )
+
+                val failure =
+                    runCatching {
+                        bandalartDao.createBandalartTree(
+                            CreateBandalartDto(
+                                title = "롤백 검증",
+                                subGoals =
+                                    listOf(
+                                        CreateBandalartSubGoalDto(
+                                            title = "첫 목표",
+                                            tasks = listOf("정상 셀", "강제 실패"),
+                                        ),
+                                    ),
+                            ),
+                        )
+                    }.exceptionOrNull()
+
+                assertNotNull(failure)
+                assertEquals(initialBandalartCount, rowCount("bandalarts"))
+                assertEquals(initialCellCount, rowCount("bandalart_cells"))
+            }
     }
+
+    private fun rowCount(tableName: String): Long =
+        db.openHelper.writableDatabase
+            .query("SELECT COUNT(*) FROM $tableName")
+            .use { cursor ->
+                cursor.moveToFirst()
+                cursor.getLong(0)
+            }
 
     @Nested
     @DisplayName("반다라트 셀 업데이트 테스트")

--- a/core/database/src/commonMain/kotlin/com/nexters/bandalart/core/database/BandalartDao.kt
+++ b/core/database/src/commonMain/kotlin/com/nexters/bandalart/core/database/BandalartDao.kt
@@ -26,6 +26,7 @@ import androidx.room.Update
 import com.nexters.bandalart.core.database.entity.BandalartCellDBEntity
 import com.nexters.bandalart.core.database.entity.BandalartCellWithChildrenDto
 import com.nexters.bandalart.core.database.entity.BandalartDBEntity
+import com.nexters.bandalart.core.database.entity.CreateBandalartDto
 import com.nexters.bandalart.core.database.entity.UpdateBandalartEmojiDto
 import com.nexters.bandalart.core.database.entity.UpdateBandalartMainCellDto
 import com.nexters.bandalart.core.database.entity.UpdateBandalartSubCellDto
@@ -56,15 +57,17 @@ interface BandalartDao {
         }
     }
 
-    /** 빈 반다라트 생성 (메인 셀 1개, 서브 셀 4개, 각 서브 셀당 하위 셀 5개) */
+    /** 반다라트 생성 (메인 셀 1개, 서브 셀 4개, 각 서브 셀당 하위 셀 5개) */
     @Transaction
-    suspend fun createEmptyBandalart(): Long {
+    suspend fun createBandalartTree(template: CreateBandalartDto? = null): Long {
         // 1. 기본 반다라트 생성
         val bandalartId =
             createBandalart(
                 BandalartDBEntity(
                     mainColor = "#3FFFBA",
                     subColor = "#111827",
+                    profileEmoji = template?.profileEmoji,
+                    title = template?.title,
                 ),
             )
 
@@ -73,26 +76,29 @@ interface BandalartDao {
             insertCell(
                 BandalartCellDBEntity(
                     bandalartId = bandalartId,
-                    title = "",
+                    title = template?.title.orEmpty(),
                 ),
             )
 
         // 3. 4개의 서브 셀 생성
-        repeat(4) {
+        repeat(4) { subGoalIndex ->
+            val subGoal = template?.subGoals?.getOrNull(subGoalIndex)
             val subCellId =
                 insertCell(
                     BandalartCellDBEntity(
                         bandalartId = bandalartId,
                         parentId = mainCellId,
+                        title = subGoal?.title,
                     ),
                 )
 
             // 4. 각 서브 셀마다 5개의 태스크 셀 생성
-            repeat(5) {
+            repeat(5) { taskIndex ->
                 insertCell(
                     BandalartCellDBEntity(
                         bandalartId = bandalartId,
                         parentId = subCellId,
+                        title = subGoal?.tasks?.getOrNull(taskIndex),
                     ),
                 )
             }
@@ -100,6 +106,10 @@ interface BandalartDao {
 
         return bandalartId
     }
+
+    /** 기존 빈 생성 호출을 위한 호환 경계 */
+    @Transaction
+    suspend fun createEmptyBandalart(): Long = createBandalartTree()
 
     // Read - 반다라트
     @Query("SELECT * FROM bandalarts WHERE id = :bandalartId")

--- a/core/database/src/commonMain/kotlin/com/nexters/bandalart/core/database/entity/CreateBandalartDto.kt
+++ b/core/database/src/commonMain/kotlin/com/nexters/bandalart/core/database/entity/CreateBandalartDto.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.database.entity
+
+data class CreateBandalartDto(
+    val title: String? = null,
+    val profileEmoji: String? = null,
+    val subGoals: List<CreateBandalartSubGoalDto> = emptyList(),
+)
+
+data class CreateBandalartSubGoalDto(
+    val title: String,
+    val tasks: List<String>,
+)

--- a/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreTest.kt
+++ b/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreTest.kt
@@ -138,15 +138,42 @@ class BandalartDataStoreTest {
                     bandalartDataStore.prepareRewardedCreation(
                         requestId = 42L,
                         minimumSlots = 3,
+                        templateId = "study_plan_v1",
                     )
 
-                assertEquals(StoredPendingRewardedCreation(42L, 4, false), pending)
-                assertEquals(StoredPendingRewardedCreation(42L, 4, true), bandalartDataStore.grantRewardedCreation(42L))
+                assertEquals(StoredPendingRewardedCreation(42L, 4, false, "study_plan_v1"), pending)
+                assertEquals(
+                    StoredPendingRewardedCreation(42L, 4, true, "study_plan_v1"),
+                    bandalartDataStore.grantRewardedCreation(42L),
+                )
                 assertEquals(4, bandalartDataStore.resolveMaxBandalartSlots(minimumSlots = 3))
-                assertEquals(StoredPendingRewardedCreation(42L, 4, true), bandalartDataStore.getPendingRewardedCreation())
+                assertEquals(
+                    StoredPendingRewardedCreation(42L, 4, true, "study_plan_v1"),
+                    bandalartDataStore.getPendingRewardedCreation(),
+                )
 
                 bandalartDataStore.clearPendingRewardedCreation(42L)
                 assertEquals(null, bandalartDataStore.getPendingRewardedCreation())
+            }
+
+        @Test
+        @DisplayName("템플릿 키가 없는 구버전 보상 요청은 빈 생성으로 복구해야 한다")
+        fun legacyRewardedCreationWithoutTemplateRemainsCompatible() =
+            runTest {
+                bandalartDataStore.prepareRewardedCreation(
+                    requestId = 43L,
+                    minimumSlots = 3,
+                )
+
+                assertEquals(
+                    StoredPendingRewardedCreation(
+                        requestId = 43L,
+                        targetSlots = 4,
+                        isGranted = true,
+                        templateId = null,
+                    ),
+                    bandalartDataStore.grantRewardedCreation(43L),
+                )
             }
 
         @Test

--- a/core/datastore/src/commonMain/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStore.kt
+++ b/core/datastore/src/commonMain/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStore.kt
@@ -44,6 +44,7 @@ class BandalartDataStore(
         private const val PENDING_REWARDED_REQUEST_ID = "pending_rewarded_request_id"
         private const val PENDING_REWARDED_TARGET_SLOTS = "pending_rewarded_target_slots"
         private const val PENDING_REWARDED_GRANTED = "pending_rewarded_granted"
+        private const val PENDING_REWARDED_TEMPLATE_ID = "pending_rewarded_template_id"
         private const val MAX_RECENT_EMOJIS = 12
     }
 
@@ -57,6 +58,7 @@ class BandalartDataStore(
     private val pendingRewardedRequestIdKey = longPreferencesKey(PENDING_REWARDED_REQUEST_ID)
     private val pendingRewardedTargetSlotsKey = intPreferencesKey(PENDING_REWARDED_TARGET_SLOTS)
     private val pendingRewardedGrantedKey = booleanPreferencesKey(PENDING_REWARDED_GRANTED)
+    private val pendingRewardedTemplateIdKey = stringPreferencesKey(PENDING_REWARDED_TEMPLATE_ID)
 
     suspend fun resolveMaxBandalartSlots(minimumSlots: Int): Int {
         var resolvedSlots = minimumSlots
@@ -79,14 +81,20 @@ class BandalartDataStore(
     suspend fun prepareRewardedCreation(
         requestId: Long,
         minimumSlots: Int,
+        templateId: String? = null,
     ): StoredPendingRewardedCreation {
-        var pending = StoredPendingRewardedCreation(requestId, minimumSlots + 1, false)
+        var pending = StoredPendingRewardedCreation(requestId, minimumSlots + 1, false, templateId)
         dataStore.edit { preferences ->
             val resolvedSlots = maxOf(preferences[maxBandalartSlotsKey] ?: 0, minimumSlots)
-            pending = StoredPendingRewardedCreation(requestId, resolvedSlots + 1, false)
+            pending = StoredPendingRewardedCreation(requestId, resolvedSlots + 1, false, templateId)
             preferences[pendingRewardedRequestIdKey] = pending.requestId
             preferences[pendingRewardedTargetSlotsKey] = pending.targetSlots
             preferences[pendingRewardedGrantedKey] = false
+            if (templateId == null) {
+                preferences.remove(pendingRewardedTemplateIdKey)
+            } else {
+                preferences[pendingRewardedTemplateIdKey] = templateId
+            }
         }
         return pending
     }
@@ -118,6 +126,7 @@ class BandalartDataStore(
             preferences.remove(pendingRewardedRequestIdKey)
             preferences.remove(pendingRewardedTargetSlotsKey)
             preferences.remove(pendingRewardedGrantedKey)
+            preferences.remove(pendingRewardedTemplateIdKey)
         }
     }
 
@@ -174,6 +183,7 @@ class BandalartDataStore(
             requestId = requestId,
             targetSlots = targetSlots,
             isGranted = this[pendingRewardedGrantedKey] ?: false,
+            templateId = this[pendingRewardedTemplateIdKey],
         )
     }
 
@@ -289,4 +299,5 @@ data class StoredPendingRewardedCreation(
     val requestId: Long,
     val targetSlots: Int,
     val isGranted: Boolean,
+    val templateId: String? = null,
 )

--- a/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
@@ -186,6 +186,14 @@
     <string name="settings_deadline_reminder_confirm">Turn on</string>
     <string name="settings_deadline_reminder_cancel">Cancel</string>
 
+    <!-- template catalog -->
+    <string name="bandalart_create_title">Create a Bandalart</string>
+    <string name="bandalart_create_direct_title">Start from scratch</string>
+    <string name="bandalart_create_direct_summary">Fill in a blank Bandalart your way</string>
+    <string name="bandalart_create_template_section">Quick start with a template</string>
+    <string name="bandalart_create_template_request">Request a template</string>
+    <string name="back_description">Go back</string>
+
     <!-- in-app update -->
     <string name="update_ready_to_install">App update is ready to install.</string>
     <string name="update_action_restart">Restart</string>

--- a/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
@@ -187,6 +187,14 @@
     <string name="settings_deadline_reminder_confirm">オンにする</string>
     <string name="settings_deadline_reminder_cancel">キャンセル</string>
 
+    <!-- template catalog -->
+    <string name="bandalart_create_title">新しいバンダラート</string>
+    <string name="bandalart_create_direct_title">自分で作る</string>
+    <string name="bandalart_create_direct_summary">空のバンダラートを自由に埋めます</string>
+    <string name="bandalart_create_template_section">テンプレートですぐに始める</string>
+    <string name="bandalart_create_template_request">テンプレートをリクエスト</string>
+    <string name="back_description">戻る</string>
+
     <!-- in-app update -->
     <string name="update_ready_to_install">アプリのアップデートのインストール準備が完了しました。</string>
     <string name="update_action_restart">再起動</string>

--- a/core/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -188,6 +188,14 @@
     <string name="settings_deadline_reminder_confirm">알림 켜기</string>
     <string name="settings_deadline_reminder_cancel">취소</string>
 
+    <!-- template catalog -->
+    <string name="bandalart_create_title">새 반다라트 만들기</string>
+    <string name="bandalart_create_direct_title">직접 만들기</string>
+    <string name="bandalart_create_direct_summary">빈 반다라트부터 자유롭게 채워요</string>
+    <string name="bandalart_create_template_section">템플릿으로 빠르게 시작</string>
+    <string name="bandalart_create_template_request">원하는 템플릿 요청하기</string>
+    <string name="back_description">뒤로 가기</string>
+
     <!-- in-app update -->
     <string name="update_ready_to_install">앱의 업데이트 설치 준비가 완료되었습니다.</string>
     <string name="update_action_restart">재시작</string>

--- a/core/domain/src/androidHostTest/kotlin/com/nexters/bandalart/core/domain/template/BandalartTemplateCatalogTest.kt
+++ b/core/domain/src/androidHostTest/kotlin/com/nexters/bandalart/core/domain/template/BandalartTemplateCatalogTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.domain.template
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class BandalartTemplateCatalogTest {
+    @Test
+    fun catalogContainsFiveUniqueVersionedTemplatesWithinGridCapacity() {
+        val templates = BandalartTemplateCatalog.templates
+
+        assertEquals(5, templates.size)
+        assertEquals(templates.size, templates.map { it.id }.distinct().size)
+        assertTrue(templates.all { it.id.storedValue.endsWith("_v1") })
+        assertTrue(templates.all { it.subGoals.size <= 4 })
+        assertTrue(templates.flatMap { it.subGoals }.all { it.tasks.size <= 5 })
+        assertTrue(templates.all { it.title.length <= 15 })
+        assertTrue(templates.flatMap { it.subGoals }.all { it.title.length <= 15 })
+        assertTrue(templates.flatMap { it.subGoals }.flatMap { it.tasks }.all { it.length <= 15 })
+    }
+
+    @Test
+    fun storedIdsRoundTripAndUnknownIdsRemainUnsupported() {
+        BandalartTemplateId.entries.forEach { id ->
+            assertEquals(id, BandalartTemplateId.fromStoredValue(id.storedValue))
+        }
+        assertEquals(null, BandalartTemplateId.fromStoredValue("unknown_v1"))
+    }
+}

--- a/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/repository/BandalartRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/repository/BandalartRepository.kt
@@ -6,6 +6,7 @@ import com.nexters.bandalart.core.domain.entity.UpdateBandalartEmojiEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
+import com.nexters.bandalart.core.domain.template.BandalartTemplateId
 import kotlinx.coroutines.flow.Flow
 
 /** 반다라트 API */
@@ -13,7 +14,7 @@ interface BandalartRepository {
     /**
      * 반다라트 생성
      */
-    suspend fun createBandalart(): BandalartEntity?
+    suspend fun createBandalart(templateId: BandalartTemplateId? = null): BandalartEntity?
 
     /**
      * 반다라트 목록 조회
@@ -123,7 +124,10 @@ interface BandalartRepository {
      * @param bandalartId 반다라트 고유 id
      * @param isCompleted 반다라트 완료 여부
      */
-    suspend fun upsertBandalartId(bandalartId: Long, isCompleted: Boolean)
+    suspend fun upsertBandalartId(
+        bandalartId: Long,
+        isCompleted: Boolean
+    )
 
     /**
      * 이번에 목표를 달성한 반다라트 인지 여부 확인

--- a/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/repository/BandalartSlotRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/repository/BandalartSlotRepository.kt
@@ -16,6 +16,8 @@
 
 package com.nexters.bandalart.core.domain.repository
 
+import com.nexters.bandalart.core.domain.template.BandalartTemplateId
+
 interface BandalartSlotRepository {
     suspend fun getMaxBandalartSlots(currentBandalartCount: Int): Int
 
@@ -24,6 +26,7 @@ interface BandalartSlotRepository {
     suspend fun prepareRewardedCreation(
         requestId: Long,
         currentBandalartCount: Int,
+        templateId: BandalartTemplateId? = null,
     ): PendingRewardedCreation
 
     suspend fun grantRewardedCreation(requestId: Long): PendingRewardedCreation?
@@ -37,4 +40,5 @@ data class PendingRewardedCreation(
     val requestId: Long,
     val targetSlots: Int,
     val isGranted: Boolean,
+    val templateId: BandalartTemplateId? = null,
 )

--- a/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/template/BandalartTemplate.kt
+++ b/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/template/BandalartTemplate.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.domain.template
+
+enum class BandalartTemplateId(
+    val storedValue: String,
+) {
+    JOB_PREPARATION_V1("job_preparation_v1"),
+    WORKOUT_HABIT_V1("workout_habit_v1"),
+    STUDY_PLAN_V1("study_plan_v1"),
+    MONEY_HABIT_V1("money_habit_v1"),
+    TRAVEL_PLAN_V1("travel_plan_v1"),
+    ;
+
+    companion object {
+        fun fromStoredValue(value: String?): BandalartTemplateId? = entries.firstOrNull { it.storedValue == value }
+    }
+}
+
+data class BandalartTemplate(
+    val id: BandalartTemplateId,
+    val title: String,
+    val summary: String,
+    val profileEmoji: String,
+    val subGoals: List<BandalartTemplateSubGoal>,
+)
+
+data class BandalartTemplateSubGoal(
+    val title: String,
+    val tasks: List<String>,
+)
+
+object BandalartTemplateCatalog {
+    val templates: List<BandalartTemplate> =
+        listOf(
+            BandalartTemplate(
+                id = BandalartTemplateId.JOB_PREPARATION_V1,
+                title = "취업 준비",
+                summary = "지원 준비부터 면접까지",
+                profileEmoji = "💼",
+                subGoals =
+                    listOf(
+                        subGoal("지원 전략", "희망 직무 정하기", "기업 목록 만들기", "지원 일정 정리하기"),
+                        subGoal("서류 준비", "이력서 업데이트", "자기소개서 초안", "포트폴리오 점검"),
+                        subGoal("실력 준비", "핵심 역량 공부", "예상 과제 연습", "경험 사례 정리"),
+                        subGoal("면접 준비", "예상 질문 답변", "모의 면접", "회사별 질문 준비"),
+                    ),
+            ),
+            BandalartTemplate(
+                id = BandalartTemplateId.WORKOUT_HABIT_V1,
+                title = "운동 습관",
+                summary = "운동·회복·기록을 꾸준하게",
+                profileEmoji = "💪",
+                subGoals =
+                    listOf(
+                        subGoal("운동 계획", "주간 횟수 정하기", "운동 시간 확보", "운동복 미리 준비"),
+                        subGoal("근력 운동", "하체 운동", "상체 운동", "코어 운동"),
+                        subGoal("유산소", "걷기 또는 달리기", "심박수 기록", "주간 거리 확인"),
+                        subGoal("회복 습관", "스트레칭", "수면 시간 지키기", "몸 상태 기록"),
+                    ),
+            ),
+            BandalartTemplate(
+                id = BandalartTemplateId.STUDY_PLAN_V1,
+                title = "공부 계획",
+                summary = "목표부터 복습·실전까지",
+                profileEmoji = "📚",
+                subGoals =
+                    listOf(
+                        subGoal("목표 설계", "시험일 확인", "학습 범위 나누기", "주간 목표 정하기"),
+                        subGoal("개념 학습", "교재 1회독", "핵심 개념 정리", "모르는 내용 표시"),
+                        subGoal("복습", "오답 노트", "주간 복습", "암기 내용 점검"),
+                        subGoal("실전 연습", "기출 문제 풀기", "시간 재고 풀기", "약점 보완"),
+                    ),
+            ),
+            BandalartTemplate(
+                id = BandalartTemplateId.MONEY_HABIT_V1,
+                title = "재테크 습관",
+                summary = "예산·저축·투자를 한눈에",
+                profileEmoji = "💰",
+                subGoals =
+                    listOf(
+                        subGoal("예산 관리", "월 예산 정하기", "고정비 확인", "주간 지출 기록"),
+                        subGoal("저축", "저축 목표 정하기", "자동 이체 설정", "비상금 만들기"),
+                        subGoal("투자 공부", "투자 원칙 정리", "관심 자산 공부", "위험 수준 점검"),
+                        subGoal("정기 점검", "월말 결산", "자산 현황 기록", "다음 달 계획 수정"),
+                    ),
+            ),
+            BandalartTemplate(
+                id = BandalartTemplateId.TRAVEL_PLAN_V1,
+                title = "여행 준비",
+                summary = "일정·예약·짐·현지 준비",
+                profileEmoji = "🧳",
+                subGoals =
+                    listOf(
+                        subGoal("일정 짜기", "여행 기간 정하기", "가고 싶은 곳 저장", "동선 정리"),
+                        subGoal("예약", "교통편 예약", "숙소 예약", "입장권 확인"),
+                        subGoal("짐 챙기기", "필수 서류", "의류와 세면도구", "충전기와 어댑터"),
+                        subGoal("현지 준비", "예산과 환전", "교통 방법 확인", "비상 연락처 저장"),
+                    ),
+            ),
+        )
+
+    fun find(id: BandalartTemplateId): BandalartTemplate = templates.first { it.id == id }
+}
+
+private fun subGoal(
+    title: String,
+    vararg tasks: String,
+): BandalartTemplateSubGoal =
+    BandalartTemplateSubGoal(
+        title = title,
+        tasks = tasks.toList(),
+    )

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@
 ### Home, Settings, Updates
 
 - [태스크 셀 햅틱 완료](features/home/TASK_CELL_HAPTIC_COMPLETION_STRATEGY.md)
+- [반다라트 템플릿 catalog v1](features/templates/BANDALART_TEMPLATE_CATALOG_V1_STRATEGY.md)
 - [마감일 기반 로컬 알림 조사](features/notifications/LOCAL_DEADLINE_NOTIFICATION_RESEARCH.md)
 - [마감일 기반 로컬 알림 구현 전략](features/notifications/LOCAL_DEADLINE_NOTIFICATION_STRATEGY.md)
 - [이메일 문의](features/settings/EMAIL_INQUIRY_STRATEGY.md)

--- a/docs/features/templates/BANDALART_TEMPLATE_CATALOG_V1_STRATEGY.md
+++ b/docs/features/templates/BANDALART_TEMPLATE_CATALOG_V1_STRATEGY.md
@@ -85,4 +85,4 @@ catalog는 앱 바이너리에 포함된 버전 관리형 Kotlin 데이터로 �
 - [x] 광고 대기·grant·process recovery 동안 template ID가 보존된다.
 - [x] 문의 row가 기존 support mail 흐름을 연다.
 - [x] 관련 host tests, Android compile, iOS simulator Kotlin compile과 정적 검사가 통과한다.
-- [ ] PR을 생성하되 사용자 검토 전 merge하지 않는다.
+- [x] PR을 생성하고 CI와 사용자 검토를 거쳐 merge한다.

--- a/docs/features/templates/BANDALART_TEMPLATE_CATALOG_V1_STRATEGY.md
+++ b/docs/features/templates/BANDALART_TEMPLATE_CATALOG_V1_STRATEGY.md
@@ -1,0 +1,88 @@
+# 반다라트 템플릿 catalog v1 전략
+
+## 배경
+
+사용자는 25칸을 모두 직접 입력하지 않고도 자주 쓰는 목표 구조로 빠르게 시작할 수 있어야 한다. 템플릿은 한 번 출시하고 끝나는 정적 예제가 아니라, 문의로 받은 요청을 다음 앱 업데이트의 catalog에 반영하는 살아 있는 기능으로 운영한다.
+
+이 문서는 GitHub issue #208의 첫 출하 범위를 고정한다. 이전 조사에서 고려한 별도 선택 화면, 전체 미리보기, 생성 전 편집은 v1에서 제외한다. 생성된 모든 셀은 기존 편집 흐름에서 바로 수정할 수 있으므로 선택과 생성 사이에 별도 단계를 두지 않는다.
+
+## 사용자 흐름
+
+1. 사용자가 기존 반다라트 목록 bottom sheet에서 `반다라트 추가`를 누른다.
+2. 같은 sheet가 생성 방법 목록으로 전환된다. modal을 중첩하거나 새 navigation destination을 만들지 않는다.
+3. 첫 항목은 빈 반다라트 직접 만들기이고, 그 아래에 앱에 포함된 템플릿 5개를 표시한다.
+4. 항목을 누르면 기존 슬롯 확인과 보상형 광고 gate를 그대로 거친다.
+5. 생성 가능한 경우 새 반다라트를 원자적으로 만들고 곧바로 선택한다.
+6. 사용자는 기존 셀 편집 bottom sheet에서 자신의 상황에 맞게 내용을 수정한다.
+7. `원하는 템플릿 요청하기`는 기존 문의 메일 흐름을 연다.
+
+## v1 catalog
+
+catalog는 앱 바이너리에 포함된 버전 관리형 Kotlin 데이터로 시작한다. 서버, 원격 config, 추천·인기순은 요청량을 확인한 뒤 별도 단계로 확장한다.
+
+| ID | 표시 이름 | 기본 이모지 | 의도 |
+| --- | --- | --- | --- |
+| `job_preparation_v1` | 취업 준비 | 💼 | 지원 준비부터 면접까지 |
+| `workout_habit_v1` | 운동 습관 | 💪 | 운동·회복·기록 습관 |
+| `study_plan_v1` | 공부 계획 | 📚 | 목표·학습·복습·실전 |
+| `money_habit_v1` | 재테크 습관 | 💰 | 예산·저축·투자·점검 |
+| `travel_plan_v1` | 여행 준비 | 🧳 | 일정·예약·짐·현지 준비 |
+
+- Room의 5×5 구조는 그대로 생성하되 모든 칸을 채울 필요는 없다. 정의되지 않은 칸은 빈 셀로 남긴다.
+- 최초 catalog 내용은 issue의 기존 합의대로 한국어 기준으로 제공한다. 다른 언어 catalog는 실제 요청과 함께 후속 범위로 분리한다.
+- ID에는 버전을 포함한다. 출시 뒤 내용을 크게 바꿀 때 기존 ID를 재해석하지 않고 새 버전을 추가한다.
+
+## 생성과 데이터 정합성
+
+### 원자 생성
+
+- `BandalartRepository.createBandalart(templateId?)`가 빈 생성과 템플릿 생성을 한 경계에서 제공한다.
+- DAO transaction 하나가 `bandalarts` 행, main 1개, sub 4개, task 20개를 모두 삽입한다.
+- template은 title·profile emoji와 일부 셀 title만 제공한다. 나머지 색상, 완료 상태와 빈 셀 규칙은 현재 기본값을 따른다.
+- transaction 실패 시 일부 셀이나 기존 반다라트가 수정된 상태를 남기지 않는다.
+- 기존 반다라트를 update하거나 덮어쓰는 API는 사용하지 않는다.
+
+### 슬롯·보상형 광고
+
+- template 선택도 빈 생성과 동일한 무료 슬롯·추가 슬롯 정책을 거친다. UI에서 직접 repository를 호출해 gate를 우회하지 않는다.
+- 무료 슬롯이 있으면 선택한 template ID로 즉시 생성한다.
+- 광고가 필요하면 선택한 template ID를 pending rewarded creation과 함께 DataStore에 저장한다.
+- reward grant 뒤 생성과 process recovery는 저장된 동일 ID를 사용한다. 구버전 pending 데이터처럼 ID가 없으면 빈 생성으로 호환한다.
+- 광고 dismiss는 생성하지 않고 pending template도 함께 지운다. 광고 SDK 실패의 기존 fail-open 정책은 유지하되 선택한 template으로 생성한다.
+
+## UI와 상태
+
+- `BandalartList` bottom sheet state에 목록/생성 방법 두 화면만 둔다.
+- 생성 방법 상태는 sheet 안에서만 필요한 작은 UI state이므로 Circuit state에 명시하고 dismissal과 함께 제거한다.
+- template row는 이모지, 이름, 한 줄 설명을 보여준다. 선택 즉시 생성 요청을 보내며 별도의 preview·확인 dialog는 만들지 않는다.
+- 문의 row는 기존 `ContactSupport` event와 mail launcher를 재사용한다.
+- TalkBack/VoiceOver가 행 전체를 하나의 button으로 읽도록 하고 최소 48dp touch target을 유지한다.
+
+## 테스트와 검증
+
+### 자동 테스트
+
+- catalog ID는 유일하고 5개이며 각 template은 sub 4개 이하, sub별 task 5개 이하이다.
+- DAO가 빈 생성과 부분 template 모두 정확히 1+4+20 셀로 원자 생성한다.
+- repository가 template ID를 올바른 DB draft로 변환한다.
+- DataStore/slot repository가 pending template ID를 prepare, grant, clear, recovery에서 보존한다.
+- Presenter가 무료 슬롯, 광고 grant, fail-open, process recovery에서 선택한 template을 생성한다.
+- template 선택이 기존 selection coordinator를 통해 새 board를 선택하고 기존 board를 덮어쓰지 않는다.
+
+### 수동 확인
+
+- Android/iOS에서 기존 목록 → 추가 → 직접 만들기/5개 template/문의 row가 표시된다.
+- 작은 화면에서 목록이 스크롤되고 마지막 문의 row까지 접근 가능하다.
+- 무료 슬롯과 슬롯 소진 상태에서 같은 template이 생성된다.
+- 광고 dismiss 시 생성되지 않고, grant 시 정확히 한 개만 생성된다.
+- 생성된 일부 빈 셀을 기존 편집 흐름으로 자유롭게 수정할 수 있다.
+
+## 완료 조건
+
+- [x] 기존 bottom sheet 안에서 직접 만들기와 5개 template을 선택할 수 있다.
+- [x] 선택 즉시 기존 slot/reward gate를 거쳐 새 반다라트를 만든다.
+- [x] template 생성은 원자적이며 기존 데이터를 덮어쓰지 않는다.
+- [x] 광고 대기·grant·process recovery 동안 template ID가 보존된다.
+- [x] 문의 row가 기존 support mail 흐름을 연다.
+- [x] 관련 host tests, Android compile, iOS simulator Kotlin compile과 정적 검사가 통과한다.
+- [ ] PR을 생성하되 사용자 검토 전 merge하지 않는다.

--- a/feature/complete/src/androidHostTest/kotlin/com/nexters/bandalart/feature/complete/presenter/RecordingBandalartRepository.kt
+++ b/feature/complete/src/androidHostTest/kotlin/com/nexters/bandalart/feature/complete/presenter/RecordingBandalartRepository.kt
@@ -23,6 +23,7 @@ import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
 import com.nexters.bandalart.core.domain.repository.BandalartRepository
+import com.nexters.bandalart.core.domain.template.BandalartTemplateId
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
@@ -47,7 +48,7 @@ internal class RecordingBandalartRepository : BandalartRepository {
         completionRecorded.complete(Unit)
     }
 
-    override suspend fun createBandalart(): BandalartEntity? = error("Not used")
+    override suspend fun createBandalart(templateId: BandalartTemplateId?): BandalartEntity? = error("Not used")
 
     override fun getBandalartList(): Flow<List<BandalartEntity>> = emptyFlow()
 

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
@@ -23,6 +23,7 @@ import com.nexters.bandalart.core.domain.entity.UpdateBandalartMainCellEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartSubCellEntity
 import com.nexters.bandalart.core.domain.entity.UpdateBandalartTaskCellEntity
 import com.nexters.bandalart.core.domain.repository.BandalartRepository
+import com.nexters.bandalart.core.domain.template.BandalartTemplateId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -52,6 +53,7 @@ internal class FakeBandalartRepository(
 
     var createCalls: Int = 0
         private set
+    val createdTemplateIds = mutableListOf<BandalartTemplateId?>()
 
     val completionUpdates = mutableListOf<Pair<Long, Boolean>>()
     val deletedBandalartIds = mutableListOf<Long>()
@@ -67,8 +69,9 @@ internal class FakeBandalartRepository(
     var taskCellUpdateCalls: Int = 0
         private set
 
-    override suspend fun createBandalart(): BandalartEntity? {
+    override suspend fun createBandalart(templateId: BandalartTemplateId?): BandalartEntity? {
         createCalls += 1
+        createdTemplateIds += templateId
         return createdBandalart?.also { bandalart ->
             details[bandalart.id] = bandalart
             if (publishCreatedBandalartImmediately) {

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartSlotRepository.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartSlotRepository.kt
@@ -18,6 +18,7 @@ package com.nexters.bandalart.feature.home.presenter
 
 import com.nexters.bandalart.core.domain.repository.BandalartSlotRepository
 import com.nexters.bandalart.core.domain.repository.PendingRewardedCreation
+import com.nexters.bandalart.core.domain.template.BandalartTemplateId
 
 class FakeBandalartSlotRepository(
     var maxSlots: Int = Int.MAX_VALUE,
@@ -48,11 +49,13 @@ class FakeBandalartSlotRepository(
     override suspend fun prepareRewardedCreation(
         requestId: Long,
         currentBandalartCount: Int,
+        templateId: BandalartTemplateId?,
     ): PendingRewardedCreation =
         PendingRewardedCreation(
             requestId = requestId,
             targetSlots = maxOf(maxSlots, currentBandalartCount) + 1,
             isGranted = false,
+            templateId = templateId,
         ).also { pendingRewardedCreation = it }
 
     override suspend fun grantRewardedCreation(requestId: Long): PendingRewardedCreation? {

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterRewardedAdTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterRewardedAdTest.kt
@@ -20,6 +20,7 @@ import app.cash.turbine.ReceiveTurbine
 import com.nexters.bandalart.core.common.RewardedAdResult
 import com.nexters.bandalart.core.domain.entity.BandalartEntity
 import com.nexters.bandalart.core.domain.repository.PendingRewardedCreation
+import com.nexters.bandalart.core.domain.template.BandalartTemplateId
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
@@ -29,6 +30,27 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class HomePresenterRewardedAdTest {
+    @Test
+    fun templateUsesExistingFreeSlotGateAndCreatesSelectedTemplate() =
+        runTest {
+            val repository = repository()
+            val slotRepository = FakeBandalartSlotRepository(maxSlots = 4)
+
+            presenter(repository, slotRepository).test {
+                var state = awaitLoaded()
+                state.eventSink(
+                    HomeScreen.Event.CreateBandalartFromTemplate(
+                        BandalartTemplateId.STUDY_PLAN_V1,
+                    ),
+                )
+                awaitCreated()
+
+                assertEquals(listOf(BandalartTemplateId.STUDY_PLAN_V1), repository.createdTemplateIds)
+                assertEquals(0, slotRepository.expandCalls)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     @Test
     fun slotLookupFailureDoesNotBypassGate() =
         runTest {
@@ -124,6 +146,39 @@ class HomePresenterRewardedAdTest {
         }
 
     @Test
+    fun rewardedCreationPersistsSelectedTemplateUntilGrant() =
+        runTest {
+            val repository = repository()
+            val slotRepository = FakeBandalartSlotRepository(maxSlots = 3)
+
+            presenter(repository, slotRepository).test {
+                var state = awaitLoaded()
+                state.eventSink(
+                    HomeScreen.Event.CreateBandalartFromTemplate(
+                        BandalartTemplateId.JOB_PREPARATION_V1,
+                    ),
+                )
+                state = awaitDialog()
+                state.eventSink(HomeScreen.Event.ConfirmRewardedCreate)
+                val requestId = awaitRewardedAdRequest()
+
+                assertEquals(
+                    BandalartTemplateId.JOB_PREPARATION_V1,
+                    slotRepository.pendingRewardedCreation?.templateId,
+                )
+                state.eventSink(
+                    HomeScreen.Event.RewardedAdFinished(
+                        requestId = requestId,
+                        result = RewardedAdResult.REWARDED,
+                    ),
+                )
+                awaitCreated()
+
+                assertEquals(listOf(BandalartTemplateId.JOB_PREPARATION_V1), repository.createdTemplateIds)
+            }
+        }
+
+    @Test
     fun loadOrShowFailureFailsOpenButDismissDoesNotCreate() =
         runTest {
             val failedRepository = repository()
@@ -131,7 +186,11 @@ class HomePresenterRewardedAdTest {
 
             presenter(failedRepository, failedSlots).test {
                 var state = awaitLoaded()
-                state.eventSink(HomeScreen.Event.AddBandalart)
+                state.eventSink(
+                    HomeScreen.Event.CreateBandalartFromTemplate(
+                        BandalartTemplateId.MONEY_HABIT_V1,
+                    ),
+                )
                 state = awaitDialog()
                 state.eventSink(HomeScreen.Event.ConfirmRewardedCreate)
                 val requestId = awaitRewardedAdRequest()
@@ -146,6 +205,7 @@ class HomePresenterRewardedAdTest {
 
                 assertEquals(1, failedSlots.expandCalls)
                 assertEquals(1, failedRepository.createCalls)
+                assertEquals(listOf(BandalartTemplateId.MONEY_HABIT_V1), failedRepository.createdTemplateIds)
             }
 
             val dismissedRepository = repository()
@@ -234,6 +294,7 @@ class HomePresenterRewardedAdTest {
                             requestId = 42L,
                             targetSlots = 4,
                             isGranted = true,
+                            templateId = BandalartTemplateId.TRAVEL_PLAN_V1,
                         ),
                 )
 
@@ -241,6 +302,33 @@ class HomePresenterRewardedAdTest {
                 awaitCreated()
 
                 assertEquals(1, repository.createCalls)
+                assertEquals(listOf(BandalartTemplateId.TRAVEL_PLAN_V1), repository.createdTemplateIds)
+                assertNull(slotRepository.pendingRewardedCreation)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun legacyGrantedPendingCreationWithoutTemplateRecoversAsBlankBandalart() =
+        runTest {
+            val repository = repository()
+            val slotRepository =
+                FakeBandalartSlotRepository(
+                    maxSlots = 4,
+                    initialPendingRewardedCreation =
+                        PendingRewardedCreation(
+                            requestId = 43L,
+                            targetSlots = 4,
+                            isGranted = true,
+                            templateId = null,
+                        ),
+                )
+
+            presenter(repository, slotRepository).test {
+                awaitCreated()
+
+                assertEquals(1, repository.createCalls)
+                assertEquals(listOf(null), repository.createdTemplateIds)
                 assertNull(slotRepository.pendingRewardedCreation)
                 cancelAndIgnoreRemainingEvents()
             }

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
@@ -175,6 +175,44 @@ class HomePresenterTest {
             }
         }
 
+    @Test
+    fun addButtonSwitchesExistingListSheetToCreationOptionsAndBack() =
+        runTest {
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1L)),
+                    recentBandalartId = 1L,
+                )
+
+            presenter(repository).test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != 1L || state.isLoading) {
+                    state = awaitItem()
+                }
+                state.eventSink(HomeScreen.Event.OpenBandalartList)
+                do {
+                    state = awaitItem()
+                } while (state.bottomSheet !is HomeScreen.BottomSheetState.BandalartList)
+
+                state.eventSink(HomeScreen.Event.OpenBandalartCreationOptions)
+                do {
+                    state = awaitItem()
+                } while (
+                    (state.bottomSheet as? HomeScreen.BottomSheetState.BandalartList)
+                        ?.isCreationOptionsVisible != true
+                )
+
+                state.eventSink(HomeScreen.Event.CloseBandalartCreationOptions)
+                do {
+                    state = awaitItem()
+                } while (
+                    (state.bottomSheet as? HomeScreen.BottomSheetState.BandalartList)
+                        ?.isCreationOptionsVisible != false
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     private fun bandalart(
         id: Long,
         isCompleted: Boolean = false,

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeBottomSheets.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeBottomSheets.kt
@@ -59,6 +59,7 @@ internal fun HomeBottomSheets(
             BandalartListBottomSheet(
                 bandalartList = updateBandalartListTitles(state.bandalartList).toImmutableList(),
                 currentBandalartId = bottomSheet.currentBandalartId,
+                isCreationOptionsVisible = bottomSheet.isCreationOptionsVisible,
                 onHomeUiAction = eventSink,
             )
         }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
@@ -22,6 +22,7 @@ import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
 import com.nexters.bandalart.core.domain.entity.ThemeMode
 import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorizationStatus
 import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingHealth
+import com.nexters.bandalart.core.domain.template.BandalartTemplateId
 import com.nexters.bandalart.core.navigation.CommonParcelize
 import com.nexters.bandalart.feature.home.model.BandalartUiModel
 import com.nexters.bandalart.feature.home.model.CellType
@@ -70,6 +71,7 @@ data object HomeScreen : ParcelableScreen, StaticScreen {
 
         data class BandalartList(
             val currentBandalartId: Long,
+            val isCreationOptionsVisible: Boolean = false,
         ) : BottomSheetState
 
         data class Emoji(
@@ -129,6 +131,14 @@ data object HomeScreen : ParcelableScreen, StaticScreen {
         ) : Event
 
         data object AddBandalart : Event
+
+        data object OpenBandalartCreationOptions : Event
+
+        data object CloseBandalartCreationOptions : Event
+
+        data class CreateBandalartFromTemplate(
+            val templateId: BandalartTemplateId,
+        ) : Event
 
         data object ConfirmRewardedCreate : Event
 

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -44,6 +44,7 @@ import com.nexters.bandalart.core.domain.repository.BandalartRepository
 import com.nexters.bandalart.core.domain.repository.BandalartSlotRepository
 import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
 import com.nexters.bandalart.core.domain.repository.SettingsRepository
+import com.nexters.bandalart.core.domain.template.BandalartTemplateId
 import com.nexters.bandalart.feature.complete.CompleteScreen
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.nexters.bandalart.feature.home.mapper.toUiModel
@@ -103,6 +104,7 @@ class HomePresenter(
         var updateVersionCode by remember { mutableStateOf<Int?>(null) }
         var rewardedAdRequestId by rememberRetained { mutableStateOf<Long?>(null) }
         var rewardedRecoveryChecked by rememberRetained { mutableStateOf(false) }
+        var pendingCreationTemplateId by rememberRetained { mutableStateOf<BandalartTemplateId?>(null) }
         var effect by remember { mutableStateOf<HomeScreen.Effect?>(null) }
         var requestedCompletionId by remember { mutableStateOf<Long?>(null) }
         val togglingTaskCellIds = remember { mutableSetOf<Long>() }
@@ -248,10 +250,10 @@ class HomePresenter(
             }
         }
 
-        suspend fun createBandalart(): Boolean {
+        suspend fun createBandalart(templateId: BandalartTemplateId? = null): Boolean {
             val selectionRequest = beginSelectionRequest()
             isExplicitSelectionTargetPending = true
-            val bandalart = bandalartRepository.createBandalart()
+            val bandalart = bandalartRepository.createBandalart(templateId)
             Snapshot.withMutableSnapshot {
                 if (bandalart != null && selectionLoadGeneration[0] == selectionRequest) {
                     explicitSelectionTargetId = bandalart.id
@@ -265,15 +267,17 @@ class HomePresenter(
             return true
         }
 
-        suspend fun requestCreateBandalart() {
+        suspend fun requestCreateBandalart(templateId: BandalartTemplateId? = null) {
             if (!rewardedRecoveryChecked) return
             if (!rewardedCreateCoordinator.beginSlotCheck()) return
+            pendingCreationTemplateId = templateId
             val maxSlots =
                 runRewardedOperation {
                     bandalartSlotRepository.getMaxBandalartSlots(bandalartList.size)
                 }.getOrElse { exception ->
                     Napier.e("Failed to resolve bandalart slots", exception, tag = "RewardedAd")
                     rewardedCreateCoordinator.slotCheckFailed()
+                    pendingCreationTemplateId = null
                     emitEffect(HomeScreen.Effect.ShowSlotErrorSnackbar)
                     return
                 }
@@ -285,9 +289,10 @@ class HomePresenter(
             ) {
                 var created = false
                 try {
-                    created = createBandalart()
+                    created = createBandalart(templateId)
                 } finally {
                     rewardedCreateCoordinator.creationFinished(created, bandalartList.size)
+                    pendingCreationTemplateId = null
                 }
             } else {
                 dialog = HomeScreen.DialogState.RewardedCreate
@@ -301,12 +306,17 @@ class HomePresenter(
             scope.launch(start = CoroutineStart.UNDISPATCHED) {
                 withContext(NonCancellable) {
                     runRewardedOperation {
-                        bandalartSlotRepository.prepareRewardedCreation(requestId, bandalartList.size)
+                        bandalartSlotRepository.prepareRewardedCreation(
+                            requestId = requestId,
+                            currentBandalartCount = bandalartList.size,
+                            templateId = pendingCreationTemplateId,
+                        )
                     }.onSuccess {
                         rewardedAdRequestId = requestId
                     }.onFailure { exception ->
                         Napier.e("Failed to persist rewarded request", exception, tag = "RewardedAd")
                         rewardedCreateCoordinator.adPreparationFailed(requestId)
+                        pendingCreationTemplateId = null
                         emitEffect(HomeScreen.Effect.ShowSlotErrorSnackbar)
                     }
                 }
@@ -321,6 +331,7 @@ class HomePresenter(
                 RewardedCompletion.IGNORED -> Unit
                 RewardedCompletion.DISMISSED -> {
                     rewardedAdRequestId = null
+                    pendingCreationTemplateId = null
                     scope.launch(start = CoroutineStart.UNDISPATCHED) {
                         withContext(NonCancellable) {
                             bandalartSlotRepository.clearPendingRewardedCreation(requestId)
@@ -347,13 +358,14 @@ class HomePresenter(
                                 if (pending != null) {
                                     expectedCount = pending.targetSlots
                                     created =
-                                        runRewardedOperation { createBandalart() }
+                                        runRewardedOperation { createBandalart(pending.templateId) }
                                             .onFailure { exception ->
                                                 Napier.e("Failed to create rewarded bandalart", exception, tag = "RewardedAd")
                                             }.getOrDefault(false)
                                 }
                             }
                         } finally {
+                            pendingCreationTemplateId = null
                             rewardedCreateCoordinator.grantFinished(
                                 wasCreated = created,
                                 expectedCount = expectedCount,
@@ -638,7 +650,7 @@ class HomePresenter(
                         var created = false
                         try {
                             created =
-                                runRewardedOperation { createBandalart() }
+                                runRewardedOperation { createBandalart(pendingRewardedCreation.templateId) }
                                     .onFailure { exception ->
                                         Napier.e("Failed to recover rewarded bandalart", exception, tag = "RewardedAd")
                                     }.getOrDefault(false)
@@ -782,6 +794,17 @@ class HomePresenter(
                 }
 
                 HomeScreen.Event.AddBandalart -> scope.launch { requestCreateBandalart() }
+                HomeScreen.Event.OpenBandalartCreationOptions -> {
+                    val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.BandalartList
+                    currentSheet?.let { bottomSheet = it.copy(isCreationOptionsVisible = true) }
+                }
+                HomeScreen.Event.CloseBandalartCreationOptions -> {
+                    val currentSheet = bottomSheet as? HomeScreen.BottomSheetState.BandalartList
+                    currentSheet?.let { bottomSheet = it.copy(isCreationOptionsVisible = false) }
+                }
+                is HomeScreen.Event.CreateBandalartFromTemplate -> {
+                    scope.launch { requestCreateBandalart(event.templateId) }
+                }
                 HomeScreen.Event.ConfirmRewardedCreate -> confirmRewardedCreate()
                 is HomeScreen.Event.RewardedAdFinished -> {
                     finishRewardedAd(event.requestId, event.result)
@@ -829,6 +852,7 @@ class HomePresenter(
                 HomeScreen.Event.DismissDialog -> {
                     if (dialog == HomeScreen.DialogState.RewardedCreate) {
                         rewardedCreateCoordinator.dismissDialog()
+                        pendingCreationTemplateId = null
                     }
                     dialog = null
                 }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartListBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartListBottomSheet.kt
@@ -31,9 +31,14 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.AddCircle
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Email
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -41,21 +46,35 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import bandalart.core.designsystem.generated.resources.Res
 import bandalart.core.designsystem.generated.resources.add_description
+import bandalart.core.designsystem.generated.resources.back_description
+import bandalart.core.designsystem.generated.resources.bandalart_create_direct_summary
+import bandalart.core.designsystem.generated.resources.bandalart_create_direct_title
+import bandalart.core.designsystem.generated.resources.bandalart_create_template_request
+import bandalart.core.designsystem.generated.resources.bandalart_create_template_section
+import bandalart.core.designsystem.generated.resources.bandalart_create_title
 import bandalart.core.designsystem.generated.resources.bandalart_list_add
 import bandalart.core.designsystem.generated.resources.bandalart_list_title
 import bandalart.core.designsystem.generated.resources.clear_description
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
+import com.nexters.bandalart.core.domain.template.BandalartTemplate
+import com.nexters.bandalart.core.domain.template.BandalartTemplateCatalog
 import com.nexters.bandalart.feature.home.model.BandalartUiModel
 import com.nexters.bandalart.feature.home.model.dummy.dummyBandalartList
 import com.nexters.bandalart.feature.home.HomeScreen
@@ -69,6 +88,7 @@ import androidx.compose.ui.tooling.preview.Preview
 fun BandalartListBottomSheet(
     bandalartList: ImmutableList<BandalartUiModel>,
     currentBandalartId: Long,
+    isCreationOptionsVisible: Boolean,
     onHomeUiAction: (HomeScreen.Event) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -97,8 +117,32 @@ fun BandalartListBottomSheet(
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp),
             ) {
+                if (isCreationOptionsVisible) {
+                    IconButton(
+                        modifier =
+                            Modifier
+                                .align(Alignment.CenterStart)
+                                .size(48.dp),
+                        onClick = {
+                            onHomeUiAction(HomeScreen.Event.CloseBandalartCreationOptions)
+                        },
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(Res.string.back_description),
+                            tint = MaterialTheme.colorScheme.onSurface,
+                        )
+                    }
+                }
                 Text(
-                    text = stringResource(Res.string.bandalart_list_title),
+                    text =
+                        stringResource(
+                            if (isCreationOptionsVisible) {
+                                Res.string.bandalart_create_title
+                            } else {
+                                Res.string.bandalart_list_title
+                            },
+                        ),
                     color = MaterialTheme.colorScheme.onSurface,
                     fontSize = 16.sp,
                     fontWeight = FontWeight.W700,
@@ -122,63 +166,216 @@ fun BandalartListBottomSheet(
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(40.dp))
-            LazyColumn(
-                modifier = Modifier.padding(horizontal = 20.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-                contentPadding = PaddingValues(bottom = 24.dp),
-            ) {
-                items(
-                    count = bandalartList.size,
-                    key = { index -> bandalartList[index].id },
-                ) { index ->
-                    val bandalartItem = bandalartList[index]
-                    BandalartListItem(
-                        bandalartItem = bandalartItem,
-                        currentBandalartId = currentBandalartId,
-                        onClick = { key ->
-                            // 앱에 진입할때 가장 최근에 확인한 표가 화면에 보여지도록
-                            onHomeUiAction(HomeScreen.Event.SelectBandalart(key))
-                        },
-                    )
-                }
-                item {
-                    Spacer(modifier = Modifier.height(20.dp))
+            Spacer(modifier = Modifier.height(if (isCreationOptionsVisible) 24.dp else 40.dp))
+            if (isCreationOptionsVisible) {
+                BandalartCreationOptions(
+                    onHomeUiAction = onHomeUiAction,
+                )
+            } else {
+                BandalartList(
+                    bandalartList = bandalartList,
+                    currentBandalartId = currentBandalartId,
+                    onHomeUiAction = onHomeUiAction,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BandalartList(
+    bandalartList: ImmutableList<BandalartUiModel>,
+    currentBandalartId: Long,
+    onHomeUiAction: (HomeScreen.Event) -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.padding(horizontal = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(bottom = 24.dp),
+    ) {
+        items(
+            count = bandalartList.size,
+            key = { index -> bandalartList[index].id },
+        ) { index ->
+            val bandalartItem = bandalartList[index]
+            BandalartListItem(
+                bandalartItem = bandalartItem,
+                currentBandalartId = currentBandalartId,
+                onClick = { key ->
+                    onHomeUiAction(HomeScreen.Event.SelectBandalart(key))
+                },
+            )
+        }
+        item {
+            Spacer(modifier = Modifier.height(20.dp))
+            Row {
+                Button(
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .height(56.dp)
+                            .padding(horizontal = 24.dp),
+                    onClick = {
+                        onHomeUiAction(HomeScreen.Event.OpenBandalartCreationOptions)
+                    },
+                    colors =
+                        ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        ),
+                ) {
                     Row {
-                        Button(
-                            modifier =
-                                Modifier
-                                    .weight(1f)
-                                    .height(56.dp)
-                                    .padding(horizontal = 24.dp),
-                            onClick = {
-                                onHomeUiAction(HomeScreen.Event.AddBandalart)
-                            },
-                            colors =
-                                ButtonDefaults.buttonColors(
-                                    containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                                    contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                ),
-                        ) {
-                            Row {
-                                Icon(
-                                    imageVector = Icons.Default.Add,
-                                    contentDescription = stringResource(Res.string.add_description),
-                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    modifier = Modifier.size(20.dp),
-                                )
-                                Spacer(modifier = Modifier.padding(start = 4.dp))
-                                Text(
-                                    text = stringResource(Res.string.bandalart_list_add),
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                    fontSize = 16.sp,
-                                    fontWeight = FontWeight.W600,
-                                )
-                            }
-                        }
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = stringResource(Res.string.add_description),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(20.dp),
+                        )
+                        Spacer(modifier = Modifier.padding(start = 4.dp))
+                        Text(
+                            text = stringResource(Res.string.bandalart_list_add),
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.W600,
+                        )
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun BandalartCreationOptions(onHomeUiAction: (HomeScreen.Event) -> Unit) {
+    LazyColumn(
+        modifier = Modifier.padding(horizontal = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(bottom = 24.dp),
+    ) {
+        item {
+            CreationOptionRow(
+                icon = {
+                    Icon(
+                        imageVector = Icons.Default.AddCircle,
+                        contentDescription = null,
+                        modifier = Modifier.size(32.dp),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                },
+                title = stringResource(Res.string.bandalart_create_direct_title),
+                summary = stringResource(Res.string.bandalart_create_direct_summary),
+                onClick = { onHomeUiAction(HomeScreen.Event.AddBandalart) },
+            )
+        }
+        item {
+            Text(
+                text = stringResource(Res.string.bandalart_create_template_section),
+                modifier = Modifier.padding(top = 12.dp, bottom = 4.dp),
+                color = MaterialTheme.colorScheme.onSurface,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.W700,
+            )
+        }
+        items(
+            items = BandalartTemplateCatalog.templates,
+            key = { template -> template.id.storedValue },
+        ) { template ->
+            TemplateOptionRow(
+                template = template,
+                onClick = {
+                    onHomeUiAction(HomeScreen.Event.CreateBandalartFromTemplate(template.id))
+                },
+            )
+        }
+        item {
+            TextButton(
+                onClick = { onHomeUiAction(HomeScreen.Event.ContactSupport) },
+                modifier = Modifier.fillMaxWidth().height(52.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Email,
+                    contentDescription = null,
+                    modifier = Modifier.size(20.dp),
+                )
+                Spacer(modifier = Modifier.size(8.dp))
+                Text(text = stringResource(Res.string.bandalart_create_template_request))
+            }
+        }
+    }
+}
+
+@Composable
+private fun TemplateOptionRow(
+    template: BandalartTemplate,
+    onClick: () -> Unit,
+) {
+    CreationOptionRow(
+        icon = {
+            Text(
+                text = template.profileEmoji,
+                fontSize = 28.sp,
+                textAlign = TextAlign.Center,
+            )
+        },
+        title = template.title,
+        summary = template.summary,
+        onClick = onClick,
+    )
+}
+
+@Composable
+private fun CreationOptionRow(
+    icon: @Composable () -> Unit,
+    title: String,
+    summary: String,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .semantics { role = Role.Button },
+        shape = MaterialTheme.shapes.large,
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+    ) {
+        Row(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier.size(40.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                icon()
+            }
+            Spacer(modifier = Modifier.size(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.W700,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = summary,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                modifier = Modifier.size(24.dp),
+            )
         }
     }
 }
@@ -191,6 +388,7 @@ private fun BandalartListBottomSheetPreview() {
         BandalartListBottomSheet(
             bandalartList = dummyBandalartList.toImmutableList(),
             currentBandalartId = 0L,
+            isCreationOptionsVisible = false,
             onHomeUiAction = {},
         )
     }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #208

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- 기존 반다라트 목록 bottom sheet에서 직접 만들기와 5개 템플릿을 선택하도록 구성했습니다.
- 부분 템플릿도 25칸 구조로 원자 생성하고, 생성 후 기존 셀 편집 흐름을 그대로 사용합니다.
- slot/rewarded-ad pending 상태에 template ID를 보존해 grant, fail-open, process recovery에서도 같은 템플릿을 생성합니다.
- 원하는 템플릿 요청은 기존 문의 메일 흐름으로 연결합니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 기능 설명 | <img src="링크" width="300" /> | 기능 설명 | <img src="링크" width="300" /> |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- v1은 미리보기나 생성 전 편집 없이 선택 즉시 새 보드를 만들며, 최초 catalog 내용은 한국어로 제공합니다.
- 광고 dismiss는 생성하지 않고, grant·SDK 실패 fail-open·process recovery에서는 선택한 템플릿을 유지하는 부분을 중점적으로 확인해 주세요.
