### PR TITLE
chore: Android 2.2.23 Internal 릴리스 준비

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ targetSdk = "36"
 compileSdk = "37"
 majorVersion = "2"
 minorVersion = "2"
-patchVersion = "22"
+patchVersion = "23"
 packageName = "com.nexters.bandalart"
 
 # Gradle Plugin


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #186

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- Android 버전을 `2.2.23 (20223)`으로 올립니다.
- 기존 `2.2.22` Internal 배포 이후 머지된 기능·버그 수정 사항을 포함합니다.
- 테스트 광고를 사용하고 `inAppUpdatePriority=0`으로 Internal Testing에 배포합니다.

## 🧪 테스트 내역 (선택)

- [x] Play 전체 트랙 최대 versionCode `20222`, 다음 사용 가능 값 `20223` 확인
- [x] ko-KR/en-US/ja-JP 출시 노트 500자 이내 확인
- [x] `git diff --check`
- [ ] CI 통과
- [ ] Play Internal Testing 업로드 및 priority `0` 사후 검증

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

| 기능 | 미리보기 | 기능 | 미리보기 |
|:---:|:---:|:---:|:---:|
| 릴리스 버전 변경 | - | UI 변경 없음 | - |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- Internal 빌드에는 Google 테스트 광고 ID를 사용합니다.
- 일반 릴리스이므로 선택 업데이트 정책인 priority `0`을 적용합니다.
