### PR TITLE
fix: iOS 홈 진입 Clock 크래시 수정

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
@@ -47,9 +47,9 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 @BindingContainer
 object RepositoryBindings {

--- a/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/notification/DefaultDeadlineReminderReconcilerTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/notification/DefaultDeadlineReminderReconcilerTest.kt
@@ -31,12 +31,12 @@ import com.nexters.bandalart.core.domain.repository.SettingsRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 class DefaultDeadlineReminderReconcilerTest {
     private val settings = FakeSettingsRepository()

--- a/core/domain/src/androidHostTest/kotlin/com/nexters/bandalart/core/domain/notification/DeadlineReminderPlannerTest.kt
+++ b/core/domain/src/androidHostTest/kotlin/com/nexters/bandalart/core/domain/notification/DeadlineReminderPlannerTest.kt
@@ -16,14 +16,14 @@
 
 package com.nexters.bandalart.core.domain.notification
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import kotlin.time.Clock
+import kotlin.time.Instant
 
 class DeadlineReminderPlannerTest {
     @Test

--- a/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/notification/DeadlineReminderPlanner.kt
+++ b/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/notification/DeadlineReminderPlanner.kt
@@ -16,12 +16,12 @@
 
 package com.nexters.bandalart.core.domain.notification
 
-import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import kotlin.time.Clock
 
 object DeadlineReminderDueDateParser {
     fun parse(value: String?): LocalDate? =
@@ -44,7 +44,10 @@ class DeadlineReminderPlanner(
     ): DeadlineReminderPlan {
         if (!isEnabled) return DeadlineReminderPlan(emptyList(), overflowCount = 0)
 
-        val now = clock.now().toLocalDateTime(timeZoneProvider.currentTimeZone())
+        val now =
+            kotlinx.datetime.Instant
+                .fromEpochMilliseconds(clock.now().toEpochMilliseconds())
+                .toLocalDateTime(timeZoneProvider.currentTimeZone())
         val batches =
             candidates
                 .asSequence()


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- 해당 없음

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- `DeadlineReminderPlanner`와 DI의 Clock 타입을 `kotlin.time.Clock`으로 통일
- 시간대 계산 시 `kotlinx.datetime.Instant`로 명시적으로 변환
- 테스트용 FixedClock도 동일 타입으로 변경

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

- UI 변경 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- iOS 홈 진입 시 발생하던 Kotlin/Native `IrLinkageError` 및 `SIGABRT`를 수정했습니다.
- Android host 테스트와 iPhone 13 mini 클린 빌드·실행 검증을 완료했습니다.
