### PR TITLE
chore: Android 2.3.1 Internal 릴리스 준비

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ targetSdk = "36"
 compileSdk = "37"
 majorVersion = "2"
 minorVersion = "3"
-patchVersion = "0"
+patchVersion = "1"
 packageName = "com.nexters.bandalart"
 
 # Gradle Plugin


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #211

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- Android 앱 버전을 `2.3.1`(`versionCode 20301`)로 변경했습니다.
- 현재 Play 전체 트랙 최대 `versionCode 20300` 다음 번호를 사용합니다.
- 최신 `main`의 Android 마감 알림 시작 복구와 OFF 상태 예약 정리 개선을 Internal Testing에서 검증합니다.
- 기존 한국어·영어·일본어 Internal 릴리스 노트가 해당 검증 내용을 이미 포함해 그대로 사용합니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- Play 전체 트랙 조회: `CURRENT_MAX=20300`, `NEXT=20301`
- Play 릴리스 검증 스크립트 단위 테스트 10개 통과
- 버전 계산식 확인: `2.3.1` → `20301`

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| UI 변경 없음 | - | UI 변경 없음 | - |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 병합 후 Release CD를 `target=android`, `android_update_priority=0`으로 실행합니다.
- Internal AAB에는 Google 공식 Rewarded·Banner 테스트 광고 ID만 사용합니다.
