### PR TITLE
fix: Android 위젯 활성 세션 최신 상태 동기화

### DIFF
--- a/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
@@ -29,9 +29,7 @@ import com.nexters.bandalart.ads.DelegatingRewardedAdGateway
 import com.nexters.bandalart.di.metro.AppGraph
 import com.nexters.bandalart.di.metro.createAndroidAppGraph
 import com.nexters.bandalart.di.metro.installAndroidDeadlineReminderInfrastructure
-import com.nexters.bandalart.di.metro.observeAndroidWidgetBandalarts
-import com.nexters.bandalart.di.metro.observeAndroidWidgetRecentBandalartId
-import com.nexters.bandalart.di.metro.observeAndroidWidgetRecentSubGoalId
+import com.nexters.bandalart.di.metro.observeAndroidWidgetStateChanges
 import com.nexters.bandalart.di.metro.reconcileAndroidDeadlineReminders
 import com.nexters.bandalart.di.metro.recordRewardedCreation
 import com.nexters.bandalart.widget.BandalartGlanceWidget
@@ -45,7 +43,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 class BandalartApplication : Application() {
@@ -120,11 +117,7 @@ class BandalartApplication : Application() {
     @Suppress("TooGenericExceptionCaught")
     private fun observeBandalartChangesForWidgets() {
         applicationScope.launch {
-            combine(
-                observeAndroidWidgetBandalarts(appGraph),
-                observeAndroidWidgetRecentBandalartId(appGraph),
-                observeAndroidWidgetRecentSubGoalId(appGraph),
-            ) { _, _, _ -> Unit }.collect {
+            observeAndroidWidgetStateChanges(appGraph).collect {
                 widgetRefreshRunner.refresh()
             }
         }

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/widget/BandalartGlanceWidget.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/widget/BandalartGlanceWidget.kt
@@ -21,6 +21,8 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -57,10 +59,11 @@ import androidx.glance.text.TextStyle
 import com.nexters.bandalart.BandalartApplication
 import com.nexters.bandalart.MainActivity
 import com.nexters.bandalart.R
-import com.nexters.bandalart.di.metro.getAndroidWidgetRecentBandalartId
-import com.nexters.bandalart.di.metro.getAndroidWidgetRecentSubGoalId
 import com.nexters.bandalart.di.metro.getAndroidWidgetSubGoals
 import com.nexters.bandalart.di.metro.getAndroidWidgetSnapshot
+import com.nexters.bandalart.di.metro.observeAndroidWidgetStateChanges
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 
 class BandalartGlanceWidget : GlanceAppWidget() {
     override val sizeMode: SizeMode =
@@ -81,39 +84,35 @@ class BandalartGlanceWidget : GlanceAppWidget() {
         val preferences = getAppWidgetState(context, PreferencesGlanceStateDefinition, id)
         val appGraph = (context.applicationContext as BandalartApplication).appGraph
         val configuredSelection = preferences.toWidgetSelection()
-        val recentBandalartId = getAndroidWidgetRecentBandalartId(appGraph)
-        val bandalartId = resolveWidgetBandalartId(configuredSelection, recentBandalartId)
-        val availableSubGoalIds =
-            bandalartId
-                ?.let { getAndroidWidgetSubGoals(appGraph, it) }
-                .orEmpty()
-                .filterNot { it.title.isNullOrBlank() }
-                .mapNotNull { it.id }
-        val recentSubGoalId = bandalartId?.let { getAndroidWidgetRecentSubGoalId(appGraph, it) } ?: 0L
-        val selection =
-            resolveWidgetSelection(
-                configuredSelection = configuredSelection,
-                recentBandalartId = recentBandalartId,
-                recentSubGoalId = recentSubGoalId,
-                availableSubGoalIds = availableSubGoalIds,
-            )
         val appWidgetId = GlanceAppWidgetManager(context).getAppWidgetId(id)
-        val snapshot =
-            selection?.let {
-                getAndroidWidgetSnapshot(
-                    appGraph = appGraph,
-                    bandalartId = it.bandalartId,
-                    subGoalId = it.subGoalId,
-                )
-            }
-        val viewState =
-            toWidgetViewState(
-                selection = selection,
-                snapshot = snapshot,
+        val viewStates =
+            observeWidgetViewStates(
+                configuredSelection = configuredSelection,
+                changes =
+                    observeAndroidWidgetStateChanges(appGraph).map { selection ->
+                        BandalartWidgetRecentSelection(
+                            bandalartId = selection.bandalartId,
+                            subGoalId = selection.subGoalId,
+                        )
+                    },
+                loadAvailableSubGoalIds = { bandalartId ->
+                    getAndroidWidgetSubGoals(appGraph, bandalartId)
+                        .filterNot { it.title.isNullOrBlank() }
+                        .mapNotNull { it.id }
+                },
+                loadSnapshot = { selection ->
+                    getAndroidWidgetSnapshot(
+                        appGraph = appGraph,
+                        bandalartId = selection.bandalartId,
+                        subGoalId = selection.subGoalId,
+                    )
+                },
                 unnamedGoalTitle = context.getString(R.string.bandalart_widget_unnamed_goal),
             )
+        val initialViewState = viewStates.first()
 
         provideContent {
+            val viewState by viewStates.collectAsState(initialViewState)
             BandalartWidgetContent(
                 context = context,
                 appWidgetId = appWidgetId,

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/widget/BandalartWidgetState.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/widget/BandalartWidgetState.kt
@@ -21,6 +21,10 @@ import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.longPreferencesKey
 import com.nexters.bandalart.core.domain.entity.BandalartWidgetSnapshot
 import com.nexters.bandalart.core.domain.entity.BandalartWidgetTask
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.mapLatest
 
 internal val BandalartIdKey = longPreferencesKey("bandalartId")
 internal val SubGoalIdKey = longPreferencesKey("subGoalId")
@@ -28,6 +32,11 @@ internal val SubGoalIdKey = longPreferencesKey("subGoalId")
 internal data class BandalartWidgetSelection(
     val bandalartId: Long,
     val subGoalId: Long?,
+)
+
+internal data class BandalartWidgetRecentSelection(
+    val bandalartId: Long,
+    val subGoalId: Long,
 )
 
 internal fun Preferences.toWidgetSelection(): BandalartWidgetSelection? {
@@ -89,6 +98,37 @@ internal fun resolveWidgetBandalartId(
     configuredSelection: BandalartWidgetSelection?,
     recentBandalartId: Long,
 ): Long? = recentBandalartId.takeIf { it > 0L } ?: configuredSelection?.bandalartId
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal fun observeWidgetViewStates(
+    configuredSelection: BandalartWidgetSelection?,
+    changes: Flow<BandalartWidgetRecentSelection>,
+    loadAvailableSubGoalIds: suspend (Long) -> List<Long>,
+    loadSnapshot: suspend (BandalartWidgetSelection) -> BandalartWidgetSnapshot?,
+    unnamedGoalTitle: String,
+): Flow<BandalartWidgetViewState> =
+    changes
+        .mapLatest { recentSelection ->
+            val bandalartId =
+                resolveWidgetBandalartId(
+                    configuredSelection = configuredSelection,
+                    recentBandalartId = recentSelection.bandalartId,
+                )
+            val availableSubGoalIds = bandalartId?.let { loadAvailableSubGoalIds(it) }.orEmpty()
+            val selection =
+                resolveWidgetSelection(
+                    configuredSelection = configuredSelection,
+                    recentBandalartId = recentSelection.bandalartId,
+                    recentSubGoalId = recentSelection.subGoalId,
+                    availableSubGoalIds = availableSubGoalIds,
+                )
+            val snapshot = selection?.let { loadSnapshot(it) }
+            toWidgetViewState(
+                selection = selection,
+                snapshot = snapshot,
+                unnamedGoalTitle = unnamedGoalTitle,
+            )
+        }.distinctUntilChanged()
 
 internal enum class BandalartWidgetLayout(
     val taskLimit: Int,

--- a/androidApp/src/test/kotlin/com/nexters/bandalart/widget/BandalartWidgetStateFlowTest.kt
+++ b/androidApp/src/test/kotlin/com/nexters/bandalart/widget/BandalartWidgetStateFlowTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.widget
+
+import com.nexters.bandalart.core.domain.entity.BandalartWidgetSnapshot
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class BandalartWidgetStateFlowTest {
+    @Test
+    fun `active widget session renders latest progress after a database change`() =
+        runBlocking {
+            val changes = MutableSharedFlow<BandalartWidgetRecentSelection>(replay = 1)
+            val firstStateCollected = CompletableDeferred<Unit>()
+            var completionRatio = 10
+            val renderedRatios = mutableListOf<Int>()
+            val collection =
+                launch {
+                    observeWidgetViewStates(
+                        configuredSelection = BandalartWidgetSelection(1L, 11L),
+                        changes = changes,
+                        loadAvailableSubGoalIds = { listOf(11L) },
+                        loadSnapshot = { selection ->
+                            widgetSnapshot(selection, completionRatio)
+                        },
+                        unnamedGoalTitle = "Untitled goal",
+                    ).take(2).collect { state ->
+                        renderedRatios += (state as BandalartWidgetViewState.Content).completionRatio
+                        if (renderedRatios.size == 1) firstStateCollected.complete(Unit)
+                    }
+                }
+
+            changes.emit(BandalartWidgetRecentSelection(bandalartId = 1L, subGoalId = 11L))
+            firstStateCollected.await()
+            completionRatio = 70
+            changes.emit(BandalartWidgetRecentSelection(bandalartId = 1L, subGoalId = 11L))
+            collection.join()
+
+            assertEquals(listOf(10, 70), renderedRatios)
+        }
+
+    @Test
+    fun `recent board and subgoal are resolved from one emitted selection`() =
+        runBlocking {
+            val changes = MutableSharedFlow<BandalartWidgetRecentSelection>(replay = 1)
+            val loadedSelections = mutableListOf<BandalartWidgetSelection>()
+            val collection =
+                launch {
+                    observeWidgetViewStates(
+                        configuredSelection = BandalartWidgetSelection(1L, 11L),
+                        changes = changes,
+                        loadAvailableSubGoalIds = { bandalartId ->
+                            if (bandalartId == 2L) listOf(21L) else listOf(11L)
+                        },
+                        loadSnapshot = { selection ->
+                            loadedSelections += selection
+                            widgetSnapshot(selection, completionRatio = 30)
+                        },
+                        unnamedGoalTitle = "Untitled goal",
+                    ).first()
+                }
+
+            changes.emit(BandalartWidgetRecentSelection(bandalartId = 2L, subGoalId = 21L))
+            collection.join()
+
+            assertEquals(listOf(BandalartWidgetSelection(2L, 21L)), loadedSelections)
+        }
+
+    private fun widgetSnapshot(
+        selection: BandalartWidgetSelection,
+        completionRatio: Int,
+    ) = BandalartWidgetSnapshot(
+        bandalartId = selection.bandalartId,
+        subGoalId = selection.subGoalId,
+        title = "Goal",
+        profileEmoji = "🎯",
+        completionRatio = completionRatio,
+        subGoalTitle = "Sub goal",
+        tasks = emptyList(),
+    )
+}

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
@@ -33,6 +33,12 @@ import com.nexters.bandalart.notification.AndroidDeadlineReminderScheduler
 import com.nexters.bandalart.notification.AndroidDeadlineReminderDependencies
 import com.nexters.bandalart.notification.AndroidDeadlineReminderDependenciesRegistry
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+
+data class AndroidWidgetRecentSelection(
+    val bandalartId: Long,
+    val subGoalId: Long,
+)
 
 private class AndroidPlatformBindings(
     application: Application,
@@ -110,13 +116,18 @@ fun recordAndroidWidgetLaunch(
     appGraph.bandalartWidgetLaunchTarget.record(bandalartId)
 }
 
+fun observeAndroidWidgetStateChanges(appGraph: AppGraph): Flow<AndroidWidgetRecentSelection> =
+    combine(
+        appGraph.bandalartRepository.getBandalartList(),
+        appGraph.bandalartDataStore.recentBandalartSelection,
+    ) { _, selection ->
+        AndroidWidgetRecentSelection(
+            bandalartId = selection.bandalartId,
+            subGoalId = selection.subGoalId,
+        )
+    }
+
 fun observeAndroidWidgetBandalarts(appGraph: AppGraph): Flow<List<BandalartEntity>> = appGraph.bandalartRepository.getBandalartList()
-
-fun observeAndroidWidgetRecentBandalartId(appGraph: AppGraph): Flow<Long> = appGraph.bandalartRepository.observeRecentBandalartId()
-
-fun observeAndroidWidgetRecentSubGoalId(appGraph: AppGraph): Flow<Long> = appGraph.bandalartRepository.observeRecentSubGoalId()
-
-suspend fun getAndroidWidgetRecentBandalartId(appGraph: AppGraph): Long = appGraph.bandalartRepository.getRecentBandalartId()
 
 suspend fun setAndroidWidgetRecentBandalartId(
     appGraph: AppGraph,
@@ -124,11 +135,6 @@ suspend fun setAndroidWidgetRecentBandalartId(
 ) {
     appGraph.bandalartRepository.setRecentBandalartId(bandalartId)
 }
-
-suspend fun getAndroidWidgetRecentSubGoalId(
-    appGraph: AppGraph,
-    bandalartId: Long,
-): Long = appGraph.bandalartRepository.getRecentSubGoalId(bandalartId)
 
 suspend fun setAndroidWidgetRecentSubGoalId(
     appGraph: AppGraph,

--- a/docs/features/widgets/ANDROID_WIDGET_SYNC_TROUBLESHOOTING.md
+++ b/docs/features/widgets/ANDROID_WIDGET_SYNC_TROUBLESHOOTING.md
@@ -27,11 +27,12 @@ Android `2.3.2 (20302)`에서 위젯이 늦게 바뀌거나 이전 달성률을 
 앱 프로세스가 살아 있는 동안의 로컬 변경은 다음 경로로 처리한다.
 
 1. 앱이 Room의 반다라트·세부 목표·할 일 또는 DataStore의 최근 선택을 변경한다.
-2. `BandalartApplication`이 반다라트 목록, 최근 반다라트, 최근 세부 목표 Flow를 관찰한다.
+2. `BandalartApplication`이 반다라트 목록과 원자적인 `recentBandalartSelection` Flow를 함께 관찰한다.
 3. 데이터 변경 또는 프로세스 `ON_STOP`에서 `BandalartWidgetRefreshRunner.refresh()`를 요청한다.
 4. refresh runner가 여러 요청을 `Mutex`로 직렬화한다.
 5. `BandalartGlanceWidget.updateAll()`이 설치된 모든 위젯의 갱신을 요청한다.
-6. `provideGlance()`가 최신 Room/DataStore 값을 다시 읽어 `RemoteViews`를 만들고 launcher host에 전달한다.
+6. 새 `provideGlance()`는 최신 Room/DataStore 값을 읽고, 실행 중인 Glance composition은 같은 변경 Flow를 계속 관찰한다.
+7. 변경된 snapshot을 새 `RemoteViews`로 만들어 launcher host에 전달한다.
 
 정기 polling은 사용하지 않는다. 앱에서 방금 변경한 로컬 데이터는 위 경로로 갱신하지만, 앱 프로세스가 죽은 동안 서버에서만 바뀐 데이터는 별도의 broadcast나 WorkManager 동기화 계기가 없으면 자동으로 반영되지 않는다.
 
@@ -54,6 +55,17 @@ JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home \
 
 검증 시 refresh runner의 `Mutex`를 제거하면 `latest progress wins when background and database refresh overlap`가 실패하고, 현재 `main` 구현에서는 통과한다.
 
+## 2.3.3에서 보완한 활성 세션과 최근 선택
+
+Glance 공식 동작상 `provideGlance()`가 이미 실행 중이면 뒤이어 호출한 `updateAll()`이 그 세션을 재시작하지 않는다. 이전 구현은 `provideContent()` 전에 snapshot을 한 번만 읽어서, 활성 세션이 남아 있는 동안 새 갱신 요청이 와도 이전 화면을 유지할 수 있었다.
+
+2.3.3에서는 다음 두 경계를 보완한다.
+
+1. `provideContent()` 안에서 Room/DataStore 변경으로 만든 위젯 상태 Flow를 `collectAsState()`로 구독한다. 활성 Glance 세션은 진행률·할 일·최근 선택이 바뀌면 같은 composition에서 최신 snapshot으로 다시 그린다.
+2. Android도 DataStore의 한 Preferences snapshot에서 생성된 `recentBandalartSelection`을 사용한다. 반다라트 ID를 읽은 뒤 별도 시점에 세부 목표 ID를 읽어 서로 다른 선택이 조합되는 경로를 제거했다.
+
+세션이 종료된 뒤의 변경은 기존 `updateAll()` 경로가 새 세션을 시작한다. 따라서 활성 세션 구독은 `updateAll()`을 대체하지 않고, 두 경로가 각각 실행 중·종료 후 갱신을 담당한다.
+
 ## Android/Glance의 실제 한계
 
 `updateAll()`은 launcher 화면을 앱의 Compose UI처럼 같은 프레임에 다시 그리는 API가 아니다. Android 공식 문서에 따르면 앱 위젯은 다른 프로세스에서 host되며, Glance가 콘텐츠를 `RemoteViews`로 다시 만들고 host에 전송한다. 따라서 호출 직후 한두 프레임 안에 표시된다는 실시간 보장은 없고 기기와 launcher에 따라 짧은 비동기 지연은 생길 수 있다.
@@ -75,14 +87,14 @@ JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home \
 | 비교 지점 | Android 현재 구현 | iOS 현재 구현 | Android에서 늘어나는 위험 |
 | --- | --- | --- | --- |
 | 화면 host | 제조사 또는 사용자가 선택한 launcher가 `RemoteViews`를 표시 | Apple의 WidgetKit과 시스템 host가 timeline을 표시 | launcher별 캐시·배치·크기 처리 차이를 함께 검증해야 함 |
-| 갱신 입력 | Room Flow, 최근 반다라트 Flow, 최근 세부 목표 Flow, 프로세스 `ON_STOP`, 위젯 action | 반다라트 Flow, 원자적인 최근 선택 Flow, 앱 활성화, 위젯 intent | 여러 Android 요청이 겹치거나 순서가 바뀔 가능성이 큼 |
-| 실행 중 갱신 | 실행 중인 `provideGlance()`를 새 `updateAll()`이 재시작하지 않음 | WidgetKit이 reload 요청을 받고 새 timeline 요청 시점을 관리 | Android session이 최신 데이터를 관찰하지 않으면 후속 요청이 와도 이전 snapshot을 유지할 수 있음 |
+| 갱신 입력 | Room Flow, 원자적인 최근 선택 Flow, 프로세스 `ON_STOP`, 위젯 action | 반다라트 Flow, 원자적인 최근 선택 Flow, 앱 활성화, 위젯 intent | 여러 Android 요청이 겹치거나 순서가 바뀔 가능성이 큼 |
+| 실행 중 갱신 | 새 `updateAll()`은 세션을 재시작하지 않으므로 활성 composition이 변경 Flow를 직접 관찰 | WidgetKit이 reload 요청을 받고 새 timeline 요청 시점을 관리 | Android는 활성 세션 구독과 세션 종료 후 `updateAll()` 두 경로를 함께 유지해야 함 |
 | 갱신 시점의 읽기 | `updateAll()` 처리 중 앱 프로세스가 snapshot을 읽고 각 인스턴스를 갱신 | 앱은 선택을 App Group에 먼저 쓰고 timeline reload를 요청하며, extension이 timeline 생성 시 snapshot을 읽음 | Android는 먼저 읽은 snapshot의 갱신이 늦게 끝나면 이전 화면을 덮을 수 있었음 |
-| 최근 선택 | 반다라트 ID와 해당 세부 목표 ID를 `provideGlance()`에서 따로 읽음 | 한 Preferences snapshot에서 만든 `recentBandalartSelection`을 먼저 기록 | Android는 두 읽기 사이에 선택이 바뀌면 조합이 일시적으로 어긋날 여지가 남음 |
+| 최근 선택 | 한 Preferences snapshot에서 만든 `recentBandalartSelection`을 사용 | 한 Preferences snapshot에서 만든 `recentBandalartSelection`을 먼저 기록 | 두 플랫폼 모두 앱 수준에서는 반다라트와 세부 목표를 원자적으로 전달 |
 | 인스턴스 상태 | 각 위젯의 Glance 설정값과 앱의 최근 선택 fallback을 함께 해석 | 현재 intent는 매개변수가 없고 모든 위젯이 같은 최근 선택을 사용 | 여러 Android 인스턴스에서 설정 상태와 최근 상태의 조합 수가 늘어남 |
 | 백그라운드 정책 | 앱 프로세스와 launcher가 제조사별 절전 정책의 영향을 받을 수 있음 | extension 실행과 timeline 갱신을 WidgetKit이 통제 | Android 실기기 QA에 제조사·launcher 조합이 추가됨 |
 
-Android의 `Mutex`는 앱이 시작한 갱신 요청끼리 순서를 보장한다. 실행 중인 Glance session을 다시 시작하거나 launcher가 화면에 반영하는 시점까지 통제하지는 못한다. 따라서 회귀 테스트 통과는 앱의 동시 refresh 순서를 고정했다는 뜻이며, 실행 중 session이 최신 값을 다시 읽거나 홈 화면에 즉시 보인다는 보장은 아니다.
+Android의 `Mutex`는 앱이 시작한 갱신 요청끼리 순서를 보장하고, 활성 Glance composition의 Flow 구독은 실행 중 세션이 최신 값을 다시 읽게 한다. 둘 다 launcher가 `RemoteViews`를 화면에 반영하는 시점까지 통제하지는 못하므로, 홈 화면에 같은 프레임으로 즉시 보인다는 보장은 아니다.
 
 iOS도 자동으로 안전한 것은 아니다. App Group 데이터 기록과 extension의 데이터베이스 읽기 사이에 순서 문제가 생길 수 있고, WidgetKit도 요청마다 즉시 새 timeline을 표시한다고 보장하지 않는다. Apple은 WidgetKit이 여러 위젯의 reload를 합치거나 사용 빈도에 따라 reload 예산을 조정할 수 있다고 설명한다.
 
@@ -90,12 +102,10 @@ iOS도 자동으로 안전한 것은 아니다. App Group 데이터 기록과 ex
 
 Android에서 남은 위험을 줄일 때는 다음 순서로 검토한다.
 
-1. 실행 중인 `provideGlance()`가 Room/DataStore 변경을 관찰하게 하거나, session 종료 후 최신 generation을 다시 갱신하는 구조를 검토한다.
-2. `provideGlance()`가 반다라트와 세부 목표를 따로 읽지 않고 `recentBandalartSelection` 하나를 읽게 한다.
-3. refresh 요청에 증가하는 generation과 원인을 기록해 마지막 generation이 실제 snapshot 생성까지 도달했는지 확인한다.
-4. `updateAll()` 완료와 launcher 표시 완료를 같은 의미로 기록하지 않는다.
-5. Pixel 계열 launcher와 Samsung One UI launcher에서 단일·복수 위젯을 각각 검증한다.
-6. 배포 기록에 source commit을 남겨 같은 버전 이름의 서로 다른 소스를 구분한다.
+1. refresh 요청에 증가하는 generation과 원인을 기록해 마지막 generation이 실제 snapshot 생성까지 도달했는지 확인한다.
+2. `updateAll()` 완료와 launcher 표시 완료를 같은 의미로 기록하지 않는다.
+3. Pixel 계열 launcher와 Samsung One UI launcher에서 단일·복수 위젯을 각각 검증한다.
+4. 배포 기록에 source commit을 남겨 같은 버전 이름의 서로 다른 소스를 구분한다.
 
 ## 실기기 재현 및 판정 절차
 


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #330

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 실행 중인 Glance composition이 Room/DataStore 변경 Flow를 구독해 최신 진행률과 할 일을 다시 렌더링하도록 수정했습니다.
- Android 최근 반다라트와 세부 목표를 한 DataStore snapshot에서 읽도록 통합했습니다.
- 이전 snapshot 로딩은 취소하고 최신 변경이 이기도록 했으며 회귀 테스트와 트러블슈팅 문서를 갱신했습니다.

## 🧪 테스트 내역 (선택)

- [x] `:androidApp:testDebugUnitTest` 29개 통과
- [x] `:core:datastore:testAndroidHostTest` 통과
- [x] `detekt`, `:androidApp:spotlessCheck`, `:composeApp:spotlessCheck`, `git diff --check` 통과
- [ ] 실기기에서 A → B → 홈 및 진행률 변경 시나리오 확인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 기능 설명 | <img src="링크" width="300" /> | 기능 설명 | <img src="링크" width="300" /> |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- `updateAll()`은 활성 Glance 세션을 재시작하지 않으므로 composition 내부 구독이 필요합니다. 세션 종료 후 변경은 기존 `updateAll()` 경로가 담당합니다.
- 전체 Spotless는 기존 `core/common/.../ObserveEvent.kt` 포맷 1건 때문에 실패하며, 변경 모듈의 Spotless는 통과했습니다.