### PR TITLE
feat: Ding 알림 payload 디버깅 연동

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -111,7 +111,9 @@ dependencies {
     implementation(libs.cmptoast)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.napier)
-    debugImplementation(libs.ding)
+    debugImplementation(libs.ding) {
+        exclude(group = "com.google.firebase", module = "firebase-bom")
+    }
     "releaseImplementation"(libs.ding.noop)
     testImplementation(libs.bundles.android.unit.test)
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -111,6 +111,7 @@ dependencies {
     implementation(libs.cmptoast)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.napier)
+    debugImplementation(platform(libs.firebase.bom))
     debugImplementation(libs.ding) {
         exclude(group = "com.google.firebase", module = "firebase-bom")
     }

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -111,6 +111,8 @@ dependencies {
     implementation(libs.cmptoast)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.napier)
+    debugImplementation(libs.ding)
+    "releaseImplementation"(libs.ding.noop)
     testImplementation(libs.bundles.android.unit.test)
     testRuntimeOnly(libs.junit.jupiter.engine)
     "baselineProfile"(project(":baselineprofile"))

--- a/androidApp/src/debug/AndroidManifest.xml
+++ b/androidApp/src/debug/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-sdk tools:overrideLibrary="io.github.easyhooon.ding,io.github.easyhooon.ding.core" />
+
+</manifest>

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
@@ -30,6 +30,7 @@ import com.nexters.bandalart.di.metro.installAndroidDeadlineReminderInfrastructu
 import com.nexters.bandalart.di.metro.recordRewardedCreation
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
+import io.github.easyhooon.ding.Ding
 
 class BandalartApplication : Application() {
     lateinit var appGraph: AppGraph
@@ -47,9 +48,22 @@ class BandalartApplication : Application() {
                 bannerAdHost = bannerAdHost,
                 rewardedAdGateway = rewardedAdGateway,
             )
-        installAndroidDeadlineReminderInfrastructure(appGraph) { _, _ ->
-            Intent(this, DeadlineNotificationTrampolineActivity::class.java)
-        }
+        installAndroidDeadlineReminderInfrastructure(
+            appGraph = appGraph,
+            launchIntentFactory = { _, _ ->
+                Intent(this, DeadlineNotificationTrampolineActivity::class.java)
+            },
+            notificationCapture = { notificationId, title, body, data ->
+                Ding.captureNotification(
+                    context = this,
+                    source = "deadline-reminder",
+                    notificationId = notificationId,
+                    title = title,
+                    body = body,
+                    data = data,
+                )
+            },
+        )
         rewardedAdGateway.delegate =
             AndroidRewardedAdGateway(
                 application = this,

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
@@ -53,6 +53,12 @@ fun createAndroidAppGraph(
 fun installAndroidDeadlineReminderInfrastructure(
     appGraph: AppGraph,
     launchIntentFactory: (batchId: String, bandalartId: Long) -> Intent,
+    notificationCapture: (
+        notificationId: Int,
+        title: String,
+        body: String,
+        data: Map<String, String>,
+    ) -> Unit,
 ) {
     AndroidDeadlineReminderDependenciesRegistry.install(
         object : AndroidDeadlineReminderDependencies {
@@ -69,6 +75,15 @@ fun installAndroidDeadlineReminderInfrastructure(
                 batchId: String,
                 bandalartId: Long,
             ): Intent = launchIntentFactory(batchId, bandalartId)
+
+            override fun captureDeadlineNotification(
+                notificationId: Int,
+                title: String,
+                body: String,
+                data: Map<String, String>,
+            ) {
+                notificationCapture(notificationId, title, body, data)
+            }
         },
     )
 }

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/notification/DeadlineReminderWorker.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/notification/DeadlineReminderWorker.kt
@@ -47,6 +47,13 @@ interface AndroidDeadlineReminderDependencies {
         batchId: String,
         bandalartId: Long,
     ): Intent
+
+    fun captureDeadlineNotification(
+        notificationId: Int,
+        title: String,
+        body: String,
+        data: Map<String, String>,
+    )
 }
 
 object AndroidDeadlineReminderDependenciesRegistry {
@@ -101,6 +108,7 @@ class DeadlineReminderWorker(
         publishNotification(
             batchId = batchId,
             bandalartId = bandalartId,
+            dueDate = dueDate,
             items = items,
             dependencies = dependencies,
         )
@@ -110,6 +118,7 @@ class DeadlineReminderWorker(
     private fun publishNotification(
         batchId: String,
         bandalartId: Long,
+        dueDate: LocalDate,
         items: List<String>,
         dependencies: AndroidDeadlineReminderDependencies,
     ) {
@@ -136,6 +145,7 @@ class DeadlineReminderWorker(
                 launchIntent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
             )
+        val title = applicationContext.getString(R.string.deadline_reminder_title)
         val content =
             if (items.size == 1) {
                 applicationContext.getString(R.string.deadline_reminder_single_body, items.single())
@@ -146,13 +156,27 @@ class DeadlineReminderWorker(
             NotificationCompat
                 .Builder(applicationContext, DeadlineReminderWork.CHANNEL_ID)
                 .setSmallIcon(android.R.drawable.ic_dialog_info)
-                .setContentTitle(applicationContext.getString(R.string.deadline_reminder_title))
+                .setContentTitle(title)
                 .setContentText(content)
                 .setStyle(NotificationCompat.BigTextStyle().bigText(content))
                 .setContentIntent(contentIntent)
                 .setAutoCancel(true)
                 .build()
         notificationManager.notify(batchId, DeadlineReminderWork.NOTIFICATION_ID, notification)
+        dependencies.captureDeadlineNotification(
+            notificationId = DeadlineReminderWork.NOTIFICATION_ID,
+            title = title,
+            body = content,
+            data =
+                mapOf(
+                    DeadlineReminderWork.KEY_BATCH_ID to batchId,
+                    DeadlineReminderWork.KEY_BANDALART_ID to bandalartId.toString(),
+                    DeadlineReminderWork.KEY_DUE_DATE to dueDate.toString(),
+                    "item_count" to items.size.toString(),
+                    "action" to ACTION_OPEN_DEADLINE,
+                    "data_uri" to deadlineNotificationDataUri(batchId).toString(),
+                ),
+        )
     }
 
     companion object {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,6 +73,7 @@ compottie = "2.0.0-rc04"
 buildkonfig = "0.15.2"
 cmptoast = "1.0.4"
 jindong = "1.1.0"
+ding = "0.5.0"
 spotless = "7.0.1"
 play-publisher = "4.0.0"
 
@@ -189,6 +190,8 @@ compottie = { group = "io.github.alexzhirkevich", name = "compottie", version.re
 cmptoast = { group = "network.chaintech", name = "cmptoast", version.ref = "cmptoast" }
 jindong-core = { group = "io.github.compose-jindong", name = "jindong-core", version.ref = "jindong" }
 jindong-compose = { group = "io.github.compose-jindong", name = "jindong-compose", version.ref = "jindong" }
+ding = { group = "io.github.easyhooon", name = "ding", version.ref = "ding" }
+ding-noop = { group = "io.github.easyhooon", name = "ding-noop", version.ref = "ding" }
 
 # Test
 junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit5" }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- 관련 이슈 없음

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- debug 빌드에 Ding 알림 payload inspector 0.5.0을 연동했습니다.
- release 빌드에는 `ding-noop`만 포함해 inspector와 payload 저장이 동작하지 않도록 구성했습니다.
- 마감 알림 게시 직후 제목, 본문, `batch_id`, `bandalart_id`, `due_date`, 항목 수와 딥링크 정보를 캡처합니다.
- Android 앱 계층에서 Ding을 호출하고 `composeApp`은 알림 캡처 callback에만 의존하도록 구성했습니다.

## 🧪 테스트 내역 (선택)

- [x] `:androidApp:spotlessKotlinCheck :composeApp:spotlessKotlinCheck`
- [x] `:composeApp:testAndroidHostTest`
- [x] debug runtime에 `ding`, release runtime에 `ding-noop`만 포함되는지 확인
- [ ] 실제 기기에서 마감 알림과 Ding inspector 화면 확인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

- 직접적인 제품 UI 변경 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- `androidApp:testDebugUnitTest`는 기존 Firebase BOM 전이 문제로 `firebase-crashlytics-ktx`, `firebase-config-ktx` 버전을 해석하지 못해 실행되지 않았습니다.
- 프로젝트 지침에 따라 APK/AAB 전체 빌드는 실행하지 않았습니다.
- 알림 payload에 사용자 목표 제목은 별도 data 필드로 저장하지 않고 기존 notification body만 기록합니다.
