### PR TITLE
fix: 바텀시트 헤더 수직 정렬

### DIFF
--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartListBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartListBottomSheet.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -146,15 +145,18 @@ fun BandalartListBottomSheet(
                     color = MaterialTheme.colorScheme.onSurface,
                     fontSize = 16.sp,
                     fontWeight = FontWeight.W700,
-                    modifier = modifier.fillMaxWidth(),
+                    modifier =
+                        modifier
+                            .align(Alignment.Center)
+                            .fillMaxWidth()
+                            .padding(horizontal = 48.dp),
                     textAlign = TextAlign.Center,
                 )
                 IconButton(
                     modifier =
                         Modifier
                             .align(Alignment.CenterEnd)
-                            .height(21.dp)
-                            .aspectRatio(1f),
+                            .size(48.dp),
                     onClick = {
                         onHomeUiAction(HomeScreen.Event.DismissBottomSheet)
                     },


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #307

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 반다라트 생성 바텀시트 제목을 헤더 컨테이너 중앙에 정렬합니다.
- 뒤로가기와 닫기 버튼을 동일한 48dp 터치 영역으로 맞춰 세 요소의 수직 중심선을 통일합니다.

## 🧪 테스트 내역 (선택)

- [x] `:feature:home:detekt` 통과
- [x] `:feature:home:testAndroidHostTest` 통과
- [x] `:feature:home:compileAndroidMain` 통과
- [x] 기존 기능 영향 없음

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

| 기능 | 미리보기 | 기능 | 미리보기 |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 헤더 수직 정렬 | 제보 스크린샷 기준 수정 | 동일 터치 영역 | 48dp |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 제목에는 양쪽 48dp 버튼 영역만큼 수평 padding을 적용해 긴 번역에서도 아이콘과 겹치지 않게 했습니다.