### PR TITLE
fix: 단일 반다라트 추가 시 템플릿 선택 제공

### DIFF
--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
@@ -223,11 +223,38 @@ class HomePresenterTest {
         }
 
     @Test
-    fun addButtonSwitchesExistingListSheetToCreationOptionsAndBack() =
+    fun singleBandalartTopBarActionOpensCreationOptionsWithoutCreating() =
         runTest {
             val repository =
                 FakeBandalartRepository(
                     initialBandalarts = listOf(bandalart(1L)),
+                    recentBandalartId = 1L,
+                )
+
+            presenter(repository).test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != 1L || state.isLoading) {
+                    state = awaitItem()
+                }
+
+                state.eventSink(HomeScreen.Event.OpenBandalartList)
+                do {
+                    state = awaitItem()
+                } while (state.bottomSheet !is HomeScreen.BottomSheetState.BandalartList)
+
+                val sheet = state.bottomSheet
+                assertTrue(sheet.isCreationOptionsVisible)
+                assertEquals(0, repository.createCalls)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun addButtonSwitchesExistingListSheetToCreationOptionsAndBack() =
+        runTest {
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1L), bandalart(2L)),
                     recentBandalartId = 1L,
                 )
 

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -384,7 +384,11 @@ class HomePresenter(
 
         fun openBandalartList() {
             val currentBandalartId = bandalartData?.id ?: return
-            bottomSheet = HomeScreen.BottomSheetState.BandalartList(currentBandalartId)
+            bottomSheet =
+                HomeScreen.BottomSheetState.BandalartList(
+                    currentBandalartId = currentBandalartId,
+                    isCreationOptionsVisible = bandalartList.size <= 1,
+                )
         }
 
         fun openEmoji() {

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/HomeTopBar.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/HomeTopBar.kt
@@ -97,13 +97,7 @@ internal fun HomeTopBar(
                         .height(48.dp)
                         .widthIn(min = 48.dp)
                         .clickable(
-                            onClick = {
-                                if (bandalartCount > 1) {
-                                    onHomeUiAction(HomeScreen.Event.OpenBandalartList)
-                                } else {
-                                    onHomeUiAction(HomeScreen.Event.AddBandalart)
-                                }
-                            },
+                            onClick = { onHomeUiAction(HomeScreen.Event.OpenBandalartList) },
                         ),
                 contentAlignment = Alignment.Center,
             ) {


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #208

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 반다라트가 한 개일 때 상단 `추가` 버튼이 빈 반다라트를 즉시 생성하지 않고 생성 옵션을 열도록 수정했습니다.
- 생성 옵션에서 빈 반다라트 또는 템플릿을 선택할 수 있습니다.
- 반다라트가 두 개 이상일 때의 기존 목록 진입 동작은 유지했습니다.
- 단일 반다라트 생성 옵션 흐름을 검증하는 Presenter 회귀 테스트를 추가했습니다.

## 🧪 테스트 내역 (선택)

- [ ] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `:feature:home:testAndroidHostTest` 통과
- `:feature:home:detekt` 통과
- `git diff --check` 통과
- `:feature:home:spotlessCheck`는 이번 변경과 무관한 기존 `CellText.kt` 포맷 위반 1건으로 실패

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 단일 반다라트 추가 | 첨부 없음 | 템플릿 선택 | 첨부 없음 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- `#208`의 후속 버그 수정이며 umbrella issue는 닫지 않습니다.
