### PR TITLE
fix: iOS 앱 타깃 서명 설정 추가

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -312,11 +312,22 @@ platform :ios do
       log_output: false,
     )
     installed_profile_path = install_provisioning_profile(path: profile_path)
+    project_path = File.join(REPO_ROOT, "iosApp/iosApp.xcodeproj")
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: project_path,
+      team_id: IOS_TEAM_ID,
+      targets: ["iosApp"],
+      build_configurations: ["Release"],
+      code_sign_identity: "Apple Distribution",
+      profile_name: profile_name,
+      bundle_identifier: IOS_BUNDLE_ID,
+    )
 
     output_directory = File.join(REPO_ROOT, "build/ios-release")
     FileUtils.rm_rf(output_directory)
     ipa_path = build_app(
-      project: File.join(REPO_ROOT, "iosApp/iosApp.xcodeproj"),
+      project: project_path,
       scheme: "iosApp",
       configuration: "Release",
       clean: true,

--- a/fastlane/test/signing_configuration_test.rb
+++ b/fastlane/test/signing_configuration_test.rb
@@ -8,4 +8,12 @@ unless fastfile.include?("provisioningProfiles: { IOS_BUNDLE_ID => profile_name 
   raise "app bundle provisioning profile mapping is missing"
 end
 
+unless fastfile.include?('targets: ["iosApp"]')
+  raise "manual signing must be scoped to the iosApp target"
+end
+
+unless fastfile.include?('build_configurations: ["Release"]')
+  raise "manual signing must be scoped to the Release configuration"
+end
+
 puts "iOS signing profile scope test passed"


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Refs #113
- Failed run: https://github.com/Nexters/BandalArt-KMP/actions/runs/31332310643

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- archive 전에 `iosApp` target의 `Release` 구성만 manual App Store signing으로 설정합니다.
- Team, bundle ID, Apple Distribution identity와 설치된 profile name을 앱 target에만 적용합니다.
- Swift Package targets에는 signing profile을 전파하지 않고 기존 export bundle mapping을 유지합니다.

## 🧪 테스트 내역 (선택)

- [x] `ruby fastlane/test/signing_configuration_test.rb`
- [x] `ruby -c fastlane/Fastfile`
- [x] `git diff --check`
- [x] Fastlane 2.237.0 source 기반 독립 signing 리뷰 승인
- [ ] GitHub Actions Android CI

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 해당 없음 | Release signing hotfix | 해당 없음 | - |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- CI 성공 및 merge 후 최신 main에서 iOS-only Release CD를 재실행합니다.
