### PR TITLE
fix: 템플릿 반복 생성 무응답 수정

### DIFF
--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeBandalartRepository.kt
@@ -40,6 +40,7 @@ internal class FakeBandalartRepository(
     private val beforeTaskCellUpdate: suspend () -> Unit = {},
     private val afterTaskCellUpdate: suspend () -> Unit = {},
     private val beforeBandalartLoad: suspend (Long) -> Unit = {},
+    private val beforeCompletionUpdate: suspend () -> Unit = {},
     private val taskCellUpdateError: Throwable? = null,
 ) : BandalartRepository {
     private val bandalartFlow = MutableStateFlow(initialBandalarts)
@@ -127,6 +128,7 @@ internal class FakeBandalartRepository(
         bandalartId: Long,
         isCompleted: Boolean,
     ) {
+        beforeCompletionUpdate()
         completionUpdates += bandalartId to isCompleted
     }
 

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterRewardedAdTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterRewardedAdTest.kt
@@ -25,11 +25,52 @@ import com.nexters.bandalart.feature.home.HomeScreen
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class HomePresenterRewardedAdTest {
+    @Test
+    fun templateCanBeCreatedAgainAfterFirstCreationIsObserved() =
+        runTest {
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = List(3) { index -> bandalart(index + 1L) },
+                    recentBandalartId = 1L,
+                    createdBandalart = bandalart(4L),
+                    beforeCompletionUpdate = { yield() },
+                )
+            val slotRepository = FakeBandalartSlotRepository(maxSlots = 5)
+
+            presenter(repository, slotRepository).test {
+                var state = awaitLoaded()
+                state.eventSink(
+                    HomeScreen.Event.CreateBandalartFromTemplate(
+                        BandalartTemplateId.STUDY_PLAN_V1,
+                    ),
+                )
+                state = awaitCreated()
+                state.eventSink(HomeScreen.Event.ConsumeEffect)
+                state.eventSink(
+                    HomeScreen.Event.CreateBandalartFromTemplate(
+                        BandalartTemplateId.WORKOUT_HABIT_V1,
+                    ),
+                )
+                yield()
+
+                assertEquals(2, repository.createCalls)
+                assertEquals(
+                    listOf(
+                        BandalartTemplateId.STUDY_PLAN_V1,
+                        BandalartTemplateId.WORKOUT_HABIT_V1,
+                    ),
+                    repository.createdTemplateIds,
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     @Test
     fun templateUsesExistingFreeSlotGateAndCreatesSelectedTemplate() =
         runTest {

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/RewardedCreateCoordinatorTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/RewardedCreateCoordinatorTest.kt
@@ -85,6 +85,18 @@ class RewardedCreateCoordinatorTest {
         assertTrue(coordinator.beginSlotCheck())
     }
 
+    @Test
+    fun creationObservedBeforeRepositoryReturnsStillUnlocksNextRequest() {
+        val coordinator = RewardedCreateCoordinator()
+        assertTrue(coordinator.beginSlotCheck())
+        assertTrue(coordinator.slotsResolved(canCreate = true, currentCount = 3))
+
+        coordinator.creationObserved(currentCount = 4)
+        coordinator.creationFinished(wasCreated = true, currentCount = 3)
+
+        assertTrue(coordinator.beginSlotCheck())
+    }
+
     private fun RewardedCreateCoordinator.openRewardedRequest(): Long {
         assertTrue(beginSlotCheck())
         assertFalse(slotsResolved(canCreate = false, currentCount = 3))

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/RewardedCreateCoordinator.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/RewardedCreateCoordinator.kt
@@ -23,6 +23,7 @@ internal class RewardedCreateCoordinator {
     private var state = State.IDLE
     private var activeRequestId: Long? = null
     private var expectedCreatedCount: Int? = null
+    private var latestObservedCount: Int? = null
 
     fun beginSlotCheck(): Boolean {
         if (state != State.IDLE) return false
@@ -36,7 +37,8 @@ internal class RewardedCreateCoordinator {
     ): Boolean {
         check(state == State.CHECKING_SLOTS)
         state = if (canCreate) State.CREATING else State.AWAITING_CONFIRMATION
-        if (canCreate) expectedCreatedCount = currentCount + 1
+        expectedCreatedCount = if (canCreate) currentCount + 1 else null
+        latestObservedCount = if (canCreate) currentCount else null
         return canCreate
     }
 
@@ -72,6 +74,7 @@ internal class RewardedCreateCoordinator {
             state = State.IDLE
             RewardedCompletion.DISMISSED
         } else {
+            latestObservedCount = null
             state = State.APPLYING_GRANT
             RewardedCompletion.GRANTED
         }
@@ -96,27 +99,35 @@ internal class RewardedCreateCoordinator {
     fun beginPendingRecovery(expectedCount: Int): Boolean {
         if (state != State.IDLE) return false
         expectedCreatedCount = expectedCount
+        latestObservedCount = null
         state = State.APPLYING_GRANT
         return true
     }
 
     fun creationObserved(currentCount: Int) {
+        if (state != State.CREATING && state != State.APPLYING_GRANT && state != State.AWAITING_CREATION) return
+        latestObservedCount = maxOf(latestObservedCount ?: currentCount, currentCount)
         if (state != State.AWAITING_CREATION) return
-        if (currentCount < requireNotNull(expectedCreatedCount)) return
-        expectedCreatedCount = null
-        state = State.IDLE
+        if (requireNotNull(latestObservedCount) < requireNotNull(expectedCreatedCount)) return
+        resetCreation()
     }
 
     private fun finishCreation(
         wasCreated: Boolean,
         currentCount: Int,
     ) {
-        if (!wasCreated || currentCount >= requireNotNull(expectedCreatedCount)) {
-            expectedCreatedCount = null
-            state = State.IDLE
+        val observedCount = maxOf(latestObservedCount ?: currentCount, currentCount)
+        if (!wasCreated || observedCount >= requireNotNull(expectedCreatedCount)) {
+            resetCreation()
         } else {
             state = State.AWAITING_CREATION
         }
+    }
+
+    private fun resetCreation() {
+        expectedCreatedCount = null
+        latestObservedCount = null
+        state = State.IDLE
     }
 
     fun dismissDialog() {


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #208

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 생성 결과가 repository 반환보다 먼저 관찰되면 coordinator가 대기 상태에 남던 race condition을 수정했습니다.
- 첫 템플릿 생성 이후 다른 템플릿을 다시 생성할 수 있도록 상태를 초기화합니다.
- coordinator 단위 테스트와 HomePresenter 회귀 테스트를 추가했습니다.

## 🧪 테스트 내역 (선택)

- [x] Home Android host 테스트
- [x] Home Detekt
- [x] 조기 생성 관찰 엣지 케이스 테스트
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

- UI 변경 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- creationObserved()와 creationFinished() 호출 순서가 뒤바뀌어도 다음 요청이 열리는지 확인해 주세요.