### PR TITLE
fix: Android 위젯 설정 크래시 및 세부 목표 선택 유실 수정

### DIFF
--- a/androidApp/src/main/kotlin/com/nexters/bandalart/widget/BandalartWidgetConfigurationActivity.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/widget/BandalartWidgetConfigurationActivity.kt
@@ -65,6 +65,7 @@ import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
 import com.nexters.bandalart.core.domain.entity.BandalartEntity
 import com.nexters.bandalart.di.metro.getAndroidWidgetSubGoals
 import com.nexters.bandalart.di.metro.observeAndroidWidgetBandalarts
+import com.nexters.bandalart.di.metro.setAndroidWidgetRecentBandalartId
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -168,9 +169,15 @@ class BandalartWidgetConfigurationActivity : ComponentActivity() {
         state = current.copy(isSaving = true)
         lifecycleScope.launch {
             val glanceId = GlanceAppWidgetManager(this@BandalartWidgetConfigurationActivity).getGlanceIdBy(appWidgetId)
-            updateAppWidgetState(this@BandalartWidgetConfigurationActivity, glanceId) { preferences ->
-                preferences.setWidgetSelection(selectedBandalartId, current.selectedSubGoalId)
-            }
+            saveWidgetConfiguration(
+                selection = BandalartWidgetSelection(selectedBandalartId, current.selectedSubGoalId),
+                setRecentBandalartId = { bandalartId -> setAndroidWidgetRecentBandalartId(appGraph, bandalartId) },
+                persistSelection = { selection ->
+                    updateAppWidgetState(this@BandalartWidgetConfigurationActivity, glanceId) { preferences ->
+                        preferences.setWidgetSelection(selection.bandalartId, selection.subGoalId)
+                    }
+                },
+            )
             BandalartGlanceWidget().update(this@BandalartWidgetConfigurationActivity, glanceId)
             setResult(Activity.RESULT_OK, resultIntent(appWidgetId))
             finish()
@@ -259,7 +266,7 @@ private fun ConfigurationContent(
                     )
                 }
             } else {
-                items(state.bandalarts, key = BandalartEntity::id) { bandalart ->
+                items(state.bandalarts, key = { bandalart -> bandalartConfigurationItemKey(bandalart.id) }) { bandalart ->
                     SelectionRow(
                         title = bandalart.title?.ifBlank { null } ?: unnamedGoal,
                         selected = state.selectedBandalartId == bandalart.id,
@@ -289,7 +296,7 @@ private fun ConfigurationContent(
                 if (state.isLoadingSubGoals) {
                     item { CircularProgressIndicator(modifier = Modifier.padding(16.dp)) }
                 } else {
-                    items(state.subGoals, key = BandalartCellEntity::id) { subGoal ->
+                    items(state.subGoals, key = { subGoal -> subGoalConfigurationItemKey(subGoal.id) }) { subGoal ->
                         SelectionRow(
                             title = subGoal.title?.ifBlank { null } ?: unnamedSubGoal,
                             selected = state.selectedSubGoalId == subGoal.id,
@@ -334,3 +341,7 @@ private fun SelectionRow(
 }
 
 private fun resultIntent(appWidgetId: Int): Intent = Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+
+internal fun bandalartConfigurationItemKey(bandalartId: Long): String = "bandalart:$bandalartId"
+
+internal fun subGoalConfigurationItemKey(subGoalId: Long): String = "subGoal:$subGoalId"

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/widget/BandalartWidgetState.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/widget/BandalartWidgetState.kt
@@ -45,6 +45,15 @@ internal fun MutablePreferences.setWidgetSelection(
     subGoalId?.let { this[SubGoalIdKey] = it } ?: remove(SubGoalIdKey)
 }
 
+internal suspend fun saveWidgetConfiguration(
+    selection: BandalartWidgetSelection,
+    setRecentBandalartId: suspend (Long) -> Unit,
+    persistSelection: suspend (BandalartWidgetSelection) -> Unit,
+) {
+    persistSelection(selection)
+    setRecentBandalartId(selection.bandalartId)
+}
+
 internal fun subGoalIdAfterBandalartSelection(
     currentBandalartId: Long?,
     currentSubGoalId: Long?,

--- a/androidApp/src/test/kotlin/com/nexters/bandalart/widget/BandalartWidgetConfigurationStateTest.kt
+++ b/androidApp/src/test/kotlin/com/nexters/bandalart/widget/BandalartWidgetConfigurationStateTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.widget
+
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class BandalartWidgetConfigurationStateTest {
+    @Test
+    fun `board and subgoal rows keep distinct keys when database ids overlap`() {
+        assertNotEquals(
+            bandalartConfigurationItemKey(bandalartId = 2L),
+            subGoalConfigurationItemKey(subGoalId = 2L),
+        )
+    }
+
+    @Test
+    fun `saving configuration makes its board recent before widget rendering`() =
+        runBlocking {
+            val configuredSelection = BandalartWidgetSelection(bandalartId = 1L, subGoalId = 2L)
+            var recentBandalartId = 3L
+            var persistedSelection: BandalartWidgetSelection? = null
+
+            saveWidgetConfiguration(
+                selection = configuredSelection,
+                setRecentBandalartId = { recentBandalartId = it },
+                persistSelection = { persistedSelection = it },
+            )
+
+            assertEquals(
+                configuredSelection,
+                resolveWidgetSelection(
+                    configuredSelection = persistedSelection,
+                    recentBandalartId = recentBandalartId,
+                ),
+            )
+        }
+}

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
@@ -116,6 +116,13 @@ fun observeAndroidWidgetRecentBandalartId(appGraph: AppGraph): Flow<Long> = appG
 
 suspend fun getAndroidWidgetRecentBandalartId(appGraph: AppGraph): Long = appGraph.bandalartRepository.getRecentBandalartId()
 
+suspend fun setAndroidWidgetRecentBandalartId(
+    appGraph: AppGraph,
+    bandalartId: Long,
+) {
+    appGraph.bandalartRepository.setRecentBandalartId(bandalartId)
+}
+
 suspend fun getAndroidWidgetSubGoals(
     appGraph: AppGraph,
     bandalartId: Long,


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #322

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 반다라트와 세부 목표의 DB 숫자 ID가 겹쳐도 `LazyColumn` key가 충돌하지 않도록 행 종류별 namespace를 적용했습니다.
- 위젯 설정을 저장할 때 선택한 반다라트를 최근 반다라트로 함께 기록해, 렌더링 과정에서 선택한 세부 목표가 제거되지 않도록 수정했습니다.
- 앱에서 이후 다른 반다라트를 조회하면 위젯이 최근 조회 항목을 따라가는 기존 동작은 유지됩니다.
- 중복 ID와 설정 저장 후 렌더링 흐름을 검증하는 회귀 테스트 2개를 추가했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `./gradlew :androidApp:testDebugUnitTest` — 24개 통과
- `./gradlew detekt` — 통과
- `./gradlew :androidApp:spotlessKotlinCheck :androidApp:spotlessKotlinGradleCheck :composeApp:spotlessKotlinCheck` — 통과
- `git diff --check` — 통과

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 위젯 설정 | 실기기 재검증 예정 | 세부 목표 표시 | 실기기 재검증 예정 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 최초 생성 데이터에서는 두 테이블의 auto-increment 값이 겹칠 수 있어 첫 반다라트의 세부 목표 key와 다른 반다라트 key가 충돌했습니다.
- 저장된 세부 목표는 설정 반다라트와 최근 반다라트가 같을 때만 유효하므로, 설정 저장 완료 전에 두 값을 일치시킵니다.
- 연결된 Android 실기기가 없어 launcher에서 `위젯 추가 → 페스티벌 준비 선택 → 세부 목표 선택 → 위젯 확대` 시나리오는 PR CI 후 내부 테스트에서 재확인해야 합니다.
