### PR TITLE
fix: Android 광고를 비맞춤형으로 요청

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.VIBRATE" />
-
     <queries>
         <intent>
             <action android:name="android.intent.action.SENDTO" />
@@ -23,6 +22,13 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Bandalart">
+
+        <meta-data
+            android:name="google_analytics_adid_collection_enabled"
+            android:value="false" />
+        <meta-data
+            android:name="google_analytics_default_allow_ad_personalization_signals"
+            android:value="false" />
 
 <!--        <provider-->
 <!--            android:name="androidx.startup.InitializationProvider"-->

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AdRequestPrivacy.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AdRequestPrivacy.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.ads
+
+import android.os.Bundle
+
+internal fun nonPersonalizedAdExtras(): Bundle =
+    Bundle().apply {
+        putInt(NON_PERSONALIZED_ADS_KEY, NON_PERSONALIZED_ADS_ENABLED)
+    }
+
+private const val NON_PERSONALIZED_ADS_KEY = "npa"
+private const val NON_PERSONALIZED_ADS_ENABLED = 1

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AdsInitializer.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AdsInitializer.kt
@@ -43,6 +43,7 @@ class AdsInitializer(
 
         scope.launch {
             runCatching {
+                MobileAds.putPublisherFirstPartyIdEnabled(false)
                 MobileAds.initialize(
                     context,
                     InitializationConfig.Builder(context.getString(R.string.admob_app_id)).build(),
@@ -51,7 +52,12 @@ class AdsInitializer(
                     runCatching {
                         RewardedAdPreloader.start(
                             adUnitId,
-                            PreloadConfiguration(AdRequest.Builder(adUnitId).build()),
+                            PreloadConfiguration(
+                                AdRequest
+                                    .Builder(adUnitId)
+                                    .setGoogleExtrasBundle(nonPersonalizedAdExtras())
+                                    .build(),
+                            ),
                         )
                     }.onFailure { exception ->
                         Napier.e("Rewarded ad preloader failed to start", exception, tag = "AdsInitializer")

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidBannerAdHost.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidBannerAdHost.kt
@@ -94,6 +94,7 @@ class AndroidBannerAdHost(
                     adView.loadAd(
                         BannerAdRequest
                             .Builder(activity.getString(R.string.admob_banner_ad_unit_id), adSize)
+                            .setGoogleExtrasBundle(nonPersonalizedAdExtras())
                             .build(),
                         object : AdLoadCallback<BannerAd> {
                             override fun onAdLoaded(ad: BannerAd) {

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidRewardedAdGateway.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidRewardedAdGateway.kt
@@ -88,7 +88,10 @@ class AndroidRewardedAdGateway(
         }
 
         val adRequest =
-            AdRequest.Builder(application.getString(R.string.admob_rewarded_ad_unit_id)).build()
+            AdRequest
+                .Builder(application.getString(R.string.admob_rewarded_ad_unit_id))
+                .setGoogleExtrasBundle(nonPersonalizedAdExtras())
+                .build()
         val preloadedAd = RewardedAdPreloader.pollAd(adRequest.adUnitId)
         if (preloadedAd != null) {
             showWhenActivityAvailable(requestId, preloadedAd, result)


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #206

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 배너·보상형·사전 로드 광고 요청에 비맞춤형 광고 옵션을 적용했습니다.
- publisher first-party ID 수집을 비활성화했습니다.
- Firebase 광고 개인화 신호 기본값을 비활성화했습니다.

## 🧪 테스트 내역 (선택)

- [x] Android 컴파일
- [x] Home Android host 테스트
- [x] Detekt
- [ ] 실제 광고 요청 확인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

- UI 변경 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 모든 Android 광고 경로에 npa=1이 적용되는지 확인해 주세요.