### PR TITLE
fix: Android Release Firebase BOM 충돌 해결

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -111,11 +111,13 @@ dependencies {
     implementation(libs.cmptoast)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.napier)
-    debugImplementation(platform(libs.firebase.bom))
+    implementation(platform(libs.firebase.bom))
     debugImplementation(libs.ding) {
         exclude(group = "com.google.firebase", module = "firebase-bom")
     }
-    "releaseImplementation"(libs.ding.noop)
+    "releaseImplementation"(libs.ding.noop) {
+        exclude(group = "com.google.firebase", module = "firebase-bom")
+    }
     testImplementation(libs.bundles.android.unit.test)
     testRuntimeOnly(libs.junit.jupiter.engine)
     "baselineProfile"(project(":baselineprofile"))


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- 관련 이슈 없음

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- Firebase BOM을 Debug와 Release에 공통 적용합니다.
- `ding-noop`이 Release에 전이하는 Firebase BOM 34.11.0을 제외합니다.
- 프로젝트 BOM 33.16.0을 유지해 Firebase KTX 의존성의 빈 버전 오류를 해결합니다.

## 🧪 테스트 내역 (선택)

- [x] Release 런타임 Firebase BOM 33.16.0 확인
- [x] 테스트 광고 설정으로 clean Release AAB 빌드
- [x] AAB 버전·서명·테스트 광고 ID·Compose 리소스 검증
- [x] `git diff --check`
- [ ] CI 통과

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

- 빌드 설정 변경으로 UI 변경 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- 수정 전 `bundleRelease`에서 Firebase KTX 의존성 해석 실패를 재현했습니다.
- 수정 후 `2.2.23 (20223)` AAB 빌드와 배포 전 검증을 통과했습니다.
