### PR TITLE
fix: 업데이트 강제 정책을 배포 우선순위로 분리

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -235,6 +235,7 @@ jobs:
                     bundle exec ruby fastlane/test/plist_file_test.rb
                     bundle exec ruby fastlane/test/provisioning_profile_test.rb
                     bundle exec ruby fastlane/test/signing_configuration_test.rb
+                    bundle exec ruby fastlane/test/android_update_priority_test.rb
                     python3 -m unittest scripts.tests.test_play_release_scripts
                     bundle exec fastlane lanes
                     xmllint --noout iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme

--- a/.github/workflows/release-cd.yml
+++ b/.github/workflows/release-cd.yml
@@ -17,6 +17,18 @@ on:
                 required: true
                 default: false
                 type: boolean
+            android_update_priority:
+                description: Android in-app update priority (0=normal, 4-5=mandatory)
+                required: true
+                default: '0'
+                type: choice
+                options:
+                    - '0'
+                    - '1'
+                    - '2'
+                    - '3'
+                    - '4'
+                    - '5'
 
 concurrency:
     group: release-cd
@@ -40,9 +52,14 @@ jobs:
                 env:
                     RELEASE_REF: ${{ github.ref }}
                     RELEASE_CONFIRMED: ${{ inputs.confirm_release }}
+                    ANDROID_UPDATE_PRIORITY: ${{ inputs.android_update_priority }}
                 run: |
                     test "$RELEASE_REF" = "refs/heads/main"
                     test "$RELEASE_CONFIRMED" = "true"
+                    case "$ANDROID_UPDATE_PRIORITY" in
+                        0|1|2|3|4|5) ;;
+                        *) exit 1 ;;
+                    esac
 
     android:
         name: Play Internal Testing
@@ -125,6 +142,7 @@ jobs:
                     PLAY_SERVICE_ACCOUNT_PATH: ${{ github.workspace }}/playstore/service-account-key.json
                     ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/bandalart-upload.jks
                     BUNDLETOOL_JAR: ${{ runner.temp }}/bundletool-all-1.18.3.jar
+                    ANDROID_UPDATE_PRIORITY: ${{ inputs.android_update_priority }}
                 run: bundle exec fastlane android internal
 
             -   name: Remove Android credentials

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -90,6 +90,7 @@ play {
     }
     track.set("internal")
     releaseStatus.set(ReleaseStatus.COMPLETED)
+    updatePriority.set(0)
     defaultToAppBundles.set(true)
 }
 

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/MainActivity.kt
@@ -32,7 +32,7 @@ import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.appupdate.AppUpdateOptions
 import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.UpdateAvailability
-import com.nexters.bandalart.core.common.utils.isImmediateUpdate
+import com.nexters.bandalart.core.common.utils.isMandatoryUpdate
 import io.github.aakira.napier.Napier
 
 class MainActivity : ComponentActivity() {
@@ -89,10 +89,7 @@ class MainActivity : ComponentActivity() {
 
                     appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
                         appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE) &&
-                        isImmediateUpdate(
-                            currentVersionCode = currentVersionCode(),
-                            availableVersionCode = appUpdateInfo.availableVersionCode(),
-                        ) -> {
+                        isMandatoryUpdate(appUpdateInfo.updatePriority()) -> {
                         startImmediateUpdate(appUpdateInfo)
                     }
                 }
@@ -126,10 +123,4 @@ class MainActivity : ComponentActivity() {
             )
         }
     }
-
-    private fun currentVersionCode(): Int =
-        packageManager
-            .getPackageInfo(packageName, 0)
-            .longVersionCode
-            .toInt()
 }

