### PR TITLE
refactor: 홈 액션 다이얼로그 UI 통일

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -12,10 +12,10 @@ The generated WebP comparison assets under `tools/fluent-emoji/generated/color/`
 ## Google Material Symbols
 
 - Source: `https://fonts.gstatic.com/s/i/short-term/release/materialsymbolsoutlined/{icon}/default/24px.svg`
-- Retrieved: 2026-08-09 (category navigation icons); 2026-08-10 (`add_circle`)
-- Icons: `apps`, `history`, `sentiment_satisfied`, `groups`, `pets`, `restaurant`, `flight`, `sports_soccer`, `lightbulb`, `tag`, `outlined_flag`, `add_circle`
+- Retrieved: 2026-08-09 (category navigation icons); 2026-08-10 (`add_circle`, `notifications`)
+- Icons: `apps`, `history`, `sentiment_satisfied`, `groups`, `pets`, `restaurant`, `flight`, `sports_soccer`, `lightbulb`, `tag`, `outlined_flag`, `add_circle`, `notifications`
 - License: Apache License 2.0 ([local license text](licenses/Apache-2.0.txt))
 - Licensing reference: [Google Fonts — Material Icons licensing](https://developers.google.com/fonts/docs/material_icons#licensing)
 - Copyright: Google LLC
 
-The category navigation vectors under `core/designsystem/src/commonMain/composeResources/drawable/emoji_category_nav_*.xml` and the rewarded-create dialog vector `core/designsystem/src/commonMain/composeResources/drawable/ic_add_circle_outlined.xml` are adapted from the listed 24px Material Symbols Outlined SVG paths. The SVG view box origin is represented with an equivalent vector group translation; the icon geometry is otherwise unchanged. The application does not download Material Symbols resources at runtime.
+The category navigation vectors under `core/designsystem/src/commonMain/composeResources/drawable/emoji_category_nav_*.xml`, the rewarded-create dialog vector `core/designsystem/src/commonMain/composeResources/drawable/ic_add_circle_outlined.xml`, and the deadline-reminder dialog vector `core/designsystem/src/commonMain/composeResources/drawable/ic_notifications_outlined.xml` are adapted from the listed 24px Material Symbols Outlined SVG paths. The SVG view box origin is represented with an equivalent vector group translation; the icon geometry is otherwise unchanged. The application does not download Material Symbols resources at runtime.

--- a/core/designsystem/src/commonMain/composeResources/drawable/ic_notifications_outlined.xml
+++ b/core/designsystem/src/commonMain/composeResources/drawable/ic_notifications_outlined.xml
@@ -1,0 +1,15 @@
+<!--
+  Adapted from the Google Material Symbol "notifications" 24px Outlined SVG.
+  Copyright Google LLC. Licensed under the Apache License 2.0.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <group android:translateY="960">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M160,-200v-80h80v-280q0,-83 50,-147.5T420,-792v-28q0,-25 17.5,-42.5T480,-880q25,0 42.5,17.5T540,-820v28q80,20 130,84.5T720,-560v280h80v80H160Zm320,-300Zm0,420q-33,0 -56.5,-23.5T400,-160h160q0,33 -23.5,56.5T480,-80ZM320,-280h320v-280q0,-66 -47,-113t-113,-47q-66,0 -113,47t-47,113v280Z" />
+  </group>
+</vector>

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartActionAlertDialog.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartActionAlertDialog.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home.ui.bandalart
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import org.jetbrains.compose.resources.DrawableResource
+import org.jetbrains.compose.resources.vectorResource
+
+@Composable
+internal fun BandalartActionAlertDialog(
+    icon: DrawableResource,
+    iconContentDescription: String?,
+    title: String,
+    message: String,
+    confirmLabel: String,
+    cancelLabel: String,
+    onConfirmClick: () -> Unit,
+    onCancelClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Dialog(onDismissRequest = onCancelClick) {
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = MaterialTheme.colorScheme.surface,
+        ) {
+            Column(
+                modifier =
+                    modifier
+                        .fillMaxWidth()
+                        .padding(top = 24.dp),
+            ) {
+                Icon(
+                    imageVector = vectorResource(icon),
+                    contentDescription = iconContentDescription,
+                    modifier =
+                        Modifier
+                            .size(28.dp)
+                            .align(Alignment.CenterHorizontally),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(modifier = Modifier.height(18.dp))
+                Text(
+                    text = title,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.W700,
+                    modifier =
+                        Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .padding(horizontal = 24.dp),
+                    textAlign = TextAlign.Center,
+                    lineHeight = 30.sp,
+                    letterSpacing = (-0.4).sp,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = message,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.W500,
+                    modifier =
+                        Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .padding(horizontal = 24.dp),
+                    textAlign = TextAlign.Center,
+                    lineHeight = 21.sp,
+                    letterSpacing = (-0.28).sp,
+                )
+                Spacer(modifier = Modifier.height(30.dp))
+                Row(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Button(
+                        modifier =
+                            Modifier
+                                .weight(1f)
+                                .height(56.dp),
+                        onClick = onCancelClick,
+                        colors =
+                            ButtonColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                            ),
+                    ) {
+                        Text(
+                            text = cancelLabel,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.W600,
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(9.dp))
+                    Button(
+                        modifier =
+                            Modifier
+                                .weight(1f)
+                                .height(56.dp),
+                        onClick = onConfirmClick,
+                        colors =
+                            ButtonColors(
+                                containerColor = MaterialTheme.colorScheme.primary,
+                                contentColor = MaterialTheme.colorScheme.onPrimary,
+                                disabledContainerColor = MaterialTheme.colorScheme.primary,
+                                disabledContentColor = MaterialTheme.colorScheme.onPrimary,
+                            ),
+                    ) {
+                        Text(
+                            text = confirmLabel,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.W600,
+                            textAlign = TextAlign.Center,
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(20.dp))
+            }
+        }
+    }
+}

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/RewardedBandalartAlertDialog.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/RewardedBandalartAlertDialog.kt
@@ -16,30 +16,8 @@
 
 package com.nexters.bandalart.feature.home.ui.bandalart
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonColors
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import bandalart.core.designsystem.generated.resources.Res
 import bandalart.core.designsystem.generated.resources.add_description
 import bandalart.core.designsystem.generated.resources.ic_add_circle_outlined
@@ -48,7 +26,6 @@ import bandalart.core.designsystem.generated.resources.rewarded_create_dialog_co
 import bandalart.core.designsystem.generated.resources.rewarded_create_dialog_message
 import bandalart.core.designsystem.generated.resources.rewarded_create_dialog_title
 import org.jetbrains.compose.resources.stringResource
-import org.jetbrains.compose.resources.vectorResource
 
 @Composable
 fun RewardedBandalartAlertDialog(
@@ -56,108 +33,15 @@ fun RewardedBandalartAlertDialog(
     onCancelClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Dialog(onDismissRequest = onCancelClick) {
-        Surface(
-            shape = RoundedCornerShape(16.dp),
-            color = MaterialTheme.colorScheme.surface,
-        ) {
-            Column(
-                modifier =
-                    modifier
-                        .fillMaxWidth()
-                        .padding(top = 24.dp),
-            ) {
-                Icon(
-                    imageVector = vectorResource(Res.drawable.ic_add_circle_outlined),
-                    contentDescription = stringResource(Res.string.add_description),
-                    modifier =
-                        Modifier
-                            .size(28.dp)
-                            .align(Alignment.CenterHorizontally),
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-                Spacer(modifier = Modifier.height(18.dp))
-                Text(
-                    text = stringResource(Res.string.rewarded_create_dialog_title),
-                    color = MaterialTheme.colorScheme.onSurface,
-                    fontSize = 20.sp,
-                    fontWeight = FontWeight.W700,
-                    modifier =
-                        Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .padding(horizontal = 24.dp),
-                    textAlign = TextAlign.Center,
-                    lineHeight = 30.sp,
-                    letterSpacing = (-0.4).sp,
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = stringResource(Res.string.rewarded_create_dialog_message),
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.W500,
-                    modifier =
-                        Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .padding(horizontal = 24.dp),
-                    textAlign = TextAlign.Center,
-                    lineHeight = 21.sp,
-                    letterSpacing = (-0.28).sp,
-                )
-                Spacer(modifier = Modifier.height(30.dp))
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 24.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Button(
-                        modifier =
-                            Modifier
-                                .weight(1f)
-                                .height(56.dp),
-                        onClick = onCancelClick,
-                        colors =
-                            ButtonColors(
-                                containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                                contentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                                disabledContainerColor = MaterialTheme.colorScheme.surfaceVariant,
-                                disabledContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                            ),
-                    ) {
-                        Text(
-                            text = stringResource(Res.string.rewarded_create_dialog_cancel),
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.W600,
-                        )
-                    }
-                    Spacer(modifier = Modifier.width(9.dp))
-                    Button(
-                        modifier =
-                            Modifier
-                                .weight(1f)
-                                .height(56.dp),
-                        onClick = onConfirmClick,
-                        colors =
-                            ButtonColors(
-                                containerColor = MaterialTheme.colorScheme.primary,
-                                contentColor = MaterialTheme.colorScheme.onPrimary,
-                                disabledContainerColor = MaterialTheme.colorScheme.primary,
-                                disabledContentColor = MaterialTheme.colorScheme.onPrimary,
-                            ),
-                    ) {
-                        Text(
-                            text = stringResource(Res.string.rewarded_create_dialog_confirm),
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.W600,
-                            textAlign = TextAlign.Center,
-                        )
-                    }
-                }
-                Spacer(modifier = Modifier.height(20.dp))
-            }
-        }
-    }
+    BandalartActionAlertDialog(
+        icon = Res.drawable.ic_add_circle_outlined,
+        iconContentDescription = stringResource(Res.string.add_description),
+        title = stringResource(Res.string.rewarded_create_dialog_title),
+        message = stringResource(Res.string.rewarded_create_dialog_message),
+        confirmLabel = stringResource(Res.string.rewarded_create_dialog_confirm),
+        cancelLabel = stringResource(Res.string.rewarded_create_dialog_cancel),
+        onConfirmClick = onConfirmClick,
+        onCancelClick = onCancelClick,
+        modifier = modifier,
+    )
 }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/settings/SettingsBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/settings/SettingsBottomSheet.kt
@@ -35,7 +35,6 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Email
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -44,7 +43,6 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Switch
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -59,6 +57,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import bandalart.core.designsystem.generated.resources.Res
 import bandalart.core.designsystem.generated.resources.clear_description
+import bandalart.core.designsystem.generated.resources.ic_notifications_outlined
 import bandalart.core.designsystem.generated.resources.settings_app_info
 import bandalart.core.designsystem.generated.resources.settings_appearance
 import bandalart.core.designsystem.generated.resources.settings_deadline_reminder
@@ -83,6 +82,7 @@ import com.nexters.bandalart.core.domain.entity.ThemeMode
 import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorizationStatus
 import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingHealth
 import com.nexters.bandalart.feature.home.HomeScreen
+import com.nexters.bandalart.feature.home.ui.bandalart.BandalartActionAlertDialog
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -100,25 +100,18 @@ internal fun SettingsBottomSheet(
     var showDeadlineReminderConfirmation by remember { mutableStateOf(false) }
 
     if (showDeadlineReminderConfirmation) {
-        AlertDialog(
-            onDismissRequest = { showDeadlineReminderConfirmation = false },
-            title = { Text(stringResource(Res.string.settings_deadline_reminder_dialog_title)) },
-            text = { Text(stringResource(Res.string.settings_deadline_reminder_dialog_body)) },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        showDeadlineReminderConfirmation = false
-                        onHomeUiAction(HomeScreen.Event.ConfirmDeadlineReminderPermission)
-                    },
-                ) {
-                    Text(stringResource(Res.string.settings_deadline_reminder_confirm))
-                }
+        BandalartActionAlertDialog(
+            icon = Res.drawable.ic_notifications_outlined,
+            iconContentDescription = stringResource(Res.string.settings_deadline_reminder),
+            title = stringResource(Res.string.settings_deadline_reminder_dialog_title),
+            message = stringResource(Res.string.settings_deadline_reminder_dialog_body),
+            confirmLabel = stringResource(Res.string.settings_deadline_reminder_confirm),
+            cancelLabel = stringResource(Res.string.settings_deadline_reminder_cancel),
+            onConfirmClick = {
+                showDeadlineReminderConfirmation = false
+                onHomeUiAction(HomeScreen.Event.ConfirmDeadlineReminderPermission)
             },
-            dismissButton = {
-                TextButton(onClick = { showDeadlineReminderConfirmation = false }) {
-                    Text(stringResource(Res.string.settings_deadline_reminder_cancel))
-                }
-            },
+            onCancelClick = { showDeadlineReminderConfirmation = false },
         )
     }
 


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #206
- #211

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 보상형 광고 안내 UI를 공통 BandalartActionAlertDialog로 추출했습니다.
- 알림 활성화 확인에도 같은 다이얼로그를 적용했습니다.
- 알림 아이콘과 Material Symbols 라이선스 고지를 추가했습니다.

## 🧪 테스트 내역 (선택)

- [x] Home Android host 테스트
- [x] Home Detekt
- [x] Android 및 iOS KMP 컴파일
- [ ] Android/iOS 실제 화면 확인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

- 알림 확인 다이얼로그를 기존 반다라트 다이얼로그 디자인으로 통일

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 알림 바텀시트 위 다이얼로그의 레이아웃과 dismiss 동작을 확인해 주세요.