### PR TITLE
fix: 앱 백그라운드 전환 시 Android 위젯 갱신

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -103,6 +103,7 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.fragment)
     implementation(libs.androidx.glance.appwidget)
+    implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.splash)
     implementation(libs.androidx.profileinstaller)

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
@@ -19,6 +19,7 @@ package com.nexters.bandalart
 import android.app.Application
 import android.content.Intent
 import androidx.glance.appwidget.updateAll
+import androidx.lifecycle.ProcessLifecycleOwner
 import com.google.firebase.Firebase
 import com.google.firebase.initialize
 import com.nexters.bandalart.ads.AdsInitializer
@@ -33,6 +34,7 @@ import com.nexters.bandalart.di.metro.observeAndroidWidgetRecentBandalartId
 import com.nexters.bandalart.di.metro.reconcileAndroidDeadlineReminders
 import com.nexters.bandalart.di.metro.recordRewardedCreation
 import com.nexters.bandalart.widget.BandalartGlanceWidget
+import com.nexters.bandalart.widget.BandalartWidgetProcessLifecycleObserver
 import io.github.aakira.napier.DebugAntilog
 import io.github.aakira.napier.Napier
 import io.github.easyhooon.ding.Ding
@@ -49,6 +51,12 @@ class BandalartApplication : Application() {
         private set
     private val adsInitializer by lazy { AdsInitializer(applicationContext) }
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val widgetProcessLifecycleObserver =
+        BandalartWidgetProcessLifecycleObserver(
+            onBackground = {
+                applicationScope.launch { refreshWidgets() }
+            },
+        )
 
     override fun onCreate() {
         super.onCreate()
@@ -97,6 +105,7 @@ class BandalartApplication : Application() {
             .apply { set(applicationContext) }
 
         observeBandalartChangesForWidgets()
+        ProcessLifecycleOwner.get().lifecycle.addObserver(widgetProcessLifecycleObserver)
     }
 
     internal fun reconcileDeadlineRemindersOnUserLaunch() {
@@ -112,14 +121,19 @@ class BandalartApplication : Application() {
                 observeAndroidWidgetBandalarts(appGraph),
                 observeAndroidWidgetRecentBandalartId(appGraph),
             ) { _, _ -> Unit }.collect {
-                try {
-                    BandalartGlanceWidget().updateAll(this@BandalartApplication)
-                } catch (exception: CancellationException) {
-                    throw exception
-                } catch (exception: Exception) {
-                    Napier.e("Failed to refresh widgets after an app edit", exception, tag = "BandalartWidget")
-                }
+                refreshWidgets()
             }
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private suspend fun refreshWidgets() {
+        try {
+            BandalartGlanceWidget().updateAll(this@BandalartApplication)
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (exception: Exception) {
+            Napier.e("Failed to refresh widgets", exception, tag = "BandalartWidget")
         }
     }
 }

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/widget/BandalartWidgetProcessLifecycleObserver.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/widget/BandalartWidgetProcessLifecycleObserver.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.widget
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+
+internal class BandalartWidgetProcessLifecycleObserver(
+    private val onBackground: () -> Unit,
+) : DefaultLifecycleObserver {
+    override fun onStop(owner: LifecycleOwner) {
+        onBackground()
+    }
+}

--- a/androidApp/src/test/kotlin/com/nexters/bandalart/widget/BandalartWidgetProcessLifecycleObserverTest.kt
+++ b/androidApp/src/test/kotlin/com/nexters/bandalart/widget/BandalartWidgetProcessLifecycleObserverTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.widget
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class BandalartWidgetProcessLifecycleObserverTest {
+    @Test
+    fun `refreshes widgets when the app process moves to background`() {
+        var refreshCount = 0
+        val observer = BandalartWidgetProcessLifecycleObserver(onBackground = { refreshCount += 1 })
+
+        observer.onPause(UnusedLifecycleOwner)
+        assertEquals(0, refreshCount)
+
+        observer.onStop(UnusedLifecycleOwner)
+
+        assertEquals(1, refreshCount)
+    }
+
+    private object UnusedLifecycleOwner : LifecycleOwner {
+        override val lifecycle: Lifecycle
+            get() = error("The widget lifecycle observer does not read owner state")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -137,6 +137,7 @@ androidx-work-testing = { group = "androidx.work", name = "work-testing", versio
 androidx-fragment = { group = "androidx.fragment", name = "fragment", version.ref = "androidx-fragment" }
 androidx-glance-appwidget = { group = "androidx.glance", name = "glance-appwidget", version.ref = "androidx-glance" }
 androidx-lifecycle-runtime-compose = { group = "org.jetbrains.androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "androidx-lifecycle-runtime" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "androidx-lifecycle-runtime" }
 androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel", version.ref = "androidx-lifecycle-runtime" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidx-compose-bom" }
 androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #318

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 앱 프로세스가 백그라운드로 전환되는 `ON_STOP` 시점에 설치된 Android 위젯 전체 갱신을 요청합니다.
- 단일 Activity의 `onStop()` 대신 `ProcessLifecycleOwner`를 사용해 Activity 전환이나 구성 변경을 앱 백그라운드 전환으로 오인하지 않습니다.
- 기존 Room/최근 반다라트 변경 갱신과 백그라운드 갱신이 동일한 오류 처리 경로를 사용하도록 정리했습니다.
- 생명주기 `ON_STOP`에서만 갱신 callback이 호출되는 회귀 테스트를 추가했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `./gradlew :androidApp:testDebugUnitTest` — 22개 통과
- `./gradlew detekt` — 통과
- `./gradlew :androidApp:spotlessKotlinCheck :androidApp:spotlessKotlinGradleCheck` — 통과
- `git diff --check` — 통과
- 전체 `spotlessCheck`는 이번 변경과 무관한 기존 `SuspendCatching.kt`, `ObserveEvent.kt` 위반 2건으로 실패
- 연결된 실기기가 없어 `A → B 선택 → 홈 버튼 → 위젯 B 표시` launcher 검증은 미실행

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 기능 설명 | <img src="링크" width="300" /> | 기능 설명 | <img src="링크" width="300" /> |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- `ProcessLifecycleOwner`는 앱의 마지막 Activity가 멈춘 뒤 프로세스 `ON_STOP`을 전달하므로 시스템 홈 버튼으로 나가는 시나리오를 직접 복구합니다.
- 위젯 갱신은 비동기로 실행되며 실패해도 앱의 최근 반다라트 저장 결과를 되돌리지 않습니다.