--- a/core/common/src/androidHostTest/kotlin/com/nexters/bandalart/core/common/utils/InAppUpdatePolicyTest.kt
+++ b/core/common/src/androidHostTest/kotlin/com/nexters/bandalart/core/common/utils/InAppUpdatePolicyTest.kt
@@ -22,44 +22,23 @@ import org.junit.jupiter.api.Test
 
 class InAppUpdatePolicyTest {
     @Test
-    fun patchUpdateUsesFlexibleFlow() {
-        assertFalse(
-            isImmediateUpdate(
-                currentVersionCode = 20206,
-                availableVersionCode = 20299,
-            ),
-        )
+    fun priorityBelowFourUsesFlexibleFlow() {
+        assertFalse(isMandatoryUpdate(updatePriority = 0))
+        assertFalse(isMandatoryUpdate(updatePriority = 3))
     }
 
     @Test
-    fun minorAndMajorUpdatesUseImmediateFlow() {
-        assertTrue(
-            isImmediateUpdate(
-                currentVersionCode = 20206,
-                availableVersionCode = 20300,
-            ),
-        )
-        assertTrue(
-            isImmediateUpdate(
-                currentVersionCode = 20206,
-                availableVersionCode = 30000,
-            ),
-        )
+    fun priorityFourOrHigherUsesImmediateFlow() {
+        assertTrue(isMandatoryUpdate(updatePriority = 4))
+        assertTrue(isMandatoryUpdate(updatePriority = 5))
     }
 
     @Test
-    fun sameOrOlderVersionDoesNotStartImmediateFlow() {
-        assertFalse(
-            isImmediateUpdate(
-                currentVersionCode = 20206,
-                availableVersionCode = 20206,
-            ),
-        )
-        assertFalse(
-            isImmediateUpdate(
-                currentVersionCode = 20206,
-                availableVersionCode = 20199,
-            ),
-        )
+    fun semanticVersionDoesNotAffectMandatoryPolicy() {
+        val minorFeaturePriority = 0
+        val patchHotfixPriority = 4
+
+        assertFalse(isMandatoryUpdate(updatePriority = minorFeaturePriority))
+        assertTrue(isMandatoryUpdate(updatePriority = patchHotfixPriority))
     }
 }

--- a/core/common/src/commonMain/kotlin/com/nexters/bandalart/core/common/utils/InAppUpdate.kt
+++ b/core/common/src/commonMain/kotlin/com/nexters/bandalart/core/common/utils/InAppUpdate.kt
@@ -16,14 +16,6 @@
 
 package com.nexters.bandalart.core.common.utils
 
-fun isImmediateUpdate(
-    currentVersionCode: Int,
-    availableVersionCode: Int,
-): Boolean {
-    val availableMajor = availableVersionCode / 10_000
-    val availableMinor = (availableVersionCode % 10_000) / 100
-    val currentMajor = currentVersionCode / 10_000
-    val currentMinor = (currentVersionCode % 10_000) / 100
+const val MANDATORY_UPDATE_PRIORITY_THRESHOLD = 4
 
-    return availableMajor > currentMajor || availableMinor > currentMinor
-}
+fun isMandatoryUpdate(updatePriority: Int): Boolean = updatePriority >= MANDATORY_UPDATE_PRIORITY_THRESHOLD

--- a/docs/features/updates/IN_APP_UPDATE_FOREGROUND_STRATEGY.md
+++ b/docs/features/updates/IN_APP_UPDATE_FOREGROUND_STRATEGY.md
@@ -1,4 +1,4 @@
-# In-App Update foreground 보강 전략
+# In-App Update foreground·priority 정책 전략
 
 - 관련 이슈: #186
 - 기준 브랜치: `main`
@@ -13,13 +13,18 @@
 
 앱 프로세스가 살아 있는 상태에서 사용자가 다른 앱으로 이동했다가 돌아왔을 때 새 minor/major 업데이트가 배포되면, `Splash`는 이미 back stack에서 제거돼 Immediate Update를 다시 검사하지 않는다. `Home`의 검사는 해당 버전을 의도적으로 Flexible 대상에서 제외하므로 아무 flow도 시작하지 않는다.
 
+PR #215에서 foreground 누락은 보강했지만 강제 여부는 여전히 versionCode의 major/minor에 묶여 있다. 이 상태에서는 일반 minor 기능도 강제 업데이트가 되고, 긴급 patch는 선택 업데이트가 된다. semantic version은 변경 범위를 표현하고 강제 여부는 운영 긴급도를 표현하므로 두 책임을 분리해야 한다.
+
 ## 성공 기준
 
 - 새 프로세스의 cold start에서는 기존 Splash Immediate Update UX를 유지한다.
 - 프로세스가 살아 있는 앱이 foreground로 복귀할 때 화면 위치와 관계없이 Immediate Update를 검사한다.
 - 진행 중인 Immediate Update가 있으면 공식 가이드대로 복귀 시 재개한다.
-- patch Flexible Update의 안내 bottom sheet, 다운로드, 설치 Snackbar 동작은 변경하지 않는다.
+- Flexible Update의 안내 bottom sheet, 다운로드, 설치 Snackbar 동작은 변경하지 않는다.
 - 동일 resume에서 update flow를 중복 실행하지 않는다.
+- major/minor/patch와 무관하게 Play release priority만으로 강제 여부를 결정한다.
+- 일반 배포는 priority `0`, 긴급 업데이트만 priority `4` 이상으로 게시한다.
+- 배포 후 exact versionCode·track·status뿐 아니라 priority도 Play API로 검증한다.
 
 ## 결정
 
@@ -32,6 +37,8 @@
 - 이미 Internal Testing으로 검증한 Home Flexible Update UI와 거절 이력 저장 경로를 변경하지 않는다.
 - Splash의 최초 차단 UX를 유지하면서 관측된 누락만 작게 보강한다.
 
+강제 여부의 유일한 입력은 Play Core `AppUpdateInfo.updatePriority()`로 둔다. 공통 정책 함수는 priority `4` 이상을 mandatory로 변환하고, Splash·Activity·Home은 versionCode의 자릿수를 해석하지 않는다. versionCode는 업데이트 후보 식별과 거절 이력에만 사용한다.
+
 ## 상태 우선순위
 
 `MainActivity.onResume()`에서 최초 fresh launch를 제외하고 새 `AppUpdateInfo`를 조회한 뒤 다음 순서를 적용한다.
@@ -39,9 +46,9 @@
 1. `DEVELOPER_TRIGGERED_UPDATE_IN_PROGRESS`
    - Immediate Update flow를 재개한다.
 2. `UPDATE_AVAILABLE`
-   - 현재/신규 versionCode의 major 또는 minor가 달라지고 Immediate가 허용되면 flow를 시작한다.
+   - `updatePriority() >= 4`이고 Immediate가 허용되면 flow를 시작한다.
 3. 그 외
-   - 아무 작업도 하지 않는다. patch Flexible Update는 Home의 기존 effect가 담당한다.
+   - 아무 작업도 하지 않는다. priority `0..3`인 선택 업데이트는 Home의 기존 effect가 담당한다.
 
 fresh launch의 첫 `onResume`은 Splash가 이미 최초 검사를 담당하므로 Activity 검사를 생략한다. saved instance state가 있는 복원 진입은 Splash가 현재 화면이라는 보장이 없으므로 첫 resume부터 검사한다.
 
@@ -59,9 +66,9 @@ sequenceDiagram
     Activity->>Activity: fresh launch의 첫 onResume 검사 생략
     Activity->>Splash: Circuit Splash 표시
     Splash->>Play: 최신 AppUpdateInfo 조회
-    Play-->>Splash: availability, versionCode, allowed type
+    Play-->>Splash: availability, priority, allowed type
 
-    alt minor/major 업데이트이며 Immediate 허용
+    alt priority 4 이상이며 Immediate 허용
         Splash->>Play: Immediate Update 시작
         alt 사용자가 취소
             Play-->>Splash: RESULT_CANCELED
@@ -72,7 +79,7 @@ sequenceDiagram
     else 강제 업데이트 대상 아님
         Splash->>Home: 온보딩 상태 확인 후 화면 이동
         Home->>Play: Home RESUMED 시 AppUpdateInfo 조회
-        alt patch 업데이트이며 Flexible 허용
+        alt priority 0..3이며 Flexible 허용
             Play-->>Home: 선택 업데이트 가능
             Home-->>User: 업데이트 안내 bottom sheet
             alt 사용자가 업데이트 진행 선택
@@ -97,7 +104,7 @@ sequenceDiagram
 
     alt Immediate Update 진행 중
         Activity->>Play: Immediate Update flow 재개
-    else 새 minor/major 업데이트이며 Immediate 허용
+    else 새 priority 4 이상 업데이트이며 Immediate 허용
         Activity->>Play: Immediate Update 시작
         alt 사용자가 취소
             Play-->>Activity: RESULT_CANCELED
@@ -105,16 +112,35 @@ sequenceDiagram
         else 업데이트 완료
             Play-->>Activity: 설치 후 앱 재시작
         end
-    else patch 업데이트 또는 업데이트 없음
+    else priority 0..3 업데이트 또는 업데이트 없음
         Activity->>Activity: Immediate coordinator는 no-op
         opt Home이 현재 화면
             Home->>Play: 기존 Flexible Update 검사
-            Play-->>Home: patch면 선택 업데이트 안내
+            Play-->>Home: 선택 업데이트 안내
         end
     end
 ```
 
-핵심은 cold start의 차단 책임은 Splash, 실행 중 foreground 복귀의 강제 업데이트 책임은 Activity, patch 선택 업데이트와 설치 완료 UI는 Home이 갖는 것이다.
+핵심은 cold start의 차단 책임은 Splash, 실행 중 foreground 복귀의 강제 업데이트 책임은 Activity, priority가 낮은 선택 업데이트와 설치 완료 UI는 Home이 갖는 것이다.
+
+## 배포 priority 계약
+
+- Release CD의 Android 입력은 `0..5` 중 하나를 명시한다.
+- 기본값은 `0`이며 일반 기능·patch 배포 모두 선택 업데이트다.
+- 긴급 차단이 필요한 release만 `4` 또는 `5`를 명시한다.
+- Gradle Play Publisher에도 안전한 기본값 `0`을 고정하고, workflow가 선택한 값은 publish task의 `--update-priority`로 전달한다.
+- 업로드 전 source SHA·versionCode·track·status와 함께 선택한 priority를 출력한다.
+- 업로드 후 Play Developer API의 exact internal release에서 `inAppUpdatePriority`를 다시 읽어 기대값과 일치해야 성공으로 처리한다. API 응답에서 priority가 생략된 경우 기본값 `0`으로 해석한다.
+- Play는 rollout 뒤 priority 변경을 허용하지 않으므로, 사후 검증 실패를 기존 release 수정으로 우회하지 않고 새 versionCode로 재출시한다.
+
+## 전환 순서
+
+1. 현재 `2.2.x` line에 priority 기반 판정을 먼저 포함한다.
+2. 이 전환 버전은 priority `0`으로 Internal·Production에 배포한다.
+3. 기존 사용자의 전환 버전 보급을 확인한 뒤 `2.3.0` 같은 minor 기능 버전을 출시한다.
+4. 이후 semantic version은 기능 범위만, priority는 강제 여부만 표현한다.
+
+구버전은 여전히 major/minor 규칙을 사용하므로 전환 버전이 충분히 보급되기 전에 minor를 올리면 기존 사용자에게 Immediate flow가 표시될 수 있다.
 
 ## 중복·실패 정책
 
@@ -122,7 +148,7 @@ sequenceDiagram
 - update flow 시작 전마다 새 `AppUpdateInfo`를 사용한다.
 - Immediate 동의 화면을 사용자가 취소하면 기존 정책과 동일하게 Activity를 종료한다.
 - 조회 또는 flow 시작 실패는 기록하고 다음 foreground 복귀에서 재시도한다.
-- Remote Config kill switch, Play update priority/staleness 정책은 이번 범위에 추가하지 않는다.
+- Remote Config kill switch와 staleness 정책은 이번 범위에 추가하지 않는다.
 
 ## 코드 변경
 
@@ -131,29 +157,33 @@ sequenceDiagram
   - fresh launch 구분 및 foreground resume 검사
   - 진행 중/new Immediate Update 시작
 - `core/common/utils/InAppUpdate.kt`
-  - Splash/Home/Activity가 공유하는 versionCode 기반 Immediate 정책으로 정리
+  - Splash/Home/Activity가 공유하는 priority 기반 mandatory 정책과 임계값 정의
+- `ImmediateUpdateEffect.android.kt`, `MainActivity`, `FlexibleUpdateEffect.android.kt`
+  - versionCode major/minor 판정을 제거하고 `AppUpdateInfo.updatePriority()` 사용
+- `androidApp/build.gradle.kts`, `Fastfile`, Release CD workflow
+  - 일반 배포 기본 priority `0`, workflow 입력 전달, 업로드 전후 검증
+- `play_next_version_code.py`
+  - exact release의 versionCode·status·priority 검증
 - `ImmediateUpdateEffect.android.kt`
   - cold start 최초 검사만 유지
   - 진행 중 update 재개 책임은 Activity로 이동
-- Gradle
-  - `androidApp`에 `core:common`, Play app-update 의존성 명시
-- 테스트
-  - 공통 versionCode 정책의 patch/minor/major/same/downgrade 경계값 검증
 
 ## 검증
 
 ### 자동
 
-- 공통 업데이트 정책 단위 테스트
+- priority `0..3` 선택 업데이트, `4..5` 강제 업데이트 경계 테스트
+- minor priority `0`과 patch priority `4`가 versionCode와 무관하게 분류되는 회귀 테스트
+- Play API priority 생략=`0`, 일치·불일치 사후 검증 테스트
 - 기존 Home Presenter rejection 테스트
 - 기존 Splash Presenter 중복 navigation 테스트
 - Android 컴파일과 CI는 commit/push 단계에서 실행
 
 ### Internal Testing
 
-1. patch 버전: 기존 선택 업데이트 bottom sheet와 설치 Snackbar 유지
-2. minor 버전: cold start에서 Immediate Update 표시
-3. minor 버전 배포 전 앱 실행 → background → 배포 전파 후 foreground: Immediate Update 표시
+1. priority `0` minor 버전: 기존 선택 업데이트 bottom sheet와 설치 Snackbar 유지
+2. priority `4` patch 버전: cold start에서 Immediate Update 표시
+3. priority `4` 배포 전 앱 실행 → background → 배포 전파 후 foreground: Immediate Update 표시
 4. Immediate Update 진행 중 background/foreground: flow 재개
 5. Immediate Update 취소: 앱 종료
 6. Home 외 Onboarding/Complete 화면에서 foreground 복귀: Immediate Update 표시
@@ -161,5 +191,7 @@ sequenceDiagram
 ## 공식 참고
 
 - https://developer.android.com/guide/playcore/in-app-updates/kotlin-java
+- https://developer.android.com/reference/com/google/android/play/core/appupdate/AppUpdateInfo
+- https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks
 - `AppUpdateInfo`는 update flow 시작마다 새 인스턴스를 조회해야 한다.
 - Immediate Update가 진행 중이면 앱이 foreground로 돌아올 때 flow를 재개해야 한다.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -55,7 +55,13 @@ def android_version
   [name, code]
 end
 
-def play_version_check!(version_code, post_upload: false)
+def android_update_priority
+  raw_priority = required_env!("ANDROID_UPDATE_PRIORITY")
+  UI.user_error!("ANDROID_UPDATE_PRIORITY must be an integer from 0 to 5") unless raw_priority.match?(/\A[0-5]\z/)
+  raw_priority.to_i
+end
+
+def play_version_check!(version_code, update_priority:, post_upload: false)
   command = [
     "uv",
     "run",
@@ -70,6 +76,8 @@ def play_version_check!(version_code, post_upload: false)
       "internal",
       "--verify-status",
       "completed",
+      "--expect-update-priority",
+      update_priority.to_s,
       "--retries",
       "6",
     ]
@@ -177,16 +185,18 @@ platform :android do
     UI.user_error!("bundletool is missing") unless File.file?(bundletool_path)
 
     version_name, version_code = android_version
+    update_priority = android_update_priority
     source_sha = capture_command!("git", "rev-parse", "HEAD").strip
     UI.message("SOURCE_SHA=#{source_sha}")
     UI.message("PACKAGE=#{ANDROID_PACKAGE}")
     UI.message("Android release #{version_name} (#{version_code}) -> Play Internal Testing")
+    UI.message("IN_APP_UPDATE_PRIORITY=#{update_priority}")
     %w[ko-KR en-US ja-JP].each do |locale|
       notes_path = File.join(REPO_ROOT, "androidApp/src/main/play/release-notes", locale, "internal.txt")
       UI.message("RELEASE_NOTES[#{locale}]=#{File.read(notes_path).strip}")
     end
     UI.message("TASKS=clean :androidApp:bundleRelease -> :androidApp:publishReleaseBundle")
-    play_version_check!(version_code)
+    play_version_check!(version_code, update_priority: update_priority)
 
     gradle(
       task: "clean :androidApp:bundleRelease",
@@ -219,15 +229,15 @@ platform :android do
     checksum = Digest::SHA256.file(verified_aab).hexdigest
 
     verify_ci_source!
-    play_version_check!(version_code)
+    play_version_check!(version_code, update_priority: update_priority)
     gradle(
       task: ":androidApp:publishReleaseBundle",
       project_dir: REPO_ROOT,
       properties: { "bandalart.useTestAds" => "true" },
-      flags: "--artifact-dir #{Shellwords.escape(artifact_dir)} --no-configuration-cache --stacktrace",
+      flags: "--artifact-dir #{Shellwords.escape(artifact_dir)} --update-priority #{update_priority} --no-configuration-cache --stacktrace",
     )
     UI.user_error!("Uploaded AAB changed after validation") unless Digest::SHA256.file(verified_aab).hexdigest == checksum
-    play_version_check!(version_code, post_upload: true)
+    play_version_check!(version_code, update_priority: update_priority, post_upload: true)
     append_github_summary(
       [
         "## Android Play Internal Testing",
@@ -235,6 +245,7 @@ platform :android do
         "- Package: `#{ANDROID_PACKAGE}`",
         "- Version: `#{version_name} (#{version_code})`",
         "- Track/status: `internal / completed`",
+        "- In-app update priority: `#{update_priority}`",
         "- Result: verified upload",
       ],
     )

--- a/fastlane/test/android_update_priority_test.rb
+++ b/fastlane/test/android_update_priority_test.rb
@@ -1,0 +1,21 @@
+repo_root = File.expand_path("../..", __dir__)
+fastfile = File.read(File.join(repo_root, "fastlane/Fastfile"))
+workflow = File.read(File.join(repo_root, ".github/workflows/release-cd.yml"))
+android_build = File.read(File.join(repo_root, "androidApp/build.gradle.kts"))
+
+unless workflow.include?("android_update_priority:") &&
+    workflow.include?("ANDROID_UPDATE_PRIORITY: ${{ inputs.android_update_priority }}")
+  raise "Release CD must expose and forward the Android update priority"
+end
+
+unless android_build.include?("updatePriority.set(0)")
+  raise "Gradle Play Publisher must default normal releases to priority 0"
+end
+
+unless fastfile.include?('required_env!("ANDROID_UPDATE_PRIORITY")') &&
+    fastfile.include?("--update-priority") &&
+    fastfile.include?("--expect-update-priority")
+  raise "Fastlane must publish and verify the selected update priority"
+end
+
+puts "Android update priority release contract test passed"

--- a/feature/home/src/androidMain/kotlin/com/nexters/bandalart/feature/home/FlexibleUpdateEffect.android.kt
+++ b/feature/home/src/androidMain/kotlin/com/nexters/bandalart/feature/home/FlexibleUpdateEffect.android.kt
@@ -17,7 +17,6 @@
 package com.nexters.bandalart.feature.home
 
 import android.app.Activity
-import android.content.Context
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.SnackbarDuration
@@ -47,7 +46,7 @@ import com.google.android.play.core.install.InstallStateUpdatedListener
 import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.InstallStatus
 import com.google.android.play.core.install.model.UpdateAvailability
-import com.nexters.bandalart.core.common.utils.isImmediateUpdate
+import com.nexters.bandalart.core.common.utils.isMandatoryUpdate
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -130,7 +129,7 @@ internal fun FlexibleUpdateEffect(
 
                     appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
                         appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE) &&
-                        !isImmediateUpdate(context, appUpdateInfo.availableVersionCode()) -> {
+                        !isMandatoryUpdate(appUpdateInfo.updatePriority()) -> {
                         currentOnUpdateAvailable(appUpdateInfo.availableVersionCode())
                     }
                 }
@@ -148,7 +147,7 @@ internal fun FlexibleUpdateEffect(
                 appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
                     appUpdateInfo.availableVersionCode() == requestedVersionCode &&
                     appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE) &&
-                    !isImmediateUpdate(context, requestedVersionCode)
+                    !isMandatoryUpdate(appUpdateInfo.updatePriority())
 
             if (canStartUpdate) {
                 updateManager.startUpdateFlowForResult(
@@ -161,21 +160,6 @@ internal fun FlexibleUpdateEffect(
             Napier.e("Failed to start flexible update", exception, tag = "InAppUpdate")
         }
     }
-}
-
-private fun isImmediateUpdate(
-    context: Context,
-    availableVersionCode: Int,
-): Boolean {
-    val currentVersionCode =
-        context.packageManager
-            .getPackageInfo(context.packageName, 0)
-            .longVersionCode
-            .toInt()
-    return isImmediateUpdate(
-        currentVersionCode = currentVersionCode,
-        availableVersionCode = availableVersionCode,
-    )
 }
 
 @Suppress("TooGenericExceptionCaught")

--- a/feature/splash/src/androidMain/kotlin/com/nexters/bandalart/feature/splash/ImmediateUpdateEffect.android.kt
+++ b/feature/splash/src/androidMain/kotlin/com/nexters/bandalart/feature/splash/ImmediateUpdateEffect.android.kt
@@ -17,7 +17,6 @@
 package com.nexters.bandalart.feature.splash
 
 import android.app.Activity
-import android.content.Context
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResultLauncher
@@ -36,7 +35,7 @@ import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.appupdate.AppUpdateOptions
 import com.google.android.play.core.install.model.AppUpdateType
 import com.google.android.play.core.install.model.UpdateAvailability
-import com.nexters.bandalart.core.common.utils.isImmediateUpdate
+import com.nexters.bandalart.core.common.utils.isMandatoryUpdate
 import io.github.aakira.napier.Napier
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -64,7 +63,7 @@ internal actual fun ImmediateUpdateEffect(onComplete: () -> Unit) {
             val appUpdateInfo = appUpdateManager.appUpdateInfo.await()
             val canStartImmediateUpdate =
                 appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE &&
-                    isValidImmediateUpdate(context, appUpdateInfo.availableVersionCode()) &&
+                    isMandatoryUpdate(appUpdateInfo.updatePriority()) &&
                     appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)
 
             if (canStartImmediateUpdate) {
@@ -77,21 +76,6 @@ internal actual fun ImmediateUpdateEffect(onComplete: () -> Unit) {
             currentOnComplete()
         }
     }
-}
-
-private fun isValidImmediateUpdate(
-    context: Context,
-    availableVersionCode: Int,
-): Boolean {
-    val currentVersionCode =
-        context.packageManager
-            .getPackageInfo(context.packageName, 0)
-            .longVersionCode
-            .toInt()
-    return isImmediateUpdate(
-        currentVersionCode = currentVersionCode,
-        availableVersionCode = availableVersionCode,
-    )
 }
 
 private fun AppUpdateManager.startImmediateUpdate(

--- a/scripts/play_next_version_code.py
+++ b/scripts/play_next_version_code.py
@@ -24,6 +24,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--expect-version-code", type=int)
     parser.add_argument("--verify-track")
     parser.add_argument("--verify-status", default="completed")
+    parser.add_argument("--expect-update-priority", type=int)
     parser.add_argument("--retries", type=int, default=1)
     return parser.parse_args()
 
@@ -71,13 +72,22 @@ def expected_release_exists(
     track_name: str,
     version_code: int,
     status: str,
+    update_priority: Optional[int] = None,
 ) -> bool:
     for track in tracks:
         if track.get("track") != track_name:
             continue
         for release in track.get("releases", []):
             codes = {int(code) for code in release.get("versionCodes", []) or []}
-            if version_code in codes and release.get("status") == status:
+            actual_priority = int(release.get("inAppUpdatePriority", 0))
+            priority_matches = (
+                update_priority is None or actual_priority == update_priority
+            )
+            if (
+                version_code in codes
+                and release.get("status") == status
+                and priority_matches
+            ):
                 return True
     return False
 
@@ -86,6 +96,12 @@ def main() -> int:
     args = parse_args()
     if args.verify_track and args.expect_version_code is None:
         print("error: --verify-track requires --expect-version-code", file=sys.stderr)
+        return 2
+    if args.expect_update_priority is not None and not 0 <= args.expect_update_priority <= 5:
+        print("error: --expect-update-priority must be between 0 and 5", file=sys.stderr)
+        return 2
+    if args.expect_update_priority is not None and not args.verify_track:
+        print("error: --expect-update-priority requires --verify-track", file=sys.stderr)
         return 2
     if args.retries < 1:
         print("error: --retries must be at least 1", file=sys.stderr)
@@ -133,6 +149,7 @@ def main() -> int:
             args.verify_track,
             args.expect_version_code,
             args.verify_status,
+            args.expect_update_priority,
         ):
             break
         if attempt + 1 < args.retries:
