### PR TITLE
fix: iOS 서명 프로파일 적용 범위 수정

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -234,6 +234,7 @@ jobs:
                     bundle exec ruby fastlane/test/app_store_connect_builds_test.rb
                     bundle exec ruby fastlane/test/plist_file_test.rb
                     bundle exec ruby fastlane/test/provisioning_profile_test.rb
+                    bundle exec ruby fastlane/test/signing_configuration_test.rb
                     python3 -m unittest scripts.tests.test_play_release_scripts
                     bundle exec fastlane lanes
                     xmllint --noout iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -326,12 +326,6 @@ platform :ios do
       archive_path: File.join(output_directory, "BandalArt.xcarchive"),
       disable_package_automatic_updates: true,
       skip_profile_detection: true,
-      xcargs: [
-        "CODE_SIGN_STYLE=Manual",
-        "DEVELOPMENT_TEAM=#{IOS_TEAM_ID}",
-        "CODE_SIGN_IDENTITY=#{Shellwords.escape("Apple Distribution")}",
-        "PROVISIONING_PROFILE_SPECIFIER=#{Shellwords.escape(profile_name)}",
-      ].join(" "),
       export_options: {
         method: "app-store",
         signingStyle: "manual",

--- a/fastlane/test/signing_configuration_test.rb
+++ b/fastlane/test/signing_configuration_test.rb
@@ -1,0 +1,11 @@
+fastfile = File.read(File.expand_path("../Fastfile", __dir__))
+
+if fastfile.include?("PROVISIONING_PROFILE_SPECIFIER=")
+  raise "provisioning profile must not be passed globally to Swift Package targets"
+end
+
+unless fastfile.include?("provisioningProfiles: { IOS_BUNDLE_ID => profile_name }")
+  raise "app bundle provisioning profile mapping is missing"
+end
+
+puts "iOS signing profile scope test passed"


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Refs #113
- Failed run: https://github.com/Nexters/BandalArt-KMP/actions/runs/31331533186

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- 앱용 provisioning profile을 모든 Swift Package target에 전파하던 전역 signing `xcargs`를 제거합니다.
- 앱 bundle ID와 App Store profile의 manual export mapping은 유지합니다.
- 전역 profile override 재도입과 app bundle mapping 누락을 차단하는 Release CD validation을 추가합니다.

## 🧪 테스트 내역 (선택)

- [x] `ruby fastlane/test/signing_configuration_test.rb`
- [x] `ruby -c fastlane/Fastfile`
- [x] `git diff --check`
- [x] 독립 signing/release safety 리뷰 승인
- [ ] GitHub Actions Android CI

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 해당 없음 | Release signing hotfix | 해당 없음 | - |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- CI 성공 및 merge 후 최신 main에서 iOS-only Release CD를 다시 실행합니다.
