### PR TITLE
chore: CI 액션 Node 24 런타임 대응

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -24,21 +24,21 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v7
                 with:
                     fetch-depth: 0
 
             -   name: Setup JDK 21
-                uses: actions/setup-java@v4
+                uses: actions/setup-java@v5
                 with:
                     distribution: zulu
                     java-version: 21
 
             -   name: Setup Android SDK
-                uses: android-actions/setup-android@v3
+                uses: android-actions/setup-android@v4
 
             -   name: Setup Gradle
-                uses: gradle/actions/setup-gradle@v4
+                uses: gradle/actions/setup-gradle@v6
 
             -   name: Generate build properties
                 env:
@@ -64,19 +64,19 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v7
 
             -   name: Setup JDK 21
-                uses: actions/setup-java@v4
+                uses: actions/setup-java@v5
                 with:
                     distribution: zulu
                     java-version: 21
 
             -   name: Setup Android SDK
-                uses: android-actions/setup-android@v3
+                uses: android-actions/setup-android@v4
 
             -   name: Setup Gradle
-                uses: gradle/actions/setup-gradle@v4
+                uses: gradle/actions/setup-gradle@v6
 
             -   name: Generate build properties
                 env:
@@ -102,19 +102,19 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v7
 
             -   name: Setup JDK 21
-                uses: actions/setup-java@v4
+                uses: actions/setup-java@v5
                 with:
                     distribution: zulu
                     java-version: 21
 
             -   name: Setup Android SDK
-                uses: android-actions/setup-android@v3
+                uses: android-actions/setup-android@v4
 
             -   name: Setup Gradle
-                uses: gradle/actions/setup-gradle@v4
+                uses: gradle/actions/setup-gradle@v6
 
             -   name: Generate build properties
                 env:
@@ -140,19 +140,19 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
 
         steps:
-            -   uses: actions/checkout@v4
+            -   uses: actions/checkout@v7
 
             -   name: Setup JDK 21
-                uses: actions/setup-java@v4
+                uses: actions/setup-java@v5
                 with:
                     distribution: zulu
                     java-version: 21
 
             -   name: Setup Android SDK
-                uses: android-actions/setup-android@v3
+                uses: android-actions/setup-android@v4
 
             -   name: Setup Gradle
-                uses: gradle/actions/setup-gradle@v4
+                uses: gradle/actions/setup-gradle@v6
 
             -   name: Generate build properties
                 env:

--- a/.github/workflows/release-cd.yml
+++ b/.github/workflows/release-cd.yml
@@ -85,7 +85,7 @@ jobs:
                     java-version: 21
 
             -   name: Setup Android SDK
-                uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+                uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
             -   name: Setup Gradle
                 uses: gradle/actions/setup-gradle@4733eaac7c1b0da527e4206b7671e0061de1ce37 # v6
@@ -177,7 +177,7 @@ jobs:
                     java-version: 21
 
             -   name: Setup Android SDK
-                uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+                uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
 
             -   name: Setup Gradle
                 uses: gradle/actions/setup-gradle@4733eaac7c1b0da527e4206b7671e0061de1ce37 # v6


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #283

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- Android CI의 checkout, setup-java, setup-android, setup-gradle을 Node.js 24 기반 버전으로 업데이트합니다.
- Release CD의 setup-android를 v4.0.1 SHA로 갱신해 기존 공급망 고정 방식을 유지합니다.
- 기존 CI job과 빌드 설정은 변경하지 않습니다.

## 🧪 테스트 내역 (선택)

- [x] actionlint 1.7.7 workflow 검증
- [x] 적용한 action tag와 SHA의 `node24` 런타임 확인
- [x] git diff 검사
- [ ] PR CI 전체 통과 확인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

- 해당 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- CI 실행 후 Node.js 20 및 setup-java v4 사용 중단 경고가 사라지는지 확인합니다.