@@ -141,7 +158,8 @@ def main() -> int:
         print(
             "error: expected release was not found on "
             f"{args.verify_track}: versionCode={args.expect_version_code}, "
-            f"status={args.verify_status}",
+            f"status={args.verify_status}, "
+            f"updatePriority={args.expect_update_priority}",
             file=sys.stderr,
         )
         return 1
@@ -163,7 +181,8 @@ def main() -> int:
         print(f"EXPECTED_VERSION_CODE={args.expect_version_code}")
     if args.verify_track:
         print(
-            f"VERIFIED={args.verify_track}:{args.expect_version_code}:{args.verify_status}"
+            f"VERIFIED={args.verify_track}:{args.expect_version_code}:"
+            f"{args.verify_status}:priority={args.expect_update_priority}"
         )
     return 0
 

--- a/scripts/tests/test_play_release_scripts.py
+++ b/scripts/tests/test_play_release_scripts.py
@@ -15,7 +15,11 @@ class PlayVersionTest(unittest.TestCase):
             {
                 "track": "internal",
                 "releases": [
-                    {"status": "completed", "versionCodes": ["20217"]},
+                    {
+                        "status": "completed",
+                        "versionCodes": ["20217"],
+                        "inAppUpdatePriority": 4,
+                    },
                 ],
             },
             {
@@ -39,6 +43,7 @@ class PlayVersionTest(unittest.TestCase):
                 "internal",
                 20217,
                 "completed",
+                4,
             )
         )
         self.assertFalse(
@@ -47,6 +52,29 @@ class PlayVersionTest(unittest.TestCase):
                 "internal",
                 20218,
                 "completed",
+                4,
+            )
+        )
+
+    def test_rejects_exact_release_with_wrong_update_priority(self) -> None:
+        self.assertFalse(
+            play_next_version_code.expected_release_exists(
+                self.tracks,
+                "internal",
+                20217,
+                "completed",
+                0,
+            )
+        )
+
+    def test_treats_missing_update_priority_as_zero(self) -> None:
+        self.assertTrue(
+            play_next_version_code.expected_release_exists(
+                self.tracks,
+                "production",
+                20213,
+                "completed",
+                0,
             )
         )
 


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #186

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- semantic version 자릿수와 강제 업데이트 판정을 분리하고 Play `updatePriority()` 4 이상만 Immediate로 처리합니다.
- Release CD에 Android update priority 입력을 추가하고 일반 배포 기본값을 0으로 고정했습니다.
- 업로드 후 exact Internal release의 versionCode·status·priority를 Play API로 함께 검증합니다.
- #186 전략 문서와 앱 정책·배포 wiring 회귀 테스트를 갱신했습니다.

## 🧪 테스트 내역 (선택)

- [x] `:core:common:testAndroidHostTest`, Home/Splash Android compile 통과
- [x] 변경 KMP 모듈 Detekt 통과
- [x] Python Play release script 테스트 9개 통과
- [x] actionlint와 Android update priority release 계약 테스트 통과
- [ ] Play Internal Testing에서 priority 0/4 cold·warm update flow 수동 검증

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 해당 없음 | UI 변경 없음 | 해당 없음 | UI 변경 없음 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 이번 PR은 #186의 priority 정책·배포 계약 범위이며, 앱 root 단일 coordinator로의 후속 통합은 umbrella 이슈에 남깁니다.
- 기존 설치본 전환을 위해 2.2.x에 먼저 반영하고, 충분히 보급된 뒤 minor version을 올려야 합니다.
