### PR TITLE
fix: Ding 0.5.1 업데이트 및 minSdk 우회 제거

### DIFF
--- a/androidApp/src/debug/AndroidManifest.xml
+++ b/androidApp/src/debug/AndroidManifest.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:tools="http://schemas.android.com/tools">
-
-    <uses-sdk tools:overrideLibrary="io.github.easyhooon.ding,io.github.easyhooon.ding.core" />
-
-</manifest>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,7 +73,7 @@ compottie = "2.0.0-rc04"
 buildkonfig = "0.15.2"
 cmptoast = "1.0.4"
 jindong = "1.1.0"
-ding = "0.5.0"
+ding = "0.5.1"
 spotless = "7.0.1"
 play-publisher = "4.0.0"
 


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- 없음

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- Ding 의존성을 0.5.1로 업데이트합니다.
- minSdk 28 지원에 따라 debug manifest의 minSdk override를 제거합니다.

## 🧪 테스트 내역 (선택)

- [x] Ding·ding-core 0.5.1 의존성 해석 확인
- [x] override 없이 debug manifest 병합 성공
- [x] 기존 Firebase BOM 충돌 대응 유지 확인
- [ ] 실제 기기 동작 확인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

UI 변경 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- Ding 0.5.1부터 BandalArt의 minSdk 28과 호환됩니다.
