### PR TITLE
fix: iOS 위젯 아카이브 순환 의존성 해소

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -134,8 +134,8 @@
 				226F38522D5A407D00A1512E /* Sources */,
 				226F38532D5A407D00A1512E /* Frameworks */,
 				226F38542D5A407D00A1512E /* Resources */,
-				F1BDA0012E4A000100000001 /* Upload Crashlytics Symbols */,
 				F300000C2F3000000000000C /* Embed App Extensions */,
+				F1BDA0012E4A000100000001 /* Upload Crashlytics Symbols */,
 			);
 			buildRules = (
 			);

--- a/scripts/tests/test_ios_widget_project.py
+++ b/scripts/tests/test_ios_widget_project.py
@@ -49,6 +49,17 @@ class IosWidgetProjectTest(unittest.TestCase):
         self.assertIn('APPLICATION_EXTENSION_API_ONLY = YES;', project)
         self.assertIn(':iosWidgetShared:embedAndSignAppleFrameworkForXcode', project)
 
+    def test_crashlytics_upload_runs_after_widget_embedding(self):
+        project = PROJECT.read_text()
+        app_target_phases = project.split(
+            '226F38552D5A407D00A1512E /* iosApp */ = {', 1
+        )[1].split('buildRules = (', 1)[0]
+
+        self.assertLess(
+            app_target_phases.index('/* Embed App Extensions */'),
+            app_target_phases.index('/* Upload Crashlytics Symbols */'),
+        )
+
     def test_app_and_widget_share_only_the_expected_app_group(self):
         expected = ["group.com.nexters.bandalart"]
 


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #296

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 위젯 확장을 앱 번들에 포함한 뒤 Crashlytics 심볼 업로드가 실행되도록 iOS 앱 Build Phase 순서를 변경했습니다.
- 동일한 순환 의존성이 다시 생기지 않도록 Build Phase 순서를 확인하는 회귀 테스트를 추가했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인 (`python3 -m unittest scripts.tests.test_ios_widget_project`, 7개 통과)
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료 (Crashlytics 업로드가 위젯 embed 이후인지 검증)
- [x] 기존 기능 영향 없음 (`plutil -lint iosApp/iosApp.xcodeproj/project.pbxproj` 통과)

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 해당 없음 | UI 변경 없음 | 해당 없음 | UI 변경 없음 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- Release CD에서 `Cycle inside iosApp`로 아카이브가 실패한 원인을 최소 변경으로 해소합니다.
