### PR TITLE
fix: 이모지 카테고리 ripple 제거

### DIFF
--- a/core/ui/src/commonMain/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiPicker.kt
+++ b/core/ui/src/commonMain/kotlin/com/nexters/bandalart/core/ui/component/emoji/FluentEmojiPicker.kt
@@ -17,6 +17,7 @@
 package com.nexters.bandalart.core.ui.component.emoji
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -338,6 +339,7 @@ private fun EmojiCategoryRow(
         ) { tab ->
             val selected = selectedCategory == tab.category
             val label = categoryLabel(tab.category)
+            val interactionSource = remember { MutableInteractionSource() }
 
             Box(
                 modifier =
@@ -345,6 +347,8 @@ private fun EmojiCategoryRow(
                         .size(48.dp)
                         .selectable(
                             selected = selected,
+                            interactionSource = interactionSource,
+                            indication = null,
                             role = Role.Tab,
                             onClick = { onCategorySelect(tab.category) },
                         ).semantics(mergeDescendants = true) {


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #212

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- 이모지 picker 카테고리 탭의 ripple indication을 제거했습니다.
- 선택된 탭의 배경·아이콘 상태, 48dp 터치 영역과 `Role.Tab` 접근성 semantics는 유지했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 기능 설명 | <img src="링크" width="300" /> | 기능 설명 | <img src="링크" width="300" /> |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- category tab의 click 동작과 선택 상태는 유지하고 시각적 ripple만 제거했습니다.
