### PR TITLE
fix: iOS 마감 알림 생명주기 복구

### DIFF
--- a/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/notification/DeadlineReminderLifecycleBridgeTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/notification/DeadlineReminderLifecycleBridgeTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.notification
+
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingHealth
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DeadlineReminderLifecycleBridgeTest {
+    @Test
+    fun lifecycleSignalBeforeGraphAttachmentIsReplayed() =
+        runTest {
+            val reconciler = RecordingReconciler()
+            val bridge = DeadlineReminderLifecycleBridge(this)
+
+            bridge.record()
+            bridge.attach(reconciler)
+            runCurrent()
+
+            assertEquals(1, reconciler.reconcileCalls)
+        }
+
+    @Test
+    fun lifecycleSignalAfterGraphAttachmentReconcilesImmediately() =
+        runTest {
+            val reconciler = RecordingReconciler()
+            val bridge = DeadlineReminderLifecycleBridge(this)
+            bridge.attach(reconciler)
+
+            bridge.record()
+            runCurrent()
+
+            assertEquals(1, reconciler.reconcileCalls)
+        }
+
+    private class RecordingReconciler : DeadlineReminderReconciler {
+        override val schedulingHealth: StateFlow<DeadlineReminderSchedulingHealth> =
+            MutableStateFlow(DeadlineReminderSchedulingHealth())
+        var reconcileCalls = 0
+
+        override suspend fun reconcileAll() {
+            reconcileCalls += 1
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/notification/DeadlineReminderLifecycleBridge.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/notification/DeadlineReminderLifecycleBridge.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.notification
+
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+class DeadlineReminderLifecycleBridge internal constructor(
+    private val scope: CoroutineScope,
+) {
+    constructor() : this(CoroutineScope(SupervisorJob() + Dispatchers.Default))
+
+    private var reconciler: DeadlineReminderReconciler? = null
+    private var hasPendingReconcile = false
+
+    fun record() {
+        val currentReconciler = reconciler
+        if (currentReconciler == null) {
+            hasPendingReconcile = true
+            return
+        }
+        scope.launch {
+            currentReconciler.reconcileAll()
+        }
+    }
+
+    internal fun attach(reconciler: DeadlineReminderReconciler) {
+        this.reconciler = reconciler
+        if (hasPendingReconcile) {
+            hasPendingReconcile = false
+            record()
+        }
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/MainViewController.kt
@@ -20,15 +20,18 @@ import androidx.compose.ui.window.ComposeUIViewController
 import com.nexters.bandalart.ads.IosAdsBridge
 import com.nexters.bandalart.di.metro.createIosAppGraph
 import com.nexters.bandalart.notification.DeadlineNotificationLaunchBridge
+import com.nexters.bandalart.notification.DeadlineReminderLifecycleBridge
 import platform.UIKit.UIViewController
 
 @Suppress("FunctionName")
 fun MainViewController(
     notificationLaunchBridge: DeadlineNotificationLaunchBridge,
+    deadlineReminderLifecycleBridge: DeadlineReminderLifecycleBridge,
     adsBridge: IosAdsBridge,
 ): UIViewController {
     val appGraph = createIosAppGraph(adsBridge)
     notificationLaunchBridge.attach(appGraph.deadlineNotificationLaunchTarget)
+    deadlineReminderLifecycleBridge.attach(appGraph.deadlineReminderReconciler)
 
     return ComposeUIViewController {
         BandalartApp(appGraph = appGraph)

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterDeadlineReminderTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterDeadlineReminderTest.kt
@@ -397,6 +397,71 @@ class HomePresenterDeadlineReminderTest {
             }
         }
 
+    @Test
+    fun foregroundReconcilesEvenWhenReminderPreferenceIsDisabled() =
+        runTest {
+            val authorization = FakeAuthorization(DeadlineNotificationAuthorizationStatus.GRANTED)
+            val reconciler = RecordingReconciler()
+            val presenter =
+                presenter(
+                    repository = repository(),
+                    authorization = authorization,
+                    reconciler = reconciler,
+                )
+
+            presenter.test {
+                var state = awaitItem()
+                state.eventSink(HomeScreen.Event.DeadlineReminderForegrounded)
+                while (
+                    state.deadlineNotificationAuthorizationStatus !=
+                    DeadlineNotificationAuthorizationStatus.GRANTED
+                ) {
+                    state = awaitItem()
+                }
+
+                assertEquals(false, state.deadlineReminderEnabled)
+                assertEquals(1, reconciler.reconcileCalls)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun blockedEnableIntentCompletesAfterGrantingPermissionInSystemSettings() =
+        runTest {
+            val settings = FakeSettingsRepository()
+            val authorization = FakeAuthorization(DeadlineNotificationAuthorizationStatus.BLOCKED)
+            val reconciler = RecordingReconciler()
+            val presenter =
+                presenter(
+                    repository = repository(),
+                    settings = settings,
+                    authorization = authorization,
+                    reconciler = reconciler,
+                )
+
+            presenter.test {
+                var state = awaitItem()
+                state.eventSink(HomeScreen.Event.OpenSettings)
+                while (
+                    state.deadlineNotificationAuthorizationStatus !=
+                    DeadlineNotificationAuthorizationStatus.BLOCKED
+                ) {
+                    state = awaitItem()
+                }
+                state.eventSink(HomeScreen.Event.ConfirmDeadlineReminderPermission)
+                advanceUntilIdle()
+                assertEquals(1, authorization.openSettingsCalls)
+
+                authorization.status = DeadlineNotificationAuthorizationStatus.GRANTED
+                state.eventSink(HomeScreen.Event.DeadlineReminderForegrounded)
+                while (!state.deadlineReminderEnabled) state = awaitItem()
+
+                assertEquals(DeadlineNotificationAuthorizationStatus.GRANTED, state.deadlineNotificationAuthorizationStatus)
+                assertEquals(1, reconciler.reconcileCalls)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     private fun presenter(
         repository: FakeBandalartRepository,
         settings: FakeSettingsRepository = FakeSettingsRepository(),
@@ -448,6 +513,7 @@ class HomePresenterDeadlineReminderTest {
         private val requestedStatus: DeadlineNotificationAuthorizationStatus = status,
     ) : DeadlineNotificationAuthorization {
         var requestCalls = 0
+        var openSettingsCalls = 0
 
         override suspend fun getStatus() = status
 
@@ -457,7 +523,9 @@ class HomePresenterDeadlineReminderTest {
             return status
         }
 
-        override suspend fun openSettings() = Unit
+        override suspend fun openSettings() {
+            openSettingsCalls += 1
+        }
     }
 
     private class RecordingReconciler : DeadlineReminderReconciler {

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -124,6 +124,7 @@ class HomePresenter(
         }
         var deadlinePermissionRequestId by remember { mutableStateOf<Long?>(null) }
         var nextDeadlinePermissionRequestId by remember { mutableStateOf(0L) }
+        var enableDeadlineReminderAfterSettings by rememberRetained { mutableStateOf(false) }
         val scope = rememberCoroutineScope()
         val recentEmojiSaveJobs = remember { mutableListOf<kotlinx.coroutines.Job>() }
         val selectionLoadGeneration = remember { longArrayOf(0L) }
@@ -996,6 +997,7 @@ class HomePresenter(
                             }
 
                             DeadlineNotificationAuthorizationStatus.BLOCKED -> {
+                                enableDeadlineReminderAfterSettings = true
                                 deadlineNotificationAuthorization.openSettings()
                             }
 
@@ -1019,9 +1021,19 @@ class HomePresenter(
                 HomeScreen.Event.DeadlineReminderForegrounded -> {
                     scope.launch {
                         deadlineNotificationAuthorizationStatus = deadlineNotificationAuthorization.getStatus()
-                        if (deadlineReminderEnabled) {
-                            deadlineReminderReconciler.reconcileAll()
+                        val shouldEnableAfterSettings =
+                            enableDeadlineReminderAfterSettings &&
+                                (
+                                    deadlineNotificationAuthorizationStatus ==
+                                        DeadlineNotificationAuthorizationStatus.GRANTED ||
+                                        deadlineNotificationAuthorizationStatus ==
+                                        DeadlineNotificationAuthorizationStatus.QUIET
+                                )
+                        enableDeadlineReminderAfterSettings = false
+                        if (shouldEnableAfterSettings) {
+                            settingsRepository.setDeadlineReminderEnabled(true)
                         }
+                        deadlineReminderReconciler.reconcileAll()
                     }
                 }
 

--- a/feature/home/src/iosMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderForegroundEffect.ios.kt
+++ b/feature/home/src/iosMain/kotlin/com/nexters/bandalart/feature/home/DeadlineReminderForegroundEffect.ios.kt
@@ -18,40 +18,26 @@ package com.nexters.bandalart.feature.home
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.rememberUpdatedState
 import platform.Foundation.NSNotificationCenter
 import platform.Foundation.NSOperationQueue
-import platform.Foundation.NSSystemTimeZoneDidChangeNotification
 import platform.UIKit.UIApplicationDidBecomeActiveNotification
-import platform.UIKit.UIApplicationSignificantTimeChangeNotification
 
 @Composable
 internal actual fun DeadlineReminderForegroundEffect(onForeground: () -> Unit) {
     val currentOnForeground = rememberUpdatedState(onForeground)
-    LaunchedEffect(Unit) {
-        currentOnForeground.value()
-    }
     DisposableEffect(Unit) {
         val center = NSNotificationCenter.defaultCenter
-        val names =
-            listOf(
-                UIApplicationDidBecomeActiveNotification,
-                UIApplicationSignificantTimeChangeNotification,
-                NSSystemTimeZoneDidChangeNotification,
-            )
-        val observers =
-            names.map { name ->
-                center.addObserverForName(
-                    name = name,
-                    `object` = null,
-                    queue = NSOperationQueue.mainQueue,
-                ) {
-                    currentOnForeground.value()
-                }
+        val observer =
+            center.addObserverForName(
+                name = UIApplicationDidBecomeActiveNotification,
+                `object` = null,
+                queue = NSOperationQueue.mainQueue,
+            ) {
+                currentOnForeground.value()
             }
         onDispose {
-            observers.forEach(center::removeObserver)
+            center.removeObserver(observer)
         }
     }
 }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -11,11 +11,13 @@ import ComposeApp
 
 struct ComposeView: UIViewControllerRepresentable {
     let notificationLaunchBridge: DeadlineNotificationLaunchBridge
+    let deadlineReminderLifecycleBridge: DeadlineReminderLifecycleBridge
     let adsBridge: IosAdsBridge
 
     func makeUIViewController(context: Context) -> UIViewController {
         MainViewControllerKt.MainViewController(
             notificationLaunchBridge: notificationLaunchBridge,
+            deadlineReminderLifecycleBridge: deadlineReminderLifecycleBridge,
             adsBridge: adsBridge
         )
     }
@@ -25,11 +27,13 @@ struct ComposeView: UIViewControllerRepresentable {
 
 struct ContentView: View {
     let notificationLaunchBridge: DeadlineNotificationLaunchBridge
+    let deadlineReminderLifecycleBridge: DeadlineReminderLifecycleBridge
     let adsBridge: IosAdsBridge
 
     var body: some View {
         ComposeView(
             notificationLaunchBridge: notificationLaunchBridge,
+            deadlineReminderLifecycleBridge: deadlineReminderLifecycleBridge,
             adsBridge: adsBridge
         )
                 .ignoresSafeArea(edges: .all)

--- a/iosApp/iosApp/iosApp.swift
+++ b/iosApp/iosApp/iosApp.swift
@@ -16,7 +16,9 @@ private let deadlineBandalartIdKey = "deadline_bandalart_id"
 
 final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     let notificationLaunchBridge = DeadlineNotificationLaunchBridge()
+    let deadlineReminderLifecycleBridge = DeadlineReminderLifecycleBridge()
     let adsBridge = IosAdsBridgeImpl()
+    private var timeZoneObserver: NSObjectProtocol?
 
     func application(
         _ application: UIApplication,
@@ -25,7 +27,29 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         FirebaseApp.configure()
         adsBridge.start()
         UNUserNotificationCenter.current().delegate = self
+        timeZoneObserver = NotificationCenter.default.addObserver(
+            forName: NSNotification.Name.NSSystemTimeZoneDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.deadlineReminderLifecycleBridge.record()
+        }
+        deadlineReminderLifecycleBridge.record()
         return true
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        deadlineReminderLifecycleBridge.record()
+    }
+
+    func applicationSignificantTimeChange(_ application: UIApplication) {
+        deadlineReminderLifecycleBridge.record()
+    }
+
+    deinit {
+        if let timeZoneObserver {
+            NotificationCenter.default.removeObserver(timeZoneObserver)
+        }
     }
 
     func userNotificationCenter(
@@ -78,6 +102,7 @@ struct iosApp: App {
         WindowGroup {
             ContentView(
                 notificationLaunchBridge: appDelegate.notificationLaunchBridge,
+                deadlineReminderLifecycleBridge: appDelegate.deadlineReminderLifecycleBridge,
                 adsBridge: appDelegate.adsBridge
             )
         }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #211

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- AppDelegate가 앱 시작·foreground·시간대 변경 신호를 앱 수명 bridge에 전달하고, AppGraph 준비 전 신호도 보존하도록 수정했습니다.
- foreground 재조정이 화면의 임시 알림 설정값에 막히지 않도록 durable 설정 판단을 reconciler에 위임했습니다.
- 권한 거절 후 시스템 설정에서 허용하고 돌아오면 기존 활성화 의도를 이어서 설정 저장과 예약 재조정을 완료합니다.
- Home 화면은 권한 상태 갱신만 관찰하고, 알림 예약 복구는 화면 composition과 분리했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `./gradlew :feature:home:testAndroidHostTest :composeApp:testAndroidHostTest`
- `./gradlew :composeApp:compileKotlinIosSimulatorArm64`
- `./gradlew :feature:home:detekt :composeApp:detekt`
- 변경 파일별 Spotless 적용과 `git diff --check` 통과
- 전체 Spotless는 이번 변경과 무관한 기존 `CellText.kt` 포맷 1건 때문에만 실패

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| UI 변경 없음 | - | UI 변경 없음 | - |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 실제 Android/iOS 알림 전달은 Internal/TestFlight 설치본에서 수동 검증이 필요합니다.
- 앱 수명 bridge는 플랫폼 신호 전달과 graph attach 전 버퍼링만 담당하고, 예약 정책은 기존 `DeadlineReminderReconciler`가 계속 소유합니다.
