### PR TITLE
fix: iOS 프로파일 만료일 검증 수정

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -233,6 +233,7 @@ jobs:
                     "$RUNNER_TEMP/actionlint" .github/workflows/android-ci.yml .github/workflows/release-cd.yml
                     bundle exec ruby fastlane/test/app_store_connect_builds_test.rb
                     bundle exec ruby fastlane/test/plist_file_test.rb
+                    bundle exec ruby fastlane/test/provisioning_profile_test.rb
                     python3 -m unittest scripts.tests.test_play_release_scripts
                     bundle exec fastlane lanes
                     xmllint --noout iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,6 +9,7 @@ require "tmpdir"
 
 require_relative "lib/app_store_connect_builds"
 require_relative "lib/plist_file"
+require_relative "lib/provisioning_profile"
 
 default_platform(:android)
 
@@ -92,7 +93,7 @@ end
 def verify_profile!(profile)
   name = profile["Name"]
   uuid = profile["UUID"]
-  expires_at = profile["ExpirationDate"]
+  expires_at = Bandalart::ProvisioningProfile.expiration_time(profile)
   team_ids = profile["TeamIdentifier"] || []
   application_identifier = profile.dig("Entitlements", "application-identifier")
 

--- a/fastlane/lib/provisioning_profile.rb
+++ b/fastlane/lib/provisioning_profile.rb
@@ -1,0 +1,11 @@
+module Bandalart
+  class ProvisioningProfile
+    def self.expiration_time(profile)
+      value = profile["ExpirationDate"]
+      return value if value.is_a?(Time)
+      return value.to_time if value.respond_to?(:to_time)
+
+      nil
+    end
+  end
+end

--- a/fastlane/test/provisioning_profile_test.rb
+++ b/fastlane/test/provisioning_profile_test.rb
@@ -1,0 +1,14 @@
+require "date"
+
+require_relative "../lib/provisioning_profile"
+
+parsed_expiration = DateTime.new(2027, 8, 10, 0, 0, 0, "+0")
+profile = { "ExpirationDate" => parsed_expiration }
+
+expiration_time = Bandalart::ProvisioningProfile.expiration_time(profile)
+raise "expiration should normalize to Time" unless expiration_time.is_a?(Time)
+raise "expiration instant changed during normalization" unless expiration_time.to_i == parsed_expiration.to_time.to_i
+raise "Time values should remain unchanged" unless Bandalart::ProvisioningProfile.expiration_time("ExpirationDate" => expiration_time).equal?(expiration_time)
+raise "missing expiration should stay nil" unless Bandalart::ProvisioningProfile.expiration_time({}).nil?
+
+puts "ProvisioningProfile expiration normalization test passed"


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Refs #113
- Failed run: https://github.com/Nexters/BandalArt-KMP/actions/runs/31330565110

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- plist gem이 프로비저닝 프로파일 만료일을 `DateTime`으로 반환하는 경우 `Time.now`와 직접 비교하던 실패를 수정합니다.
- 만료일을 동일한 instant의 `Time`으로 정규화한 후 기존 만료 검증을 유지합니다.
- DateTime 변환·Time passthrough·누락 값 회귀 테스트를 Release CD validation에 연결합니다.

## 🧪 테스트 내역 (선택)

- [x] `ruby fastlane/test/provisioning_profile_test.rb`
- [x] `ruby -c fastlane/Fastfile`
- [x] `git diff --check`
- [x] 독립 Standards/release safety 리뷰 승인
- [ ] GitHub Actions Android CI

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 해당 없음 | Release validation hotfix | 해당 없음 | - |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- CI 성공 및 merge 후 최신 main에서 iOS-only Release CD를 다시 실행합니다.
