### PR TITLE
feat: 클라우드 백업 및 복원 지원

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ xcuserdata/
 
 .kotlin/
 __pycache__/
+
+# Node-based project tools
+/node_modules/

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -13,9 +13,32 @@ plugins {
 }
 
 val useTestAds = providers.gradleProperty("bandalart.useTestAds").orNull.toBoolean()
+val localProperties =
+    Properties().apply {
+        rootProject
+            .file("local.properties")
+            .takeIf { it.exists() }
+            ?.inputStream()
+            ?.use(::load)
+    }
+val supabaseUrl =
+    providers.gradleProperty("bandalart.supabaseUrl").orNull
+        ?: providers.environmentVariable("BANDALART_SUPABASE_URL").orNull
+        ?: localProperties.getProperty("bandalart.supabaseUrl").orEmpty()
+val supabasePublishableKey =
+    providers.gradleProperty("bandalart.supabasePublishableKey").orNull
+        ?: providers.environmentVariable("BANDALART_SUPABASE_PUBLISHABLE_KEY").orNull
+        ?: localProperties.getProperty("bandalart.supabasePublishableKey").orEmpty()
+
+fun String.asBuildConfigString(): String = "\"${replace("\\", "\\\\").replace("\"", "\\\"")}\""
 
 android {
     namespace = "com.nexters.bandalart"
+
+    defaultConfig {
+        buildConfigField("String", "SUPABASE_URL", supabaseUrl.asBuildConfigString())
+        buildConfigField("String", "SUPABASE_PUBLISHABLE_KEY", supabasePublishableKey.asBuildConfigString())
+    }
 
     signingConfigs {
         create("release") {
@@ -97,6 +120,7 @@ play {
 dependencies {
     implementation(projects.composeApp)
     implementation(projects.core.common)
+    implementation(projects.core.data)
     implementation(projects.core.designsystem)
     implementation(projects.core.domain)
 

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
@@ -26,6 +26,7 @@ import com.nexters.bandalart.ads.AdsInitializer
 import com.nexters.bandalart.ads.AndroidBannerAdHost
 import com.nexters.bandalart.ads.AndroidRewardedAdGateway
 import com.nexters.bandalart.ads.DelegatingRewardedAdGateway
+import com.nexters.bandalart.core.data.backup.BackupApiConfig
 import com.nexters.bandalart.di.metro.AppGraph
 import com.nexters.bandalart.di.metro.createAndroidAppGraph
 import com.nexters.bandalart.di.metro.installAndroidDeadlineReminderInfrastructure
@@ -68,6 +69,11 @@ class BandalartApplication : Application() {
                 application = this,
                 bannerAdHost = bannerAdHost,
                 rewardedAdGateway = rewardedAdGateway,
+                backupApiConfig =
+                    BackupApiConfig(
+                        url = BuildConfig.SUPABASE_URL,
+                        publishableKey = BuildConfig.SUPABASE_PUBLISHABLE_KEY,
+                    ),
             )
         installAndroidDeadlineReminderInfrastructure(
             appGraph = appGraph,

--- a/build-logic/src/main/kotlin/com/nexters/bandalart/buildlogic/task/GenerateBackupBuildConfigTask.kt
+++ b/build-logic/src/main/kotlin/com/nexters/bandalart/buildlogic/task/GenerateBackupBuildConfigTask.kt
@@ -1,0 +1,39 @@
+package com.nexters.bandalart.buildlogic.task
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+abstract class GenerateBackupBuildConfigTask : DefaultTask() {
+    @get:Input
+    abstract val supabaseUrl: Property<String>
+
+    @get:Input
+    abstract val supabasePublishableKey: Property<String>
+
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
+
+    @TaskAction
+    fun generate() {
+        val destination = outputFile.get().asFile
+        destination.parentFile.mkdirs()
+        destination.writeText(
+            """
+            package com.nexters.bandalart.backup
+
+            internal object BackupBuildConfig {
+                const val SUPABASE_URL = ${supabaseUrl.get().asKotlinStringLiteral()}
+                const val SUPABASE_PUBLISHABLE_KEY = ${supabasePublishableKey.get().asKotlinStringLiteral()}
+            }
+            """.trimIndent(),
+        )
+    }
+
+    private fun String.asKotlinStringLiteral(): String = "\"${replace("\\", "\\\\").replace("\"", "\\\"")}\""
+}

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.nexters.bandalart.buildlogic.task.GenerateBackupBuildConfigTask
 import java.util.Properties
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 
@@ -19,41 +20,24 @@ val localProperties =
             ?.inputStream()
             ?.use(::load)
     }
-val supabaseUrl =
+val backupSupabaseUrl =
     providers.gradleProperty("bandalart.supabaseUrl").orNull
         ?: providers.environmentVariable("BANDALART_SUPABASE_URL").orNull
         ?: localProperties.getProperty("bandalart.supabaseUrl").orEmpty()
-val supabasePublishableKey =
+val backupSupabasePublishableKey =
     providers.gradleProperty("bandalart.supabasePublishableKey").orNull
         ?: providers.environmentVariable("BANDALART_SUPABASE_PUBLISHABLE_KEY").orNull
         ?: localProperties.getProperty("bandalart.supabasePublishableKey").orEmpty()
 val generatedBackupConfigDirectory = layout.buildDirectory.dir("generated/backupConfig/commonMain")
-val generateBackupBuildConfig by tasks.registering {
-    val generatedFile =
+val generateBackupBuildConfig by tasks.registering(GenerateBackupBuildConfigTask::class) {
+    supabaseUrl.set(backupSupabaseUrl)
+    supabasePublishableKey.set(backupSupabasePublishableKey)
+    outputFile.set(
         generatedBackupConfigDirectory.map {
             it.file("com/nexters/bandalart/backup/BackupBuildConfig.kt")
-        }
-    inputs.property("supabaseUrl", supabaseUrl)
-    inputs.property("supabasePublishableKey", supabasePublishableKey)
-    outputs.file(generatedFile)
-    doLast {
-        generatedFile.get().asFile.apply {
-            parentFile.mkdirs()
-            writeText(
-                """
-                package com.nexters.bandalart.backup
-
-                internal object BackupBuildConfig {
-                    const val SUPABASE_URL = ${supabaseUrl.asKotlinStringLiteral()}
-                    const val SUPABASE_PUBLISHABLE_KEY = ${supabasePublishableKey.asKotlinStringLiteral()}
-                }
-                """.trimIndent(),
-            )
-        }
-    }
+        },
+    )
 }
-
-fun String.asKotlinStringLiteral(): String = "\"${replace("\\", "\\\\").replace("\"", "\\\"")}\""
 
 metro {
     enableCircuitCodegen.set(true)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.util.Properties
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
 plugins {
     id("bandalart.lint")
     id("bandalart.kmp")
@@ -7,6 +10,50 @@ plugins {
     id("bandalart.kmp.firebase")
     alias(libs.plugins.metro)
 }
+
+val localProperties =
+    Properties().apply {
+        rootProject
+            .file("local.properties")
+            .takeIf { it.exists() }
+            ?.inputStream()
+            ?.use(::load)
+    }
+val supabaseUrl =
+    providers.gradleProperty("bandalart.supabaseUrl").orNull
+        ?: providers.environmentVariable("BANDALART_SUPABASE_URL").orNull
+        ?: localProperties.getProperty("bandalart.supabaseUrl").orEmpty()
+val supabasePublishableKey =
+    providers.gradleProperty("bandalart.supabasePublishableKey").orNull
+        ?: providers.environmentVariable("BANDALART_SUPABASE_PUBLISHABLE_KEY").orNull
+        ?: localProperties.getProperty("bandalart.supabasePublishableKey").orEmpty()
+val generatedBackupConfigDirectory = layout.buildDirectory.dir("generated/backupConfig/commonMain")
+val generateBackupBuildConfig by tasks.registering {
+    val generatedFile =
+        generatedBackupConfigDirectory.map {
+            it.file("com/nexters/bandalart/backup/BackupBuildConfig.kt")
+        }
+    inputs.property("supabaseUrl", supabaseUrl)
+    inputs.property("supabasePublishableKey", supabasePublishableKey)
+    outputs.file(generatedFile)
+    doLast {
+        generatedFile.get().asFile.apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                package com.nexters.bandalart.backup
+
+                internal object BackupBuildConfig {
+                    const val SUPABASE_URL = ${supabaseUrl.asKotlinStringLiteral()}
+                    const val SUPABASE_PUBLISHABLE_KEY = ${supabasePublishableKey.asKotlinStringLiteral()}
+                }
+                """.trimIndent(),
+            )
+        }
+    }
+}
+
+fun String.asKotlinStringLiteral(): String = "\"${replace("\\", "\\\\").replace("\"", "\\\"")}\""
 
 metro {
     enableCircuitCodegen.set(true)
@@ -52,6 +99,7 @@ kotlin {
             implementation(projects.core.ui)
 
             implementation(projects.feature.complete)
+            implementation(projects.feature.backup)
             implementation(projects.feature.home)
             implementation(projects.feature.onboarding)
             implementation(projects.feature.splash)
@@ -67,11 +115,17 @@ kotlin {
 
             implementation(libs.cmptoast)
             implementation(libs.jindong.compose)
+            implementation(libs.kotlinx.serialization.json)
             implementation(libs.napier)
         }
+        getByName("commonMain").kotlin.srcDir(generatedBackupConfigDirectory)
     }
 
     compilerOptions.freeCompilerArgs.add("-Xexpect-actual-classes")
+}
+
+tasks.withType<KotlinCompilationTask<*>>().configureEach {
+    dependsOn(generateBackupBuildConfig)
 }
 
 tasks.withType<Test> {

--- a/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/backup/AndroidDeviceBackupKeyProviderTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/backup/AndroidDeviceBackupKeyProviderTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.backup
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+class AndroidDeviceBackupKeyProviderTest {
+    @Test
+    fun ssaidIsNamespacedAndHashedAsLowercaseSha256() {
+        assertEquals(
+            "73004b6c7a0e5051b3eb499961d183f4964195a27f235e0672a5a13e117aa9ae",
+            deriveDeviceBackupKey("com.nexters.bandalart", "android-id"),
+        )
+    }
+
+    @Test
+    fun appNamespaceChangesTheDerivedKey() {
+        assertNotEquals(
+            deriveDeviceBackupKey("com.nexters.bandalart", "android-id"),
+            deriveDeviceBackupKey("another.app", "android-id"),
+        )
+    }
+}

--- a/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/di/metro/AppGraphTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/di/metro/AppGraphTest.kt
@@ -21,6 +21,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.nexters.bandalart.core.common.NoOpBannerAdHost
 import com.nexters.bandalart.core.common.NoOpRewardedAdGateway
 import com.nexters.bandalart.feature.complete.CompleteScreen
+import com.nexters.bandalart.core.navigation.CloudBackupScreen
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.nexters.bandalart.feature.onboarding.OnboardingScreen
 import com.nexters.bandalart.feature.splash.SplashScreen
@@ -70,7 +71,15 @@ class AppGraphTest {
         assertSame(appGraph.inAppUpdateRepository, appGraph.inAppUpdateRepository)
         assertSame(appGraph.onboardingRepository, appGraph.onboardingRepository)
         assertSame(appGraph.settingsRepository, appGraph.settingsRepository)
+        assertSame(appGraph.cloudBackupRepository, appGraph.cloudBackupRepository)
+        assertSame(appGraph.startupBackupPolicy, appGraph.startupBackupPolicy)
         assertSame(appGraph.circuit, appGraph.circuit)
+    }
+
+    @Test
+    fun cloudBackupIsUnsupportedWithoutApiConfiguration() {
+        org.junit.jupiter.api.Assertions
+            .assertFalse(appGraph.cloudBackupRepository.isSupported)
     }
 
     @Test
@@ -90,5 +99,8 @@ class AppGraphTest {
         assertNotNull(appGraph.circuit.ui(completeScreen))
         assertNotNull(appGraph.circuit.presenter(HomeScreen, FakeNavigator(HomeScreen)))
         assertNotNull(appGraph.circuit.ui(HomeScreen))
+        val backupScreen = CloudBackupScreen(entryPoint = CloudBackupScreen.EntryPoint.SETTINGS)
+        assertNotNull(appGraph.circuit.presenter(backupScreen, FakeNavigator(backupScreen)))
+        assertNotNull(appGraph.circuit.ui(backupScreen))
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/backup/AndroidDeviceBackupKeyProvider.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/backup/AndroidDeviceBackupKeyProvider.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.backup
+
+import android.app.Application
+import android.provider.Settings
+import com.nexters.bandalart.core.domain.backup.DeviceBackupKeyProvider
+import java.security.MessageDigest
+
+class AndroidDeviceBackupKeyProvider(
+    private val application: Application,
+    private val appNamespace: String = application.packageName,
+) : DeviceBackupKeyProvider {
+    private val cachedDeviceKey: String? by lazy {
+        Settings.Secure
+            .getString(application.contentResolver, Settings.Secure.ANDROID_ID)
+            ?.takeIf(String::isNotBlank)
+            ?.let { ssaid -> deriveDeviceBackupKey(appNamespace, ssaid) }
+    }
+
+    override fun getDeviceKey(): String? = cachedDeviceKey
+}
+
+internal fun deriveDeviceBackupKey(
+    appNamespace: String,
+    ssaid: String,
+): String =
+    MessageDigest
+        .getInstance("SHA-256")
+        .digest("$appNamespace:$ssaid".encodeToByteArray())
+        .joinToString(separator = "") { byte -> "%02x".format(byte) }

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
@@ -18,13 +18,16 @@ package com.nexters.bandalart.di.metro
 
 import android.app.Application
 import android.content.Intent
+import com.nexters.bandalart.backup.AndroidDeviceBackupKeyProvider
 import com.nexters.bandalart.core.common.AndroidSupportMailLauncher
 import com.nexters.bandalart.core.common.AppVersionProvider
 import com.nexters.bandalart.core.common.BannerAdHost
 import com.nexters.bandalart.core.common.ImageHandlerProvider
 import com.nexters.bandalart.core.common.RewardedAdGateway
 import com.nexters.bandalart.core.database.BandalartDatabaseFactory
+import com.nexters.bandalart.core.data.backup.BackupApiConfig
 import com.nexters.bandalart.core.datastore.BandalartDataStoreFactory
+import com.nexters.bandalart.core.domain.backup.DeviceBackupKeyProvider
 import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
 import com.nexters.bandalart.core.domain.entity.BandalartEntity
 import com.nexters.bandalart.core.domain.entity.BandalartWidgetSnapshot
@@ -44,6 +47,7 @@ private class AndroidPlatformBindings(
     application: Application,
     override val bannerAdHost: BannerAdHost,
     override val rewardedAdGateway: RewardedAdGateway,
+    override val backupApiConfig: BackupApiConfig,
 ) : PlatformBindings {
     override val databaseFactory = BandalartDatabaseFactory(application)
     override val dataStoreFactory = BandalartDataStoreFactory(application)
@@ -52,13 +56,16 @@ private class AndroidPlatformBindings(
     override val supportMailLauncher = AndroidSupportMailLauncher(application)
     override val deadlineReminderScheduler = AndroidDeadlineReminderScheduler(application)
     override val deadlineNotificationAuthorization = AndroidDeadlineNotificationAuthorization(application)
+    override val deviceBackupKeyProvider: DeviceBackupKeyProvider =
+        if (backupApiConfig.isConfigured) AndroidDeviceBackupKeyProvider(application) else DeviceBackupKeyProvider { null }
 }
 
 fun createAndroidAppGraph(
     application: Application,
     bannerAdHost: BannerAdHost,
     rewardedAdGateway: RewardedAdGateway,
-): AppGraph = createAppGraph(AndroidPlatformBindings(application, bannerAdHost, rewardedAdGateway))
+    backupApiConfig: BackupApiConfig = BackupApiConfig(url = "", publishableKey = ""),
+): AppGraph = createAppGraph(AndroidPlatformBindings(application, bannerAdHost, rewardedAdGateway, backupApiConfig))
 
 fun installAndroidDeadlineReminderInfrastructure(
     appGraph: AppGraph,

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/AppGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/AppGraph.kt
@@ -21,6 +21,7 @@ import com.nexters.bandalart.core.common.BannerAdHost
 import com.nexters.bandalart.core.common.ImageHandlerProvider
 import com.nexters.bandalart.core.common.RewardedAdGateway
 import com.nexters.bandalart.core.common.SupportMailLauncher
+import com.nexters.bandalart.core.data.backup.BackupApiConfig
 import com.nexters.bandalart.core.database.BandalartDao
 import com.nexters.bandalart.core.database.BandalartDatabase
 import com.nexters.bandalart.core.database.BandalartDatabaseFactory
@@ -34,6 +35,9 @@ import com.nexters.bandalart.core.domain.widget.BandalartWidgetLaunchTarget
 import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
 import com.nexters.bandalart.core.domain.repository.OnboardingRepository
 import com.nexters.bandalart.core.domain.repository.SettingsRepository
+import com.nexters.bandalart.core.domain.backup.CloudBackupRepository
+import com.nexters.bandalart.core.domain.backup.DeviceBackupKeyProvider
+import com.nexters.bandalart.core.domain.backup.StartupBackupPolicy
 import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorization
 import com.nexters.bandalart.core.domain.notification.DeadlineNotificationLaunchTarget
 import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
@@ -55,6 +59,8 @@ interface PlatformBindings {
     val rewardedAdGateway: RewardedAdGateway
     val deadlineReminderScheduler: DeadlineReminderScheduler
     val deadlineNotificationAuthorization: DeadlineNotificationAuthorization
+    val deviceBackupKeyProvider: DeviceBackupKeyProvider
+    val backupApiConfig: BackupApiConfig
 }
 
 @DependencyGraph(
@@ -82,6 +88,8 @@ interface AppGraph {
     val inAppUpdateRepository: InAppUpdateRepository
     val onboardingRepository: OnboardingRepository
     val settingsRepository: SettingsRepository
+    val cloudBackupRepository: CloudBackupRepository
+    val startupBackupPolicy: StartupBackupPolicy
     val deadlineNotificationAuthorization: DeadlineNotificationAuthorization
     val deadlineReminderScheduler: DeadlineReminderScheduler
     val deadlineReminderProjectionRepository: DeadlineReminderProjectionRepository

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/RepositoryBindings.kt
@@ -16,6 +16,17 @@
 
 package com.nexters.bandalart.di.metro
 
+import com.nexters.bandalart.core.data.backup.BackupApiConfig
+import com.nexters.bandalart.core.data.backup.BackupLocalDataSource
+import com.nexters.bandalart.core.data.backup.BackupRemoteDataSource
+import com.nexters.bandalart.core.data.backup.BackupRpcClient
+import com.nexters.bandalart.core.data.backup.BackupRpcMetadataRow
+import com.nexters.bandalart.core.data.backup.BackupRpcRow
+import com.nexters.bandalart.core.data.backup.DefaultCloudBackupRepository
+import com.nexters.bandalart.core.data.backup.DefaultStartupBackupPolicy
+import com.nexters.bandalart.core.data.backup.RoomBackupLocalDataSource
+import com.nexters.bandalart.core.data.backup.SupabaseBackupRemoteDataSource
+import com.nexters.bandalart.core.data.backup.createSupabaseBackupRpcClient
 import com.nexters.bandalart.core.data.repository.DefaultBandalartRepository
 import com.nexters.bandalart.core.data.repository.DefaultBandalartSlotRepository
 import com.nexters.bandalart.core.data.repository.DefaultBandalartWidgetRepository
@@ -35,6 +46,9 @@ import com.nexters.bandalart.core.domain.widget.BufferedBandalartWidgetLaunchTar
 import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
 import com.nexters.bandalart.core.domain.repository.OnboardingRepository
 import com.nexters.bandalart.core.domain.repository.SettingsRepository
+import com.nexters.bandalart.core.domain.backup.CloudBackupRepository
+import com.nexters.bandalart.core.domain.backup.DeviceBackupKeyProvider
+import com.nexters.bandalart.core.domain.backup.StartupBackupPolicy
 import com.nexters.bandalart.core.domain.notification.BufferedDeadlineNotificationLaunchTarget
 import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorization
 import com.nexters.bandalart.core.domain.notification.DeadlineNotificationLaunchTarget
@@ -48,6 +62,7 @@ import dev.zacsweers.metro.BindingContainer
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
 import kotlinx.datetime.TimeZone
+import kotlinx.serialization.json.JsonObject
 import kotlin.time.Clock
 import kotlin.time.Instant
 
@@ -92,6 +107,34 @@ object RepositoryBindings {
 
     @Provides
     @SingleIn(AppScope::class)
+    fun provideBackupLocalDataSource(
+        bandalartDao: BandalartDao,
+        bandalartDataStore: BandalartDataStore,
+    ): BackupLocalDataSource = RoomBackupLocalDataSource(bandalartDao, bandalartDataStore)
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideBackupRpcClient(config: BackupApiConfig): BackupRpcClient =
+        if (config.isConfigured) createSupabaseBackupRpcClient(config) else UnavailableBackupRpcClient
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideBackupRemoteDataSource(rpcClient: BackupRpcClient): BackupRemoteDataSource = SupabaseBackupRemoteDataSource(rpcClient)
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideCloudBackupRepository(
+        deviceKeyProvider: DeviceBackupKeyProvider,
+        localDataSource: BackupLocalDataSource,
+        remoteDataSource: BackupRemoteDataSource,
+    ): CloudBackupRepository = DefaultCloudBackupRepository(deviceKeyProvider, localDataSource, remoteDataSource)
+
+    @Provides
+    @SingleIn(AppScope::class)
+    fun provideStartupBackupPolicy(repository: CloudBackupRepository): StartupBackupPolicy = DefaultStartupBackupPolicy(repository)
+
+    @Provides
+    @SingleIn(AppScope::class)
     fun provideDeadlineReminderProjectionRepository(bandalartDao: BandalartDao): DeadlineReminderProjectionRepository =
         DefaultDeadlineReminderProjectionRepository(bandalartDao)
 
@@ -118,6 +161,17 @@ object RepositoryBindings {
     @Provides
     @SingleIn(AppScope::class)
     fun provideDeadlineNotificationLaunchTarget(): DeadlineNotificationLaunchTarget = BufferedDeadlineNotificationLaunchTarget()
+}
+
+private object UnavailableBackupRpcClient : BackupRpcClient {
+    override suspend fun getBackup(deviceKey: String): BackupRpcRow? = error("Supabase backup API is not configured")
+
+    override suspend fun putBackup(
+        deviceKey: String,
+        schemaVersion: Int,
+        payload: JsonObject,
+        bandalartCount: Int,
+    ): BackupRpcMetadataRow = error("Supabase backup API is not configured")
 }
 
 private object SystemDeadlineReminderClock : Clock {

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/MainViewController.kt
@@ -18,6 +18,7 @@ package com.nexters.bandalart
 
 import androidx.compose.ui.window.ComposeUIViewController
 import com.nexters.bandalart.ads.IosAdsBridge
+import com.nexters.bandalart.backup.IosDeviceBackupKeyBridge
 import com.nexters.bandalart.di.metro.createIosAppGraph
 import com.nexters.bandalart.notification.DeadlineNotificationLaunchBridge
 import com.nexters.bandalart.notification.DeadlineReminderLifecycleBridge
@@ -30,10 +31,11 @@ fun MainViewController(
     notificationLaunchBridge: DeadlineNotificationLaunchBridge,
     deadlineReminderLifecycleBridge: DeadlineReminderLifecycleBridge,
     adsBridge: IosAdsBridge,
+    deviceBackupKeyBridge: IosDeviceBackupKeyBridge,
     widgetLaunchBridge: IosWidgetLaunchBridge,
     widgetRuntimeBridge: IosWidgetRuntimeBridge,
 ): UIViewController {
-    val appGraph = createIosAppGraph(adsBridge)
+    val appGraph = createIosAppGraph(adsBridge, deviceBackupKeyBridge)
     notificationLaunchBridge.attach(appGraph.deadlineNotificationLaunchTarget)
     deadlineReminderLifecycleBridge.attach(appGraph.deadlineReminderReconciler)
     widgetLaunchBridge.attach(appGraph.bandalartWidgetLaunchTarget)

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/backup/IosDeviceBackupKeyBridge.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/backup/IosDeviceBackupKeyBridge.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.backup
+
+/** Implemented by the Swift app target, where the device seed is stored in Keychain. */
+fun interface IosDeviceBackupKeyBridge {
+    fun getDeviceKey(): String?
+}

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/di/metro/IosAppGraph.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/di/metro/IosAppGraph.kt
@@ -19,16 +19,21 @@ package com.nexters.bandalart.di.metro
 import com.nexters.bandalart.ads.IosAdsBridge
 import com.nexters.bandalart.ads.IosBannerAdHost
 import com.nexters.bandalart.ads.IosRewardedAdGateway
+import com.nexters.bandalart.backup.BackupBuildConfig
+import com.nexters.bandalart.backup.IosDeviceBackupKeyBridge
 import com.nexters.bandalart.core.common.AppVersionProvider
 import com.nexters.bandalart.core.common.ImageHandlerProvider
 import com.nexters.bandalart.core.common.IosSupportMailLauncher
+import com.nexters.bandalart.core.data.backup.BackupApiConfig
 import com.nexters.bandalart.core.database.BandalartDatabaseFactory
 import com.nexters.bandalart.core.datastore.BandalartDataStoreFactory
+import com.nexters.bandalart.core.domain.backup.DeviceBackupKeyProvider
 import com.nexters.bandalart.notification.IosDeadlineNotificationAuthorization
 import com.nexters.bandalart.notification.IosDeadlineReminderScheduler
 
 private class IosPlatformBindings(
     adsBridge: IosAdsBridge,
+    deviceBackupKeyBridge: IosDeviceBackupKeyBridge,
 ) : PlatformBindings {
     override val databaseFactory = BandalartDatabaseFactory()
     override val dataStoreFactory = BandalartDataStoreFactory()
@@ -39,6 +44,20 @@ private class IosPlatformBindings(
     override val rewardedAdGateway = IosRewardedAdGateway(adsBridge)
     override val deadlineReminderScheduler = IosDeadlineReminderScheduler()
     override val deadlineNotificationAuthorization = IosDeadlineNotificationAuthorization()
+    override val backupApiConfig =
+        BackupApiConfig(
+            url = BackupBuildConfig.SUPABASE_URL,
+            publishableKey = BackupBuildConfig.SUPABASE_PUBLISHABLE_KEY,
+        )
+    override val deviceBackupKeyProvider: DeviceBackupKeyProvider =
+        if (backupApiConfig.isConfigured) {
+            DeviceBackupKeyProvider(deviceBackupKeyBridge::getDeviceKey)
+        } else {
+            DeviceBackupKeyProvider { null }
+        }
 }
 
-internal fun createIosAppGraph(adsBridge: IosAdsBridge): AppGraph = createAppGraph(IosPlatformBindings(adsBridge))
+internal fun createIosAppGraph(
+    adsBridge: IosAdsBridge,
+    deviceBackupKeyBridge: IosDeviceBackupKeyBridge,
+): AppGraph = createAppGraph(IosPlatformBindings(adsBridge, deviceBackupKeyBridge))

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -4,15 +4,26 @@ plugins {
     id("bandalart.kmp.android")
     id("bandalart.kmp.ios")
     id("bandalart.room")
+    id("bandalart.kotlin.serialization")
 }
 
 kotlin {
     sourceSets {
+        androidMain.dependencies {
+            implementation(libs.ktor.client.android)
+        }
+
         commonMain.dependencies {
             implementation(projects.core.common)
             implementation(projects.core.database)
             implementation(projects.core.datastore)
             implementation(projects.core.domain)
+            implementation(libs.kotlinx.serialization.json)
+            implementation(libs.supabase.postgrest)
+        }
+
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
         }
 
         androidHostTest.dependencies {

--- a/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/backup/DefaultCloudBackupRepositoryTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/backup/DefaultCloudBackupRepositoryTest.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.data.backup
+
+import com.nexters.bandalart.core.domain.backup.BackupBandalart
+import com.nexters.bandalart.core.domain.backup.BackupCell
+import com.nexters.bandalart.core.domain.backup.BackupMetadata
+import com.nexters.bandalart.core.domain.backup.BackupPreferences
+import com.nexters.bandalart.core.domain.backup.BackupSnapshot
+import com.nexters.bandalart.core.domain.backup.DeviceBackupKeyProvider
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DefaultCloudBackupRepositoryTest {
+    @Test
+    fun createBackupUploadsTheCurrentLocalSnapshotForThisDevice() =
+        runTest {
+            val snapshot = validSnapshot()
+            val local = FakeBackupLocalDataSource(snapshot = snapshot)
+            val remote = FakeBackupRemoteDataSource()
+            val repository =
+                DefaultCloudBackupRepository(
+                    deviceKeyProvider = FixedDeviceBackupKeyProvider(DEVICE_KEY),
+                    localDataSource = local,
+                    remoteDataSource = remote,
+                )
+
+            val metadata = repository.createBackup()
+
+            assertEquals(DEVICE_KEY, remote.lastPutDeviceKey)
+            assertEquals(snapshot, remote.lastPutSnapshot)
+            assertEquals(1, metadata.bandalartCount)
+        }
+
+    @Test
+    fun restoreBackupReplacesLocalDataOnlyAfterTheRemoteSnapshotIsValid() =
+        runTest {
+            val invalidSnapshot =
+                validSnapshot().copy(
+                    cells = validSnapshot().cells.map { it.copy(bandalartId = 999L) },
+                )
+            val local = FakeBackupLocalDataSource(snapshot = validSnapshot())
+            val remote =
+                FakeBackupRemoteDataSource(
+                    storedBackup = RemoteBackup(invalidSnapshot, METADATA),
+                )
+            val repository =
+                DefaultCloudBackupRepository(
+                    deviceKeyProvider = FixedDeviceBackupKeyProvider(DEVICE_KEY),
+                    localDataSource = local,
+                    remoteDataSource = remote,
+                )
+
+            val failure = runCatching { repository.restoreBackup() }.exceptionOrNull()
+
+            assertTrue(failure is InvalidBackupSnapshotException)
+            assertNull(local.restoredSnapshot)
+        }
+
+    @Test
+    fun missingRemoteBackupDoesNotMutateLocalData() =
+        runTest {
+            val local = FakeBackupLocalDataSource(snapshot = validSnapshot())
+            val repository =
+                DefaultCloudBackupRepository(
+                    deviceKeyProvider = FixedDeviceBackupKeyProvider(DEVICE_KEY),
+                    localDataSource = local,
+                    remoteDataSource = FakeBackupRemoteDataSource(),
+                )
+
+            assertNull(repository.restoreBackup())
+            assertNull(local.restoredSnapshot)
+        }
+
+    @Test
+    fun unavailableDeviceIdentityDisablesBackupWithoutCallingRemote() =
+        runTest {
+            val remote = FakeBackupRemoteDataSource()
+            val repository =
+                DefaultCloudBackupRepository(
+                    deviceKeyProvider = FixedDeviceBackupKeyProvider(null),
+                    localDataSource = FakeBackupLocalDataSource(validSnapshot()),
+                    remoteDataSource = remote,
+                )
+
+            assertFalse(repository.isSupported)
+            assertNull(repository.findBackup())
+            assertNull(remote.lastGetDeviceKey)
+        }
+
+    private fun validSnapshot() =
+        BackupSnapshot(
+            bandalarts =
+                listOf(
+                    BackupBandalart(
+                        id = 1L,
+                        title = "건강한 생활",
+                        mainColor = "#FF3FFFBA",
+                        subColor = "#FF111827",
+                    ),
+                ),
+            cells =
+                listOf(
+                    BackupCell(
+                        id = 10L,
+                        bandalartId = 1L,
+                        title = "건강한 생활",
+                    ),
+                ),
+            preferences =
+                BackupPreferences(
+                    recentBandalartId = 1L,
+                    recentSubGoalIds = emptyMap(),
+                    completedBandalarts = emptyList(),
+                    onboardingCompleted = true,
+                    themeMode = "system",
+                    recentEmojis = listOf("🎯"),
+                    deadlineReminderEnabled = false,
+                    maxBandalartSlots = 1,
+                ),
+        )
+
+    private class FixedDeviceBackupKeyProvider(
+        private val key: String?,
+    ) : DeviceBackupKeyProvider {
+        override fun getDeviceKey(): String? = key
+    }
+
+    private class FakeBackupLocalDataSource(
+        private val snapshot: BackupSnapshot,
+    ) : BackupLocalDataSource {
+        var restoredSnapshot: BackupSnapshot? = null
+
+        override suspend fun hasData(): Boolean = snapshot.bandalarts.isNotEmpty()
+
+        override suspend fun createSnapshot(): BackupSnapshot = snapshot
+
+        override suspend fun restoreSnapshot(snapshot: BackupSnapshot) {
+            restoredSnapshot = snapshot
+        }
+    }
+
+    private class FakeBackupRemoteDataSource(
+        private val storedBackup: RemoteBackup? = null,
+    ) : BackupRemoteDataSource {
+        var lastGetDeviceKey: String? = null
+        var lastPutDeviceKey: String? = null
+        var lastPutSnapshot: BackupSnapshot? = null
+
+        override suspend fun getBackup(deviceKey: String): RemoteBackup? {
+            lastGetDeviceKey = deviceKey
+            return storedBackup
+        }
+
+        override suspend fun putBackup(
+            deviceKey: String,
+            snapshot: BackupSnapshot,
+        ): BackupMetadata {
+            lastPutDeviceKey = deviceKey
+            lastPutSnapshot = snapshot
+            return METADATA
+        }
+    }
+
+    private companion object {
+        private const val DEVICE_KEY = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        private val METADATA = BackupMetadata(bandalartCount = 1, updatedAt = "2026-08-18T00:00:00Z")
+    }
+}

--- a/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/backup/DefaultStartupBackupPolicyTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/backup/DefaultStartupBackupPolicyTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.data.backup
+
+import com.nexters.bandalart.core.domain.backup.BackupMetadata
+import com.nexters.bandalart.core.domain.backup.CloudBackupRepository
+import com.nexters.bandalart.core.domain.backup.StartupBackupDecision
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class DefaultStartupBackupPolicyTest {
+    @Test
+    fun localDataStillChecksTheRemoteBackupWithoutOfferingRestore() =
+        runTest {
+            val repository = FakeCloudBackupRepository(hasLocalData = true, backup = METADATA)
+
+            assertEquals(StartupBackupDecision.Continue, DefaultStartupBackupPolicy(repository).evaluate())
+            assertTrue(repository.findBackupCalled)
+        }
+
+    @Test
+    fun emptyLocalDataOffersTheRemoteBackup() =
+        runTest {
+            val repository = FakeCloudBackupRepository(hasLocalData = false, backup = METADATA)
+
+            assertEquals(
+                StartupBackupDecision.OfferRestore(METADATA),
+                DefaultStartupBackupPolicy(repository).evaluate(),
+            )
+            assertTrue(repository.findBackupCalled)
+        }
+
+    @Test
+    fun remoteFailureDoesNotBlockStartup() =
+        runTest {
+            val repository = FakeCloudBackupRepository(hasLocalData = false, failure = IllegalStateException("offline"))
+
+            assertEquals(StartupBackupDecision.Continue, DefaultStartupBackupPolicy(repository).evaluate())
+        }
+
+    private class FakeCloudBackupRepository(
+        private val hasLocalData: Boolean,
+        private val backup: BackupMetadata? = null,
+        private val failure: Throwable? = null,
+    ) : CloudBackupRepository {
+        var findBackupCalled = false
+        override val isSupported = true
+
+        override suspend fun hasLocalData(): Boolean = hasLocalData
+
+        override suspend fun findBackup(): BackupMetadata? {
+            findBackupCalled = true
+            failure?.let { throw it }
+            return backup
+        }
+
+        override suspend fun createBackup(): BackupMetadata = error("Not used")
+
+        override suspend fun restoreBackup(): BackupMetadata? = error("Not used")
+    }
+
+    private companion object {
+        private val METADATA = BackupMetadata(2, "2026-08-18T01:02:03Z")
+    }
+}

--- a/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/backup/RoomBackupLocalDataSourceTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/backup/RoomBackupLocalDataSourceTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.data.backup
+
+import com.nexters.bandalart.core.database.BandalartDao
+import com.nexters.bandalart.core.database.entity.BandalartCellDBEntity
+import com.nexters.bandalart.core.database.entity.BandalartDBEntity
+import com.nexters.bandalart.core.datastore.BandalartBackupPreferences
+import com.nexters.bandalart.core.datastore.BandalartDataStore
+import com.nexters.bandalart.core.domain.backup.BackupBandalart
+import com.nexters.bandalart.core.domain.backup.BackupCell
+import com.nexters.bandalart.core.domain.backup.BackupCompletedBandalart
+import com.nexters.bandalart.core.domain.backup.BackupPreferences
+import com.nexters.bandalart.core.domain.backup.BackupSnapshot
+import io.mockk.coEvery
+import io.mockk.coVerifyOrder
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class RoomBackupLocalDataSourceTest {
+    private val dao = mockk<BandalartDao>()
+    private val dataStore = mockk<BandalartDataStore>()
+
+    @Test
+    fun createSnapshotMapsAllRoomRowsAndDurablePreferences() =
+        runTest {
+            val bandalart = BandalartDBEntity(id = 1L, title = "목표")
+            val cell = BandalartCellDBEntity(id = 10L, bandalartId = 1L, title = "목표")
+            coEvery { dao.getAllBandalarts() } returns listOf(bandalart)
+            coEvery { dao.getAllCells() } returns listOf(cell)
+            coEvery { dataStore.createBackupPreferences(listOf(1L)) } returns storedPreferences()
+            val source = RoomBackupLocalDataSource(dao, dataStore)
+
+            val snapshot = source.createSnapshot()
+
+            assertEquals(listOf(BackupBandalart(id = 1L, title = "목표", mainColor = "#FF3FFFBA", subColor = "#FF111827")), snapshot.bandalarts)
+            assertEquals(listOf(BackupCell(id = 10L, bandalartId = 1L, title = "목표")), snapshot.cells)
+            assertEquals(1L, snapshot.preferences.recentBandalartId)
+            assertEquals(listOf(BackupCompletedBandalart(1L, true)), snapshot.preferences.completedBandalarts)
+        }
+
+    @Test
+    fun restoreSnapshotReplacesRoomBeforeRestoringPreferences() =
+        runTest {
+            val snapshot = validSnapshot()
+            coEvery { dao.getAllBandalarts() } returns listOf(BandalartDBEntity(id = 9L))
+            coEvery { dao.replaceAllForBackup(any(), any()) } returns Unit
+            coEvery { dataStore.restoreBackupPreferences(any(), any()) } returns Unit
+            val source = RoomBackupLocalDataSource(dao, dataStore)
+
+            source.restoreSnapshot(snapshot)
+
+            coVerifyOrder {
+                dao.getAllBandalarts()
+                dao.replaceAllForBackup(
+                    bandalarts = listOf(BandalartDBEntity(id = 1L, title = "목표")),
+                    cells = listOf(BandalartCellDBEntity(id = 10L, bandalartId = 1L, title = "목표")),
+                )
+                dataStore.restoreBackupPreferences(
+                    backup = storedPreferences(),
+                    bandalartIdsToClear = listOf(9L, 1L),
+                )
+            }
+        }
+
+    @Test
+    fun hasDataUsesPersistedBandalarts() =
+        runTest {
+            coEvery { dao.getAllBandalarts() } returns listOf(BandalartDBEntity(id = 1L))
+
+            assertTrue(RoomBackupLocalDataSource(dao, dataStore).hasData())
+        }
+
+    private fun validSnapshot() =
+        BackupSnapshot(
+            bandalarts = listOf(BackupBandalart(id = 1L, title = "목표", mainColor = "#FF3FFFBA", subColor = "#FF111827")),
+            cells = listOf(BackupCell(id = 10L, bandalartId = 1L, title = "목표")),
+            preferences =
+                BackupPreferences(
+                    recentBandalartId = 1L,
+                    recentSubGoalIds = emptyMap(),
+                    completedBandalarts = listOf(BackupCompletedBandalart(1L, true)),
+                    onboardingCompleted = true,
+                    themeMode = "dark",
+                    recentEmojis = listOf("🎯"),
+                    deadlineReminderEnabled = true,
+                    maxBandalartSlots = 1,
+                ),
+        )
+
+    private fun storedPreferences() =
+        BandalartBackupPreferences(
+            recentBandalartId = 1L,
+            recentSubGoalIds = emptyMap(),
+            completedBandalarts = listOf(1L to true),
+            onboardingCompleted = true,
+            themeMode = "dark",
+            recentEmojis = listOf("🎯"),
+            deadlineReminderEnabled = true,
+            maxBandalartSlots = 1,
+        )
+}

--- a/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/backup/SupabaseBackupRemoteDataSourceTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/backup/SupabaseBackupRemoteDataSourceTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.data.backup
+
+import com.nexters.bandalart.core.domain.backup.BackupBandalart
+import com.nexters.bandalart.core.domain.backup.BackupPreferences
+import com.nexters.bandalart.core.domain.backup.BackupSnapshot
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class SupabaseBackupRemoteDataSourceTest {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun getBackupDecodesTheJsonPayloadAndMetadata() =
+        runTest {
+            val snapshot = snapshot()
+            val rpcClient =
+                FakeBackupRpcClient(
+                    getResult =
+                        BackupRpcRow(
+                            schemaVersion = 1,
+                            payload = json.encodeToJsonElement(snapshot).jsonObject,
+                            bandalartCount = 1,
+                            updatedAt = "2026-08-18T01:02:03Z",
+                        ),
+                )
+
+            val backup = SupabaseBackupRemoteDataSource(rpcClient, json).getBackup(DEVICE_KEY)
+
+            assertEquals(snapshot, backup?.snapshot)
+            assertEquals(1, backup?.metadata?.bandalartCount)
+            assertEquals("2026-08-18T01:02:03Z", backup?.metadata?.updatedAt)
+        }
+
+    @Test
+    fun getBackupReturnsNullWhenTheRpcHasNoRow() =
+        runTest {
+            assertNull(SupabaseBackupRemoteDataSource(FakeBackupRpcClient(), json).getBackup(DEVICE_KEY))
+        }
+
+    @Test
+    fun putBackupSendsVersionedJsonAndReturnsServerMetadata() =
+        runTest {
+            val rpcClient =
+                FakeBackupRpcClient(
+                    putResult = BackupRpcMetadataRow(1, 1, "2026-08-18T01:02:03Z"),
+                )
+            val snapshot = snapshot()
+
+            val metadata = SupabaseBackupRemoteDataSource(rpcClient, json).putBackup(DEVICE_KEY, snapshot)
+
+            assertEquals(DEVICE_KEY, rpcClient.putDeviceKey)
+            assertEquals(1, rpcClient.putSchemaVersion)
+            assertEquals(json.encodeToJsonElement(snapshot).jsonObject, rpcClient.putPayload)
+            assertEquals(1, rpcClient.putBandalartCount)
+            assertEquals("2026-08-18T01:02:03Z", metadata.updatedAt)
+        }
+
+    private fun snapshot() =
+        BackupSnapshot(
+            bandalarts = listOf(BackupBandalart(id = 1L, mainColor = "#FF3FFFBA", subColor = "#FF111827")),
+            cells = emptyList(),
+            preferences =
+                BackupPreferences(
+                    recentBandalartId = 1L,
+                    recentSubGoalIds = emptyMap(),
+                    completedBandalarts = emptyList(),
+                    onboardingCompleted = true,
+                    themeMode = null,
+                    recentEmojis = emptyList(),
+                    deadlineReminderEnabled = false,
+                    maxBandalartSlots = 1,
+                ),
+        )
+
+    private class FakeBackupRpcClient(
+        private val getResult: BackupRpcRow? = null,
+        private val putResult: BackupRpcMetadataRow = BackupRpcMetadataRow(1, 0, "2026-08-18T00:00:00Z"),
+    ) : BackupRpcClient {
+        var putDeviceKey: String? = null
+        var putSchemaVersion: Int? = null
+        var putPayload: kotlinx.serialization.json.JsonObject? = null
+        var putBandalartCount: Int? = null
+
+        override suspend fun getBackup(deviceKey: String): BackupRpcRow? = getResult
+
+        override suspend fun putBackup(
+            deviceKey: String,
+            schemaVersion: Int,
+            payload: kotlinx.serialization.json.JsonObject,
+            bandalartCount: Int,
+        ): BackupRpcMetadataRow {
+            putDeviceKey = deviceKey
+            putSchemaVersion = schemaVersion
+            putPayload = payload
+            putBandalartCount = bandalartCount
+            return putResult
+        }
+    }
+
+    private companion object {
+        private const val DEVICE_KEY = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/backup/DefaultCloudBackupRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/backup/DefaultCloudBackupRepository.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.data.backup
+
+import com.nexters.bandalart.core.domain.backup.BackupMetadata
+import com.nexters.bandalart.core.domain.backup.BackupSnapshot
+import com.nexters.bandalart.core.domain.backup.CloudBackupRepository
+import com.nexters.bandalart.core.domain.backup.DeviceBackupKeyProvider
+
+class DefaultCloudBackupRepository(
+    private val deviceKeyProvider: DeviceBackupKeyProvider,
+    private val localDataSource: BackupLocalDataSource,
+    private val remoteDataSource: BackupRemoteDataSource,
+) : CloudBackupRepository {
+    override val isSupported: Boolean
+        get() = deviceKeyProvider.getDeviceKey() != null
+
+    override suspend fun hasLocalData(): Boolean = localDataSource.hasData()
+
+    override suspend fun findBackup(): BackupMetadata? {
+        val deviceKey = deviceKeyProvider.getDeviceKey() ?: return null
+        return remoteDataSource.getBackup(deviceKey)?.metadata
+    }
+
+    override suspend fun createBackup(): BackupMetadata {
+        val deviceKey = requireDeviceKey()
+        val snapshot = localDataSource.createSnapshot()
+        snapshot.validate()
+        return remoteDataSource.putBackup(deviceKey, snapshot)
+    }
+
+    override suspend fun restoreBackup(): BackupMetadata? {
+        val deviceKey = requireDeviceKey()
+        val remoteBackup = remoteDataSource.getBackup(deviceKey) ?: return null
+        remoteBackup.snapshot.validate()
+        localDataSource.restoreSnapshot(remoteBackup.snapshot)
+        return remoteBackup.metadata
+    }
+
+    private fun requireDeviceKey(): String =
+        checkNotNull(deviceKeyProvider.getDeviceKey()) {
+            "Cloud backup is not supported on this device"
+        }
+}
+
+interface BackupLocalDataSource {
+    suspend fun hasData(): Boolean
+
+    suspend fun createSnapshot(): BackupSnapshot
+
+    suspend fun restoreSnapshot(snapshot: BackupSnapshot)
+}
+
+interface BackupRemoteDataSource {
+    suspend fun getBackup(deviceKey: String): RemoteBackup?
+
+    suspend fun putBackup(
+        deviceKey: String,
+        snapshot: BackupSnapshot,
+    ): BackupMetadata
+}
+
+data class RemoteBackup(
+    val snapshot: BackupSnapshot,
+    val metadata: BackupMetadata,
+)
+
+class InvalidBackupSnapshotException(
+    message: String,
+) : IllegalArgumentException(message)
+
+private fun BackupSnapshot.validate() {
+    if (schemaVersion != BackupSnapshot.CURRENT_SCHEMA_VERSION) {
+        throw InvalidBackupSnapshotException("Unsupported backup schema version: $schemaVersion")
+    }
+    val bandalartIds = bandalarts.map { it.id }
+    if (bandalartIds.any { it <= 0L } || bandalartIds.distinct().size != bandalartIds.size) {
+        throw InvalidBackupSnapshotException("Bandalart IDs must be unique positive values")
+    }
+    val cellsById = cells.associateBy { it.id }
+    if (cells.any { it.id <= 0L } || cellsById.size != cells.size) {
+        throw InvalidBackupSnapshotException("Cell IDs must be unique positive values")
+    }
+    val bandalartIdSet = bandalartIds.toSet()
+    cells.forEach { cell ->
+        if (cell.bandalartId !in bandalartIdSet) {
+            throw InvalidBackupSnapshotException("Cell references a missing bandalart")
+        }
+        cell.parentId?.let { parentId ->
+            val parent = cellsById[parentId]
+            if (parent == null || parent.bandalartId != cell.bandalartId || parentId == cell.id) {
+                throw InvalidBackupSnapshotException("Cell references an invalid parent")
+            }
+        }
+    }
+    if (preferences.recentBandalartId != 0L && preferences.recentBandalartId !in bandalartIdSet) {
+        throw InvalidBackupSnapshotException("Recent bandalart is missing from the snapshot")
+    }
+    if (preferences.maxBandalartSlots < bandalarts.size) {
+        throw InvalidBackupSnapshotException("Backup slot count is smaller than its bandalart count")
+    }
+}

--- a/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/backup/DefaultStartupBackupPolicy.kt
+++ b/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/backup/DefaultStartupBackupPolicy.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.data.backup
+
+import com.nexters.bandalart.core.domain.backup.CloudBackupRepository
+import com.nexters.bandalart.core.domain.backup.StartupBackupDecision
+import com.nexters.bandalart.core.domain.backup.StartupBackupPolicy
+import kotlinx.coroutines.CancellationException
+
+class DefaultStartupBackupPolicy(
+    private val repository: CloudBackupRepository,
+) : StartupBackupPolicy {
+    override suspend fun evaluate(): StartupBackupDecision =
+        try {
+            if (!repository.isSupported) {
+                StartupBackupDecision.Continue
+            } else {
+                val hasLocalData = repository.hasLocalData()
+                val backup = repository.findBackup()
+                if (hasLocalData || backup == null) {
+                    StartupBackupDecision.Continue
+                } else {
+                    StartupBackupDecision.OfferRestore(backup)
+                }
+            }
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (_: Exception) {
+            StartupBackupDecision.Continue
+        }
+}

--- a/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/backup/RoomBackupLocalDataSource.kt
+++ b/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/backup/RoomBackupLocalDataSource.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.data.backup
+
+import com.nexters.bandalart.core.database.BandalartDao
+import com.nexters.bandalart.core.database.entity.BandalartCellDBEntity
+import com.nexters.bandalart.core.database.entity.BandalartDBEntity
+import com.nexters.bandalart.core.datastore.BandalartBackupPreferences
+import com.nexters.bandalart.core.datastore.BandalartDataStore
+import com.nexters.bandalart.core.domain.backup.BackupBandalart
+import com.nexters.bandalart.core.domain.backup.BackupCell
+import com.nexters.bandalart.core.domain.backup.BackupCompletedBandalart
+import com.nexters.bandalart.core.domain.backup.BackupPreferences
+import com.nexters.bandalart.core.domain.backup.BackupSnapshot
+
+class RoomBackupLocalDataSource(
+    private val bandalartDao: BandalartDao,
+    private val bandalartDataStore: BandalartDataStore,
+) : BackupLocalDataSource {
+    override suspend fun hasData(): Boolean = bandalartDao.getAllBandalarts().isNotEmpty()
+
+    override suspend fun createSnapshot(): BackupSnapshot {
+        val bandalarts = bandalartDao.getAllBandalarts()
+        val cells = bandalartDao.getAllCells()
+        val preferences =
+            bandalartDataStore.createBackupPreferences(
+                bandalarts.mapNotNull(BandalartDBEntity::id),
+            )
+        return BackupSnapshot(
+            bandalarts = bandalarts.map(BandalartDBEntity::toBackup),
+            cells = cells.map(BandalartCellDBEntity::toBackup),
+            preferences = preferences.toBackup(),
+        )
+    }
+
+    override suspend fun restoreSnapshot(snapshot: BackupSnapshot) {
+        val previousIds = bandalartDao.getAllBandalarts().mapNotNull(BandalartDBEntity::id)
+        bandalartDao.replaceAllForBackup(
+            bandalarts = snapshot.bandalarts.map(BackupBandalart::toDatabase),
+            cells = snapshot.cells.map(BackupCell::toDatabase),
+        )
+        bandalartDataStore.restoreBackupPreferences(
+            backup = snapshot.preferences.toDataStore(),
+            bandalartIdsToClear = (previousIds + snapshot.bandalarts.map(BackupBandalart::id)).distinct(),
+        )
+    }
+}
+
+private fun BandalartDBEntity.toBackup() =
+    BackupBandalart(
+        id = checkNotNull(id),
+        mainColor = mainColor,
+        subColor = subColor,
+        profileEmoji = profileEmoji,
+        title = title,
+        description = description,
+        dueDate = dueDate,
+        isCompleted = isCompleted,
+        completionRatio = completionRatio,
+    )
+
+private fun BandalartCellDBEntity.toBackup() =
+    BackupCell(
+        id = checkNotNull(id),
+        bandalartId = bandalartId,
+        title = title,
+        description = description,
+        dueDate = dueDate,
+        isCompleted = isCompleted,
+        parentId = parentId,
+    )
+
+private fun BandalartBackupPreferences.toBackup() =
+    BackupPreferences(
+        recentBandalartId = recentBandalartId,
+        recentSubGoalIds = recentSubGoalIds,
+        completedBandalarts = completedBandalarts.map { (id, completed) -> BackupCompletedBandalart(id, completed) },
+        onboardingCompleted = onboardingCompleted,
+        themeMode = themeMode,
+        recentEmojis = recentEmojis,
+        deadlineReminderEnabled = deadlineReminderEnabled,
+        maxBandalartSlots = maxBandalartSlots,
+    )
+
+private fun BackupBandalart.toDatabase() =
+    BandalartDBEntity(
+        id = id,
+        mainColor = mainColor,
+        subColor = subColor,
+        profileEmoji = profileEmoji,
+        title = title,
+        description = description,
+        dueDate = dueDate,
+        isCompleted = isCompleted,
+        completionRatio = completionRatio,
+    )
+
+private fun BackupCell.toDatabase() =
+    BandalartCellDBEntity(
+        id = id,
+        bandalartId = bandalartId,
+        title = title,
+        description = description,
+        dueDate = dueDate,
+        isCompleted = isCompleted,
+        parentId = parentId,
+    )
+
+private fun BackupPreferences.toDataStore() =
+    BandalartBackupPreferences(
+        recentBandalartId = recentBandalartId,
+        recentSubGoalIds = recentSubGoalIds,
+        completedBandalarts = completedBandalarts.map { it.bandalartId to it.isCompleted },
+        onboardingCompleted = onboardingCompleted,
+        themeMode = themeMode,
+        recentEmojis = recentEmojis,
+        deadlineReminderEnabled = deadlineReminderEnabled,
+        maxBandalartSlots = maxBandalartSlots,
+    )

--- a/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/backup/SupabaseBackupRemoteDataSource.kt
+++ b/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/backup/SupabaseBackupRemoteDataSource.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.data.backup
+
+import com.nexters.bandalart.core.domain.backup.BackupMetadata
+import com.nexters.bandalart.core.domain.backup.BackupSnapshot
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonObject
+
+class SupabaseBackupRemoteDataSource(
+    private val rpcClient: BackupRpcClient,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) : BackupRemoteDataSource {
+    override suspend fun getBackup(deviceKey: String): RemoteBackup? {
+        val row = rpcClient.getBackup(deviceKey) ?: return null
+        val snapshot = json.decodeFromJsonElement<BackupSnapshot>(row.payload)
+        if (snapshot.schemaVersion != row.schemaVersion) {
+            throw InvalidBackupSnapshotException("Backup schema version does not match its payload")
+        }
+        return RemoteBackup(
+            snapshot = snapshot,
+            metadata = BackupMetadata(row.bandalartCount, row.updatedAt),
+        )
+    }
+
+    override suspend fun putBackup(
+        deviceKey: String,
+        snapshot: BackupSnapshot,
+    ): BackupMetadata {
+        val row =
+            rpcClient.putBackup(
+                deviceKey = deviceKey,
+                schemaVersion = snapshot.schemaVersion,
+                payload = json.encodeToJsonElement(snapshot).jsonObject,
+                bandalartCount = snapshot.bandalarts.size,
+            )
+        return BackupMetadata(row.bandalartCount, row.updatedAt)
+    }
+}
+
+interface BackupRpcClient {
+    suspend fun getBackup(deviceKey: String): BackupRpcRow?
+
+    suspend fun putBackup(
+        deviceKey: String,
+        schemaVersion: Int,
+        payload: JsonObject,
+        bandalartCount: Int,
+    ): BackupRpcMetadataRow
+}
+
+@Serializable
+data class BackupRpcRow(
+    @SerialName("schema_version")
+    val schemaVersion: Int,
+    val payload: JsonObject,
+    @SerialName("bandalart_count")
+    val bandalartCount: Int,
+    @SerialName("updated_at")
+    val updatedAt: String,
+)
+
+@Serializable
+data class BackupRpcMetadataRow(
+    @SerialName("schema_version")
+    val schemaVersion: Int,
+    @SerialName("bandalart_count")
+    val bandalartCount: Int,
+    @SerialName("updated_at")
+    val updatedAt: String,
+)

--- a/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/backup/SupabaseBackupRpcClient.kt
+++ b/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/backup/SupabaseBackupRpcClient.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.data.backup
+
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.postgrest.Postgrest
+import io.github.jan.supabase.postgrest.postgrest
+import io.github.jan.supabase.postgrest.rpc
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonObject
+
+class SupabaseBackupRpcClient(
+    private val client: SupabaseClient,
+) : BackupRpcClient {
+    override suspend fun getBackup(deviceKey: String): BackupRpcRow? =
+        client.postgrest
+            .rpc(
+                function = "get_device_backup",
+                parameters = GetBackupParams(deviceKey),
+            ).decodeSingleOrNull()
+
+    override suspend fun putBackup(
+        deviceKey: String,
+        schemaVersion: Int,
+        payload: JsonObject,
+        bandalartCount: Int,
+    ): BackupRpcMetadataRow =
+        client.postgrest
+            .rpc(
+                function = "put_device_backup",
+                parameters =
+                    PutBackupParams(
+                        deviceKey = deviceKey,
+                        schemaVersion = schemaVersion,
+                        payload = payload,
+                        bandalartCount = bandalartCount,
+                    ),
+            ).decodeSingle()
+}
+
+data class BackupApiConfig(
+    val url: String,
+    val publishableKey: String,
+) {
+    val isConfigured: Boolean
+        get() = url.startsWith("https://") && publishableKey.isNotBlank()
+}
+
+fun createSupabaseBackupRpcClient(config: BackupApiConfig): BackupRpcClient {
+    check(config.isConfigured) { "Supabase backup API is not configured" }
+    return SupabaseBackupRpcClient(
+        createSupabaseClient(
+            supabaseUrl = config.url,
+            supabaseKey = config.publishableKey,
+        ) {
+            install(Postgrest)
+        },
+    )
+}
+
+@Serializable
+private data class GetBackupParams(
+    @SerialName("p_device_key")
+    val deviceKey: String,
+)
+
+@Serializable
+private data class PutBackupParams(
+    @SerialName("p_device_key")
+    val deviceKey: String,
+    @SerialName("p_schema_version")
+    val schemaVersion: Int,
+    @SerialName("p_payload")
+    val payload: JsonObject,
+    @SerialName("p_bandalart_count")
+    val bandalartCount: Int,
+)

--- a/core/database/src/androidHostTest/kotlin/com/nexters/bandalart/core/database/BandalartBackupDaoTest.kt
+++ b/core/database/src/androidHostTest/kotlin/com/nexters/bandalart/core/database/BandalartBackupDaoTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.database
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.nexters.bandalart.core.database.entity.BandalartCellDBEntity
+import com.nexters.bandalart.core.database.entity.BandalartDBEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.annotation.Config
+import tech.apter.junit.jupiter.robolectric.RobolectricExtension
+
+@ExtendWith(RobolectricExtension::class)
+@Config(sdk = [35])
+class BandalartBackupDaoTest {
+    private lateinit var database: BandalartDatabase
+    private lateinit var dao: BandalartDao
+
+    @BeforeEach
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        database = Room.inMemoryDatabaseBuilder(context, BandalartDatabase::class.java).build()
+        dao = database.bandalartDao
+    }
+
+    @AfterEach
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun backupRestoreReplacesAllRowsWhilePreservingIds() =
+        runTest {
+            dao.createEmptyBandalart()
+            val restoredBandalart = BandalartDBEntity(id = 42L, title = "복원된 목표")
+            val restoredCell = BandalartCellDBEntity(id = 84L, bandalartId = 42L, title = "복원된 목표")
+
+            dao.replaceAllForBackup(listOf(restoredBandalart), listOf(restoredCell))
+
+            assertEquals(listOf(restoredBandalart), dao.getAllBandalarts())
+            assertEquals(listOf(restoredCell), dao.getAllCells())
+        }
+
+    @Test
+    fun backupRestoreFailureRollsBackThePreviousRows() =
+        runTest {
+            val previousId = dao.createEmptyBandalart()
+            val previousBandalarts = dao.getAllBandalarts()
+            val previousCells = dao.getAllCells()
+            val invalidCell = BandalartCellDBEntity(id = 84L, bandalartId = 999L)
+
+            val failure =
+                runCatching {
+                    dao.replaceAllForBackup(
+                        bandalarts = listOf(BandalartDBEntity(id = 42L)),
+                        cells = listOf(invalidCell),
+                    )
+                }.exceptionOrNull()
+
+            assertTrue(failure != null)
+            assertEquals(previousId, previousBandalarts.single().id)
+            assertEquals(previousBandalarts, dao.getAllBandalarts())
+            assertEquals(previousCells, dao.getAllCells())
+        }
+}

--- a/core/database/src/commonMain/kotlin/com/nexters/bandalart/core/database/BandalartDao.kt
+++ b/core/database/src/commonMain/kotlin/com/nexters/bandalart/core/database/BandalartDao.kt
@@ -123,6 +123,9 @@ interface BandalartDao {
     @Query("SELECT * FROM bandalarts")
     fun getBandalartList(): Flow<List<BandalartDBEntity>>
 
+    @Query("SELECT * FROM bandalarts")
+    suspend fun getAllBandalarts(): List<BandalartDBEntity>
+
     // Read - 셀
 
     /** 특정 반다라트의 메인 셀(최상위 셀) 조회 */
@@ -155,6 +158,25 @@ interface BandalartDao {
 
     @Query("SELECT * FROM bandalart_cells")
     suspend fun getAllCells(): List<BandalartCellDBEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertBandalartsForBackup(bandalarts: List<BandalartDBEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCellsForBackup(cells: List<BandalartCellDBEntity>)
+
+    @Query("DELETE FROM bandalarts")
+    suspend fun deleteAllBandalartsForBackup()
+
+    @Transaction
+    suspend fun replaceAllForBackup(
+        bandalarts: List<BandalartDBEntity>,
+        cells: List<BandalartCellDBEntity>,
+    ) {
+        deleteAllBandalartsForBackup()
+        insertBandalartsForBackup(bandalarts)
+        insertCellsForBackup(cells)
+    }
 
     @Transaction
     suspend fun findWidgetSnapshot(

--- a/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreTest.kt
+++ b/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreTest.kt
@@ -50,6 +50,44 @@ class BandalartDataStoreTest {
     }
 
     @Nested
+    @DisplayName("클라우드 백업 설정 테스트")
+    inner class CloudBackupPreferencesTest {
+        @Test
+        fun durablePreferencesRoundTripWithoutPendingRewardState() =
+            runTest {
+                bandalartDataStore.setRecentBandalartId(1L)
+                bandalartDataStore.setRecentSubGoalId(1L, 11L)
+                bandalartDataStore.upsertBandalartId(1L, true)
+                bandalartDataStore.setOnboardingCompletedStatus(true)
+                bandalartDataStore.setThemeMode("dark")
+                bandalartDataStore.addRecentEmoji("🎯")
+                bandalartDataStore.setDeadlineReminderEnabled(true)
+                bandalartDataStore.resolveMaxBandalartSlots(4)
+                bandalartDataStore.prepareRewardedCreation(requestId = 7L, minimumSlots = 4)
+                val backup = bandalartDataStore.createBackupPreferences(listOf(1L))
+
+                bandalartDataStore.setRecentBandalartId(2L)
+                bandalartDataStore.setRecentSubGoalId(2L, 22L)
+                bandalartDataStore.setThemeMode("light")
+                bandalartDataStore.restoreBackupPreferences(
+                    backup = backup,
+                    bandalartIdsToClear = listOf(1L, 2L),
+                )
+
+                assertEquals(1L, bandalartDataStore.getRecentBandalartId())
+                assertEquals(11L, bandalartDataStore.getRecentSubGoalId(1L))
+                assertEquals(0L, bandalartDataStore.getRecentSubGoalId(2L))
+                assertEquals(listOf(1L to true), bandalartDataStore.getPrevBandalartList())
+                assertTrue(bandalartDataStore.getOnboardingCompletedStatus())
+                assertEquals("dark", bandalartDataStore.themeMode.first())
+                assertEquals(listOf("🎯"), bandalartDataStore.recentEmojis.first())
+                assertTrue(bandalartDataStore.deadlineReminderEnabled.first())
+                assertEquals(4, bandalartDataStore.resolveMaxBandalartSlots(1))
+                assertEquals(null, bandalartDataStore.getPendingRewardedCreation())
+            }
+    }
+
+    @Nested
     @DisplayName("마감일 알림 설정 테스트")
     inner class DeadlineReminderPreferenceTest {
         @Test

--- a/core/datastore/src/commonMain/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStore.kt
+++ b/core/datastore/src/commonMain/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStore.kt
@@ -132,6 +132,60 @@ class BandalartDataStore(
         }
     }
 
+    suspend fun createBackupPreferences(bandalartIds: List<Long>): BandalartBackupPreferences {
+        val preferences =
+            dataStore.data
+                .catch { exception ->
+                    if (exception is IOException) emit(emptyPreferences()) else throw exception
+                }.first()
+        return BandalartBackupPreferences(
+            recentBandalartId = preferences[recentBandalartKey] ?: 0L,
+            recentSubGoalIds =
+                bandalartIds
+                    .associateWith { bandalartId ->
+                        preferences[recentSubGoalKey(bandalartId)] ?: 0L
+                    }.filterValues { it > 0L },
+            completedBandalarts = stringToList(preferences[completedBandalartListKey].orEmpty()),
+            onboardingCompleted = preferences[onboardingCompletedKey] ?: false,
+            themeMode = preferences[themeModeKey],
+            recentEmojis =
+                preferences[recentEmojisKey]
+                    ?.let { Json.decodeFromString<List<String>>(it) }
+                    ?: emptyList(),
+            deadlineReminderEnabled = preferences[deadlineReminderEnabledKey] ?: false,
+            maxBandalartSlots = preferences[maxBandalartSlotsKey] ?: bandalartIds.size,
+        )
+    }
+
+    suspend fun restoreBackupPreferences(
+        backup: BandalartBackupPreferences,
+        bandalartIdsToClear: List<Long>,
+    ) {
+        dataStore.edit { preferences ->
+            bandalartIdsToClear.forEach { bandalartId ->
+                preferences.remove(recentSubGoalKey(bandalartId))
+            }
+            preferences[recentBandalartKey] = backup.recentBandalartId
+            backup.recentSubGoalIds.forEach { (bandalartId, subGoalId) ->
+                preferences[recentSubGoalKey(bandalartId)] = subGoalId
+            }
+            preferences[completedBandalartListKey] = listToString(backup.completedBandalarts)
+            preferences[onboardingCompletedKey] = backup.onboardingCompleted
+            if (backup.themeMode == null) {
+                preferences.remove(themeModeKey)
+            } else {
+                preferences[themeModeKey] = backup.themeMode
+            }
+            preferences[recentEmojisKey] = Json.encodeToString(backup.recentEmojis)
+            preferences[deadlineReminderEnabledKey] = backup.deadlineReminderEnabled
+            preferences[maxBandalartSlotsKey] = backup.maxBandalartSlots
+            preferences.remove(pendingRewardedRequestIdKey)
+            preferences.remove(pendingRewardedTargetSlotsKey)
+            preferences.remove(pendingRewardedGrantedKey)
+            preferences.remove(pendingRewardedTemplateIdKey)
+        }
+    }
+
     val themeMode =
         dataStore.data
             .catch { exception ->
@@ -356,4 +410,15 @@ data class StoredPendingRewardedCreation(
     val targetSlots: Int,
     val isGranted: Boolean,
     val templateId: String? = null,
+)
+
+data class BandalartBackupPreferences(
+    val recentBandalartId: Long,
+    val recentSubGoalIds: Map<Long, Long>,
+    val completedBandalarts: List<Pair<Long, Boolean>>,
+    val onboardingCompleted: Boolean,
+    val themeMode: String?,
+    val recentEmojis: List<String>,
+    val deadlineReminderEnabled: Boolean,
+    val maxBandalartSlots: Int,
 )

--- a/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
@@ -50,6 +50,8 @@
     <string name="settings_theme_system">System default</string>
     <string name="settings_theme_light">Light mode</string>
     <string name="settings_theme_dark">Dark mode</string>
+    <string name="settings_cloud_backup">Cloud backup</string>
+    <string name="settings_cloud_backup_body">Back up data or restore from a backup</string>
     <string name="settings_app_info">App info</string>
     <string name="settings_contact">Contact us</string>
     <string name="settings_contact_subject">[BandalArt Support]</string>
@@ -57,6 +59,26 @@
     <string name="settings_contact_fallback">The email app is unavailable, so we copied the support email address.</string>
     <string name="settings_version">Version</string>
     <string name="settings_version_value">v%1$s</string>
+
+    <!-- CloudBackupScreen.kt -->
+    <string name="backup_title">Cloud backup</string>
+    <string name="backup_description">Keep this device's BandalArt data in the cloud.</string>
+    <string name="backup_status_none">No backup found</string>
+    <string name="backup_status_existing">%1$d BandalArts · backed up %2$s</string>
+    <string name="backup_not_supported">Cloud backup is unavailable on this device.</string>
+    <string name="backup_now">Back up now</string>
+    <string name="backup_restore">Restore from backup</string>
+    <string name="backup_start_fresh">Start fresh</string>
+    <string name="backup_loading">Working…</string>
+    <string name="backup_created">Backup complete.</string>
+    <string name="backup_restored">Restored from backup.</string>
+    <string name="backup_not_found">No backup is available to restore.</string>
+    <string name="backup_error">We couldn't process the backup. Please try again later.</string>
+    <string name="backup_restore_confirm_title">Restore from backup?</string>
+    <string name="backup_restore_confirm_body">Your current app data will be replaced with the backup.</string>
+    <string name="backup_restore_confirm">Restore</string>
+    <string name="backup_restore_cancel">Cancel</string>
+    <string name="backup_back">Back</string>
 
     <!--  BandalartListBottomSheet.kt -->
     <string name="bandalart_list_empty_title">New Bandalart %1$d</string>

--- a/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
@@ -50,6 +50,8 @@
     <string name="settings_theme_system">システム設定</string>
     <string name="settings_theme_light">ライトモード</string>
     <string name="settings_theme_dark">ダークモード</string>
+    <string name="settings_cloud_backup">クラウドバックアップ</string>
+    <string name="settings_cloud_backup_body">データをバックアップ、またはバックアップから復元します</string>
     <string name="settings_app_info">アプリ情報</string>
     <string name="settings_contact">お問い合わせ</string>
     <string name="settings_contact_subject">[BandalArt お問い合わせ]</string>
@@ -57,6 +59,26 @@
     <string name="settings_contact_fallback">メールアプリを開けないため、メールアドレスをコピーしました。</string>
     <string name="settings_version">バージョン</string>
     <string name="settings_version_value">v%1$s</string>
+
+    <!-- CloudBackupScreen.kt -->
+    <string name="backup_title">クラウドバックアップ</string>
+    <string name="backup_description">この端末のBandalArtデータをクラウドに保存できます。</string>
+    <string name="backup_status_none">保存されたバックアップはありません</string>
+    <string name="backup_status_existing">BandalArt %1$d件・%2$sにバックアップ</string>
+    <string name="backup_not_supported">この端末ではクラウドバックアップを利用できません。</string>
+    <string name="backup_now">今すぐバックアップ</string>
+    <string name="backup_restore">バックアップから復元</string>
+    <string name="backup_start_fresh">新しく始める</string>
+    <string name="backup_loading">処理中です…</string>
+    <string name="backup_created">バックアップが完了しました。</string>
+    <string name="backup_restored">バックアップから復元しました。</string>
+    <string name="backup_not_found">復元できるバックアップがありません。</string>
+    <string name="backup_error">バックアップを処理できませんでした。しばらくしてからもう一度お試しください。</string>
+    <string name="backup_restore_confirm_title">バックアップから復元しますか？</string>
+    <string name="backup_restore_confirm_body">現在のアプリデータはバックアップのデータに置き換わります。</string>
+    <string name="backup_restore_confirm">復元</string>
+    <string name="backup_restore_cancel">キャンセル</string>
+    <string name="backup_back">戻る</string>
 
     <!--  BandalartListBottomSheet.kt -->
     <string name="bandalart_list_empty_title">新しいバンダラート %1$d</string>

--- a/core/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -50,6 +50,8 @@
     <string name="settings_theme_system">시스템 설정</string>
     <string name="settings_theme_light">라이트 모드</string>
     <string name="settings_theme_dark">다크 모드</string>
+    <string name="settings_cloud_backup">클라우드 백업</string>
+    <string name="settings_cloud_backup_body">데이터를 백업하거나 백업에서 복원해요</string>
     <string name="settings_app_info">앱 정보</string>
     <string name="settings_contact">문의하기</string>
     <string name="settings_contact_subject">[반다라트 문의]</string>
@@ -57,6 +59,26 @@
     <string name="settings_contact_fallback">메일 앱을 열 수 없어 이메일 주소를 복사했어요.</string>
     <string name="settings_version">버전</string>
     <string name="settings_version_value">v%1$s</string>
+
+    <!-- CloudBackupScreen.kt -->
+    <string name="backup_title">클라우드 백업</string>
+    <string name="backup_description">현재 기기의 반다라트 데이터를 클라우드에 보관할 수 있어요.</string>
+    <string name="backup_status_none">저장된 백업이 없어요</string>
+    <string name="backup_status_existing">반다라트 %1$d개 · %2$s 백업</string>
+    <string name="backup_not_supported">이 기기에서는 클라우드 백업을 사용할 수 없어요.</string>
+    <string name="backup_now">지금 백업하기</string>
+    <string name="backup_restore">백업에서 복원</string>
+    <string name="backup_start_fresh">새로 시작</string>
+    <string name="backup_loading">처리 중이에요…</string>
+    <string name="backup_created">백업을 완료했어요.</string>
+    <string name="backup_restored">백업에서 복원했어요.</string>
+    <string name="backup_not_found">복원할 백업이 없어요.</string>
+    <string name="backup_error">백업을 처리하지 못했어요. 잠시 후 다시 시도해 주세요.</string>
+    <string name="backup_restore_confirm_title">백업에서 복원할까요?</string>
+    <string name="backup_restore_confirm_body">현재 앱 데이터가 백업 데이터로 교체돼요.</string>
+    <string name="backup_restore_confirm">복원</string>
+    <string name="backup_restore_cancel">취소</string>
+    <string name="backup_back">뒤로가기</string>
 
     <!--  BandalartListBottomSheet.kt -->
     <string name="bandalart_list_empty_title">새 반다라트 %1$d</string>

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("bandalart.kmp")
     id("bandalart.kmp.android")
     id("bandalart.kmp.ios")
+    id("bandalart.kotlin.serialization")
 }
 
 kotlin {
@@ -10,6 +11,7 @@ kotlin {
         commonMain.dependencies {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.datetime)
+            implementation(libs.kotlinx.serialization.json)
 
             compileOnly(libs.compose.stable.marker)
         }

--- a/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/backup/BackupSnapshot.kt
+++ b/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/backup/BackupSnapshot.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.domain.backup
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BackupSnapshot(
+    val schemaVersion: Int = CURRENT_SCHEMA_VERSION,
+    val bandalarts: List<BackupBandalart>,
+    val cells: List<BackupCell>,
+    val preferences: BackupPreferences,
+) {
+    companion object {
+        const val CURRENT_SCHEMA_VERSION = 1
+    }
+}
+
+@Serializable
+data class BackupBandalart(
+    val id: Long,
+    val mainColor: String,
+    val subColor: String,
+    val profileEmoji: String? = null,
+    val title: String? = null,
+    val description: String? = null,
+    val dueDate: String? = null,
+    val isCompleted: Boolean = false,
+    val completionRatio: Int = 0,
+)
+
+@Serializable
+data class BackupCell(
+    val id: Long,
+    val bandalartId: Long,
+    val title: String? = null,
+    val description: String? = null,
+    val dueDate: String? = null,
+    val isCompleted: Boolean = false,
+    val parentId: Long? = null,
+)
+
+@Serializable
+data class BackupPreferences(
+    val recentBandalartId: Long,
+    val recentSubGoalIds: Map<Long, Long>,
+    val completedBandalarts: List<BackupCompletedBandalart>,
+    val onboardingCompleted: Boolean,
+    val themeMode: String?,
+    val recentEmojis: List<String>,
+    val deadlineReminderEnabled: Boolean,
+    val maxBandalartSlots: Int,
+)
+
+@Serializable
+data class BackupCompletedBandalart(
+    val bandalartId: Long,
+    val isCompleted: Boolean,
+)
+
+@Serializable
+data class BackupMetadata(
+    val bandalartCount: Int,
+    val updatedAt: String,
+)

--- a/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/backup/CloudBackupRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/backup/CloudBackupRepository.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.domain.backup
+
+interface CloudBackupRepository {
+    val isSupported: Boolean
+
+    suspend fun hasLocalData(): Boolean
+
+    suspend fun findBackup(): BackupMetadata?
+
+    suspend fun createBackup(): BackupMetadata
+
+    suspend fun restoreBackup(): BackupMetadata?
+}
+
+fun interface DeviceBackupKeyProvider {
+    fun getDeviceKey(): String?
+}
+
+fun interface StartupBackupPolicy {
+    suspend fun evaluate(): StartupBackupDecision
+}
+
+sealed interface StartupBackupDecision {
+    data object Continue : StartupBackupDecision
+
+    data class OfferRestore(
+        val metadata: BackupMetadata,
+    ) : StartupBackupDecision
+}

--- a/core/navigation/src/commonMain/kotlin/com/nexters/bandalart/core/navigation/CloudBackupScreen.kt
+++ b/core/navigation/src/commonMain/kotlin/com/nexters/bandalart/core/navigation/CloudBackupScreen.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.navigation
+
+import com.slack.circuit.runtime.screen.ParcelableScreen
+
+@CommonParcelize
+data class CloudBackupScreen(
+    val entryPoint: EntryPoint,
+    val fallback: Fallback = Fallback.HOME,
+    val backupCount: Int? = null,
+    val backupUpdatedAt: String? = null,
+) : ParcelableScreen {
+    enum class EntryPoint {
+        SETTINGS,
+        STARTUP,
+    }
+
+    enum class Fallback {
+        HOME,
+        ONBOARDING,
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,10 @@
 
 ## Features
 
+### Backup
+
+- [Supabase 반다라트 백업 전략](features/backup/SUPABASE_BACKUP_STRATEGY.md)
+
 ### Ads
 
 - [Android AdMob 미노출 트러블슈팅](features/ads/ADMOB_ANDROID_TROUBLESHOOTING.md)

--- a/docs/features/backup/SUPABASE_BACKUP_STRATEGY.md
+++ b/docs/features/backup/SUPABASE_BACKUP_STRATEGY.md
@@ -1,0 +1,60 @@
+# Supabase 반다라트 백업 전략
+
+## 목적
+
+Android 또는 iOS 동일 기기에서 앱 데이터 삭제 또는 재설치 후 사용자가 수동으로 저장한 반다라트 백업을 복원한다. Room은 앱의 단일 로컬 데이터 원본으로 유지하고 Supabase는 최신 백업 스냅샷 한 건을 보관한다.
+
+## 지원 범위
+
+- Android SSAID에서 파생한 `deviceKey`로 동일 기기 백업을 식별한다.
+- iOS Keychain에 보존한 랜덤 seed에서 파생한 `deviceKey`로 동일 기기 백업을 식별한다.
+- 설정에서 사용자가 `지금 백업하기`를 실행할 때만 원격 스냅샷을 갱신한다.
+- Android와 iOS 앱 시작 시 원격 백업 존재 여부를 조회한다.
+- Room이 비어 있고 원격 백업이 있을 때만 `백업에서 복원 / 새로 시작`을 제안한다.
+- 로컬 데이터가 있으면 자동으로 덮어쓰지 않는다.
+- 실시간 동기화, 다른 기기 복원, Android와 iOS 간 복원은 포함하지 않는다.
+
+## 데이터 모델
+
+원격에는 `device_backups` 한 테이블만 둔다.
+
+- `device_key`: 앱 namespace와 Android SSAID 또는 iOS Keychain seed에서 파생한 해시
+- `schema_version`: 백업 payload 형식 버전
+- `payload`: Room 반다라트와 셀, 복원 대상 DataStore 값을 담는 JSONB
+- `bandalart_count`: 복원 안내에 표시할 반다라트 개수
+- `updated_at`: 마지막 백업 시각
+
+테이블 직접 권한은 닫고 `get_device_backup`, `put_device_backup`, `delete_device_backup` RPC만 공개한다. 이 구조는 SSAID 파생 키를 인증 자격 증명으로 사용한다는 한계를 받아들이는 저민감도 MVP이며 원본 SSAID를 저장하거나 로그에 남기지 않는다.
+
+## 저장소 구성
+
+- Supabase CLI는 루트 `package.json`의 고정 버전을 `npx supabase` 또는 npm script로 실행한다.
+- KMP 클라이언트는 기존 `kotlinx-datetime 0.6.x` ABI와 호환되는 `supabase-kt 3.2.0`을 사용한다.
+- `supabase/config.toml`, `supabase/migrations`, `supabase/tests`를 버전 관리한다.
+- secret과 CLI 임시 상태는 Git에 추가하지 않는다.
+- 로컬 전체 스택은 Docker 호환 런타임이 있을 때만 실행한다.
+
+Android와 iOS 앱의 Data API 연결값은 다음 순서로 KMP 빌드에 주입한다.
+
+1. Gradle property `bandalart.supabaseUrl`, `bandalart.supabasePublishableKey`
+2. 환경 변수 `BANDALART_SUPABASE_URL`, `BANDALART_SUPABASE_PUBLISHABLE_KEY`
+3. Git에서 제외된 루트 `local.properties`의 같은 Gradle property
+
+연결값이 없으면 앱은 클라우드 백업을 지원하지 않는 상태로 동작한다. publishable key만 앱에 포함하며 `secret` 또는 `service_role` key는 앱이나 저장소에 넣지 않는다.
+
+## 단계
+
+1. CLI 초기화와 최초 백업 스키마 migration을 추가한다.
+2. 로컬 DB reset과 database test로 권한 및 RPC 동작을 검증한다.
+3. 별도 Supabase 프로젝트를 생성 또는 선택하고 CLI로 link한다.
+4. `db push --dry-run` 확인 후 migration을 원격에 적용한다.
+5. KMP 백업 snapshot, Android SSAID provider, Supabase client와 복원 UI를 구현한다.
+
+## 완료 조건
+
+- 새 환경에서 의존성 설치 후 동일 CLI 버전을 실행할 수 있다.
+- migration만으로 백업 테이블과 RPC를 재현할 수 있다.
+- 공개 Data API에서 테이블을 직접 나열하거나 수정할 수 없다.
+- 올바른 `deviceKey`로 백업 저장, 조회, 삭제가 가능하다.
+- payload 크기와 schema version이 서버에서 검증된다.
+- 원격 연결 정보와 secret이 Git에 포함되지 않는다.

--- a/feature/backup/build.gradle.kts
+++ b/feature/backup/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+    id("bandalart.kmp.feature")
+    id("org.jetbrains.kotlin.plugin.parcelize")
+    alias(libs.plugins.metro)
+}
+
+metro {
+    enableCircuitCodegen.set(true)
+}
+
+kotlin {
+    targets.withType<com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget>().configureEach {
+        compilerOptions.freeCompilerArgs.addAll(
+            "-P",
+            "plugin:org.jetbrains.kotlin.parcelize:additionalAnnotation=com.nexters.bandalart.core.navigation.CommonParcelize",
+        )
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.core.designsystem)
+            implementation(projects.core.domain)
+            implementation(projects.core.navigation)
+            implementation(projects.feature.home)
+            implementation(projects.feature.onboarding)
+
+            implementation(libs.circuit.runtime)
+            implementation(libs.circuit.runtime.presenter)
+            implementation(libs.circuit.runtime.ui)
+            implementation(libs.kotlinx.coroutines.core)
+        }
+
+        androidHostTest.dependencies {
+            implementation(libs.bundles.android.unit.test)
+            implementation(libs.circuit.test)
+            implementation(libs.kotlinx.coroutines.test)
+        }
+    }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/feature/backup/src/androidHostTest/kotlin/com/nexters/bandalart/feature/backup/presenter/CloudBackupPresenterTest.kt
+++ b/feature/backup/src/androidHostTest/kotlin/com/nexters/bandalart/feature/backup/presenter/CloudBackupPresenterTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.backup.presenter
+
+import com.nexters.bandalart.core.domain.backup.BackupMetadata
+import com.nexters.bandalart.core.domain.backup.CloudBackupRepository
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingHealth
+import com.nexters.bandalart.core.navigation.CloudBackupScreen
+import com.nexters.bandalart.feature.backup.CloudBackupUiState
+import com.nexters.bandalart.feature.home.HomeScreen
+import com.nexters.bandalart.feature.onboarding.OnboardingScreen
+import com.slack.circuit.test.FakeNavigator
+import com.slack.circuit.test.test
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CloudBackupPresenterTest {
+    @Test
+    fun settingsLoadsExistingBackup() =
+        runTest {
+            val metadata = BackupMetadata(2, "2026-08-18T01:00:00Z")
+            val repository = FakeCloudBackupRepository(existing = metadata)
+            val presenter = presenter(CloudBackupScreen.EntryPoint.SETTINGS, repository)
+
+            presenter.test {
+                awaitItem()
+                assertEquals(metadata, awaitItem().metadata)
+            }
+        }
+
+    @Test
+    fun settingsRestoreRequiresConfirmation() =
+        runTest {
+            val repository = FakeCloudBackupRepository(existing = BackupMetadata(1, "now"))
+            val presenter = presenter(CloudBackupScreen.EntryPoint.SETTINGS, repository)
+
+            presenter.test {
+                awaitItem()
+                val state = awaitItem()
+                state.eventSink(CloudBackupUiState.Event.RestoreBackup)
+                val confirmation = awaitItem()
+
+                assertTrue(confirmation.showRestoreConfirmation)
+                assertEquals(0, repository.restoreCalls)
+
+                confirmation.eventSink(CloudBackupUiState.Event.ConfirmRestore)
+                var restored = awaitItem()
+                while (restored.result != CloudBackupUiState.Result.RESTORED) restored = awaitItem()
+                assertFalse(restored.showRestoreConfirmation)
+                assertEquals(CloudBackupUiState.Result.RESTORED, restored.result)
+                assertEquals(1, repository.restoreCalls)
+            }
+        }
+
+    @Test
+    fun startupRestoreRestoresImmediatelyAndOpensHome() =
+        runTest {
+            val repository = FakeCloudBackupRepository(existing = BackupMetadata(1, "now"))
+            val screen =
+                CloudBackupScreen(
+                    entryPoint = CloudBackupScreen.EntryPoint.STARTUP,
+                    backupCount = 1,
+                    backupUpdatedAt = "now",
+                )
+            val navigator = FakeNavigator(screen)
+            val reconciler = RecordingReconciler()
+            val presenter = CloudBackupPresenter(screen, navigator, repository, reconciler)
+
+            presenter.test {
+                awaitItem().eventSink(CloudBackupUiState.Event.RestoreBackup)
+
+                assertEquals(HomeScreen, navigator.awaitResetRoot().newRoot)
+                assertEquals(1, repository.restoreCalls)
+                assertEquals(1, reconciler.reconcileCalls)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun startupCanContinueToConfiguredFallback() =
+        runTest {
+            val screen =
+                CloudBackupScreen(
+                    entryPoint = CloudBackupScreen.EntryPoint.STARTUP,
+                    fallback = CloudBackupScreen.Fallback.ONBOARDING,
+                )
+            val navigator = FakeNavigator(screen)
+            val presenter = CloudBackupPresenter(screen, navigator, FakeCloudBackupRepository())
+
+            presenter.test {
+                awaitItem().eventSink(CloudBackupUiState.Event.StartFresh)
+
+                assertEquals(OnboardingScreen, navigator.awaitResetRoot().newRoot)
+            }
+        }
+
+    private fun presenter(
+        entryPoint: CloudBackupScreen.EntryPoint,
+        repository: CloudBackupRepository,
+    ): CloudBackupPresenter {
+        val screen = CloudBackupScreen(entryPoint = entryPoint)
+        return CloudBackupPresenter(screen, FakeNavigator(screen), repository)
+    }
+}
+
+private class RecordingReconciler : DeadlineReminderReconciler {
+    override val schedulingHealth: StateFlow<DeadlineReminderSchedulingHealth> =
+        MutableStateFlow(DeadlineReminderSchedulingHealth())
+    var reconcileCalls = 0
+
+    override suspend fun reconcileAll() {
+        reconcileCalls += 1
+    }
+}
+
+private class FakeCloudBackupRepository(
+    private var existing: BackupMetadata? = null,
+) : CloudBackupRepository {
+    override val isSupported = true
+    var restoreCalls = 0
+
+    override suspend fun hasLocalData(): Boolean = true
+
+    override suspend fun findBackup(): BackupMetadata? = existing
+
+    override suspend fun createBackup(): BackupMetadata = BackupMetadata(3, "created").also { existing = it }
+
+    override suspend fun restoreBackup(): BackupMetadata? {
+        restoreCalls += 1
+        return existing
+    }
+}

--- a/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/CloudBackupScreenUi.kt
+++ b/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/CloudBackupScreenUi.kt
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.backup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import bandalart.core.designsystem.generated.resources.Res
+import bandalart.core.designsystem.generated.resources.backup_back
+import bandalart.core.designsystem.generated.resources.backup_created
+import bandalart.core.designsystem.generated.resources.backup_description
+import bandalart.core.designsystem.generated.resources.backup_error
+import bandalart.core.designsystem.generated.resources.backup_loading
+import bandalart.core.designsystem.generated.resources.backup_not_found
+import bandalart.core.designsystem.generated.resources.backup_not_supported
+import bandalart.core.designsystem.generated.resources.backup_now
+import bandalart.core.designsystem.generated.resources.backup_restore
+import bandalart.core.designsystem.generated.resources.backup_restore_cancel
+import bandalart.core.designsystem.generated.resources.backup_restore_confirm
+import bandalart.core.designsystem.generated.resources.backup_restore_confirm_body
+import bandalart.core.designsystem.generated.resources.backup_restore_confirm_title
+import bandalart.core.designsystem.generated.resources.backup_restored
+import bandalart.core.designsystem.generated.resources.backup_start_fresh
+import bandalart.core.designsystem.generated.resources.backup_status_existing
+import bandalart.core.designsystem.generated.resources.backup_status_none
+import bandalart.core.designsystem.generated.resources.backup_title
+import com.nexters.bandalart.core.navigation.CloudBackupScreen
+import com.slack.circuit.codegen.annotations.CircuitInject
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Inject
+import org.jetbrains.compose.resources.stringResource
+
+@CircuitInject(CloudBackupScreen::class, AppScope::class)
+@Inject
+@Composable
+internal fun CloudBackup(
+    state: CloudBackupUiState,
+    modifier: Modifier = Modifier,
+) {
+    if (state.showRestoreConfirmation) {
+        RestoreConfirmationDialog(state.eventSink)
+    }
+
+    Surface(
+        modifier = modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        Column(
+            modifier =
+                Modifier
+                    .statusBarsPadding()
+                    .padding(horizontal = 20.dp),
+        ) {
+            BackupHeader(
+                showBack = state.entryPoint == CloudBackupScreen.EntryPoint.SETTINGS,
+                onBack = { state.eventSink(CloudBackupUiState.Event.Back) },
+            )
+            Text(
+                text = stringResource(Res.string.backup_description),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Surface(
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(16.dp),
+                color = MaterialTheme.colorScheme.surfaceContainer,
+            ) {
+                Column(modifier = Modifier.padding(20.dp)) {
+                    Text(
+                        text =
+                            when {
+                                !state.isSupported -> stringResource(Res.string.backup_not_supported)
+                                state.metadata == null -> stringResource(Res.string.backup_status_none)
+                                else ->
+                                    stringResource(
+                                        Res.string.backup_status_existing,
+                                        state.metadata.bandalartCount,
+                                        state.metadata.updatedAt.toDisplayDate(),
+                                    )
+                            },
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    if (state.isLoading) {
+                        Row(
+                            modifier = Modifier.padding(top = 16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            CircularProgressIndicator()
+                            Text(stringResource(Res.string.backup_loading))
+                        }
+                    }
+                    state.result?.let { result ->
+                        Text(
+                            text = stringResource(result.messageResource()),
+                            color =
+                                if (result == CloudBackupUiState.Result.ERROR) {
+                                    MaterialTheme.colorScheme.error
+                                } else {
+                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                },
+                            modifier = Modifier.padding(top = 12.dp),
+                        )
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            if (state.entryPoint == CloudBackupScreen.EntryPoint.SETTINGS) {
+                Button(
+                    onClick = { state.eventSink(CloudBackupUiState.Event.CreateBackup) },
+                    enabled = state.isSupported && !state.isLoading,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(Res.string.backup_now))
+                }
+            }
+            OutlinedButton(
+                onClick = { state.eventSink(CloudBackupUiState.Event.RestoreBackup) },
+                enabled = state.isSupported && !state.isLoading && state.metadata != null,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(Res.string.backup_restore))
+            }
+            if (state.entryPoint == CloudBackupScreen.EntryPoint.STARTUP) {
+                TextButton(
+                    onClick = { state.eventSink(CloudBackupUiState.Event.StartFresh) },
+                    enabled = !state.isLoading,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(Res.string.backup_start_fresh))
+                }
+            }
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun BackupHeader(
+    showBack: Boolean,
+    onBack: () -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(64.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (showBack) {
+            IconButton(onClick = onBack) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = stringResource(Res.string.backup_back),
+                )
+            }
+        }
+        Text(
+            text = stringResource(Res.string.backup_title),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Composable
+private fun RestoreConfirmationDialog(eventSink: (CloudBackupUiState.Event) -> Unit) {
+    AlertDialog(
+        onDismissRequest = { eventSink(CloudBackupUiState.Event.DismissRestoreConfirmation) },
+        title = { Text(stringResource(Res.string.backup_restore_confirm_title)) },
+        text = { Text(stringResource(Res.string.backup_restore_confirm_body)) },
+        confirmButton = {
+            TextButton(onClick = { eventSink(CloudBackupUiState.Event.ConfirmRestore) }) {
+                Text(stringResource(Res.string.backup_restore_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { eventSink(CloudBackupUiState.Event.DismissRestoreConfirmation) }) {
+                Text(stringResource(Res.string.backup_restore_cancel))
+            }
+        },
+    )
+}
+
+private fun String.toDisplayDate(): String = take(10).ifBlank { this }
+
+private fun CloudBackupUiState.Result.messageResource() =
+    when (this) {
+        CloudBackupUiState.Result.BACKUP_CREATED -> Res.string.backup_created
+        CloudBackupUiState.Result.RESTORED -> Res.string.backup_restored
+        CloudBackupUiState.Result.BACKUP_NOT_FOUND -> Res.string.backup_not_found
+        CloudBackupUiState.Result.ERROR -> Res.string.backup_error
+    }

--- a/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/CloudBackupUiState.kt
+++ b/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/CloudBackupUiState.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.backup
+
+import com.nexters.bandalart.core.domain.backup.BackupMetadata
+import com.nexters.bandalart.core.navigation.CloudBackupScreen
+import com.slack.circuit.runtime.CircuitUiEvent
+import com.slack.circuit.runtime.CircuitUiState
+
+data class CloudBackupUiState(
+    val entryPoint: CloudBackupScreen.EntryPoint,
+    val isSupported: Boolean,
+    val isLoading: Boolean,
+    val metadata: BackupMetadata?,
+    val showRestoreConfirmation: Boolean,
+    val result: Result?,
+    val eventSink: (Event) -> Unit,
+) : CircuitUiState {
+    enum class Result {
+        BACKUP_CREATED,
+        RESTORED,
+        BACKUP_NOT_FOUND,
+        ERROR,
+    }
+
+    sealed interface Event : CircuitUiEvent {
+        data object Back : Event
+
+        data object CreateBackup : Event
+
+        data object RestoreBackup : Event
+
+        data object ConfirmRestore : Event
+
+        data object DismissRestoreConfirmation : Event
+
+        data object StartFresh : Event
+
+        data object ConsumeResult : Event
+    }
+}

--- a/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/presenter/CloudBackupPresenter.kt
+++ b/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/presenter/CloudBackupPresenter.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.backup.presenter
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import com.nexters.bandalart.core.domain.backup.BackupMetadata
+import com.nexters.bandalart.core.domain.backup.CloudBackupRepository
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
+import com.nexters.bandalart.core.domain.notification.NoOpDeadlineReminderReconciler
+import com.nexters.bandalart.core.navigation.CloudBackupScreen
+import com.nexters.bandalart.feature.backup.CloudBackupUiState
+import com.nexters.bandalart.feature.home.HomeScreen
+import com.nexters.bandalart.feature.onboarding.OnboardingScreen
+import com.slack.circuit.codegen.annotations.CircuitInject
+import com.slack.circuit.runtime.Navigator
+import com.slack.circuit.runtime.presenter.Presenter
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+
+@AssistedInject
+class CloudBackupPresenter(
+    @Assisted private val screen: CloudBackupScreen,
+    @Assisted private val navigator: Navigator,
+    private val repository: CloudBackupRepository,
+    private val deadlineReminderReconciler: DeadlineReminderReconciler = NoOpDeadlineReminderReconciler,
+) : Presenter<CloudBackupUiState> {
+    @Composable
+    override fun present(): CloudBackupUiState {
+        val scope = rememberCoroutineScope()
+        var metadata by remember {
+            mutableStateOf(
+                screen.backupCount?.let { count ->
+                    BackupMetadata(count, screen.backupUpdatedAt.orEmpty())
+                },
+            )
+        }
+        var isLoading by remember { mutableStateOf(screen.entryPoint == CloudBackupScreen.EntryPoint.SETTINGS) }
+        var showRestoreConfirmation by remember { mutableStateOf(false) }
+        var result by remember { mutableStateOf<CloudBackupUiState.Result?>(null) }
+
+        LaunchedEffect(screen.entryPoint, repository.isSupported) {
+            if (screen.entryPoint == CloudBackupScreen.EntryPoint.SETTINGS && repository.isSupported) {
+                try {
+                    metadata = repository.findBackup()
+                } catch (exception: CancellationException) {
+                    throw exception
+                } catch (_: Exception) {
+                    result = CloudBackupUiState.Result.ERROR
+                } finally {
+                    isLoading = false
+                }
+            } else {
+                isLoading = false
+            }
+        }
+
+        fun navigateToFallback() {
+            navigator.resetRoot(
+                when (screen.fallback) {
+                    CloudBackupScreen.Fallback.HOME -> HomeScreen
+                    CloudBackupScreen.Fallback.ONBOARDING -> OnboardingScreen
+                },
+            )
+        }
+
+        fun restore() {
+            isLoading = true
+            showRestoreConfirmation = false
+            result = null
+            scope.launch {
+                try {
+                    val restored = repository.restoreBackup()
+                    if (restored == null) {
+                        result = CloudBackupUiState.Result.BACKUP_NOT_FOUND
+                    } else {
+                        deadlineReminderReconciler.reconcileAll()
+                        if (screen.entryPoint == CloudBackupScreen.EntryPoint.STARTUP) {
+                            navigator.resetRoot(HomeScreen)
+                        } else {
+                            metadata = restored
+                            result = CloudBackupUiState.Result.RESTORED
+                        }
+                    }
+                } catch (exception: CancellationException) {
+                    throw exception
+                } catch (_: Exception) {
+                    result = CloudBackupUiState.Result.ERROR
+                } finally {
+                    isLoading = false
+                }
+            }
+        }
+
+        return CloudBackupUiState(
+            entryPoint = screen.entryPoint,
+            isSupported = repository.isSupported,
+            isLoading = isLoading,
+            metadata = metadata,
+            showRestoreConfirmation = showRestoreConfirmation,
+            result = result,
+        ) { event ->
+            when (event) {
+                CloudBackupUiState.Event.Back -> {
+                    if (screen.entryPoint == CloudBackupScreen.EntryPoint.SETTINGS) navigator.pop() else navigateToFallback()
+                }
+                CloudBackupUiState.Event.CreateBackup -> {
+                    isLoading = true
+                    result = null
+                    scope.launch {
+                        try {
+                            metadata = repository.createBackup()
+                            result = CloudBackupUiState.Result.BACKUP_CREATED
+                        } catch (exception: CancellationException) {
+                            throw exception
+                        } catch (_: Exception) {
+                            result = CloudBackupUiState.Result.ERROR
+                        } finally {
+                            isLoading = false
+                        }
+                    }
+                }
+                CloudBackupUiState.Event.RestoreBackup -> {
+                    if (screen.entryPoint == CloudBackupScreen.EntryPoint.SETTINGS) {
+                        showRestoreConfirmation = true
+                    } else {
+                        restore()
+                    }
+                }
+                CloudBackupUiState.Event.ConfirmRestore -> restore()
+                CloudBackupUiState.Event.DismissRestoreConfirmation -> showRestoreConfirmation = false
+                CloudBackupUiState.Event.StartFresh -> navigateToFallback()
+                CloudBackupUiState.Event.ConsumeResult -> result = null
+            }
+        }
+    }
+
+    @CircuitInject(CloudBackupScreen::class, AppScope::class)
+    @AssistedFactory
+    fun interface Factory {
+        fun create(
+            @Assisted screen: CloudBackupScreen,
+            @Assisted navigator: Navigator,
+        ): CloudBackupPresenter
+    }
+}

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
@@ -20,6 +20,7 @@ import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
 import com.nexters.bandalart.core.domain.entity.BandalartEntity
 import com.nexters.bandalart.core.domain.widget.BandalartWidgetLaunchTarget
 import com.nexters.bandalart.core.domain.widget.BufferedBandalartWidgetLaunchTarget
+import com.nexters.bandalart.core.navigation.CloudBackupScreen
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.nexters.bandalart.feature.home.model.CellType
 import com.slack.circuit.test.FakeNavigator
@@ -34,6 +35,38 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class HomePresenterTest {
+    @Test
+    fun cloudBackupSettingsOpensDedicatedScreen() =
+        runTest {
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1L)),
+                    recentBandalartId = 1L,
+                )
+            val navigator = FakeNavigator(HomeScreen)
+            val presenter =
+                HomePresenter(
+                    navigator = navigator,
+                    bandalartRepository = repository,
+                    bandalartSlotRepository = FakeBandalartSlotRepository(),
+                    inAppUpdateRepository = FakeInAppUpdateRepository(),
+                    settingsRepository = FakeSettingsRepository(),
+                )
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != 1L || state.isLoading) state = awaitItem()
+
+                state.eventSink(HomeScreen.Event.OpenCloudBackup)
+
+                assertEquals(
+                    CloudBackupScreen(entryPoint = CloudBackupScreen.EntryPoint.SETTINGS),
+                    navigator.awaitNextScreen(),
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     fun openingASubgoalAndItsTaskRecordsTheSubgoalForTheCurrentBandalart() =

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
@@ -225,6 +225,8 @@ data object HomeScreen : ParcelableScreen, StaticScreen {
 
         data object OpenSettings : Event
 
+        data object OpenCloudBackup : Event
+
         data class SelectThemeMode(
             val themeMode: ThemeMode,
         ) : Event

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -47,6 +47,7 @@ import com.nexters.bandalart.core.domain.repository.SettingsRepository
 import com.nexters.bandalart.core.domain.template.BandalartTemplateId
 import com.nexters.bandalart.core.domain.widget.BandalartWidgetLaunchTarget
 import com.nexters.bandalart.core.domain.widget.BufferedBandalartWidgetLaunchTarget
+import com.nexters.bandalart.core.navigation.CloudBackupScreen
 import com.nexters.bandalart.feature.complete.CompleteScreen
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.nexters.bandalart.feature.home.mapper.toUiModel
@@ -856,6 +857,10 @@ class HomePresenter(
                     scope.launch {
                         deadlineNotificationAuthorizationStatus = deadlineNotificationAuthorization.getStatus()
                     }
+                }
+                HomeScreen.Event.OpenCloudBackup -> {
+                    bottomSheet = null
+                    navigator.goTo(CloudBackupScreen(entryPoint = CloudBackupScreen.EntryPoint.SETTINGS))
                 }
                 HomeScreen.Event.OpenEmoji -> {
                     if (!isUpdatingBandalartEmoji) openEmoji()

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/settings/SettingsBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/settings/SettingsBottomSheet.kt
@@ -60,6 +60,8 @@ import bandalart.core.designsystem.generated.resources.clear_description
 import bandalart.core.designsystem.generated.resources.ic_notifications_outlined
 import bandalart.core.designsystem.generated.resources.settings_app_info
 import bandalart.core.designsystem.generated.resources.settings_appearance
+import bandalart.core.designsystem.generated.resources.settings_cloud_backup
+import bandalart.core.designsystem.generated.resources.settings_cloud_backup_body
 import bandalart.core.designsystem.generated.resources.settings_deadline_reminder
 import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_body
 import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_blocked
@@ -172,6 +174,13 @@ internal fun SettingsBottomSheet(
                     modifier = Modifier.padding(horizontal = 20.dp),
                 )
             }
+            SettingsCloudBackupRow(
+                onClick = { onHomeUiAction(HomeScreen.Event.OpenCloudBackup) },
+            )
+            HorizontalDivider(
+                color = MaterialTheme.colorScheme.outlineVariant,
+                modifier = Modifier.padding(horizontal = 20.dp),
+            )
             SettingsSectionTitle(text = stringResource(Res.string.settings_app_info))
             SettingsContactRow(
                 onClick = { onHomeUiAction(HomeScreen.Event.ContactSupport) },
@@ -203,6 +212,42 @@ internal fun SettingsBottomSheet(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun SettingsCloudBackupRow(onClick: () -> Unit) {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = stringResource(Res.string.settings_cloud_backup),
+                color = MaterialTheme.colorScheme.onSurface,
+                fontSize = 15.sp,
+                fontFamily = pretendardFontFamily(),
+                fontWeight = FontWeight.W600,
+            )
+            Text(
+                text = stringResource(Res.string.settings_cloud_backup_body),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 13.sp,
+                fontFamily = pretendardFontFamily(),
+                lineHeight = 18.sp,
+                modifier = Modifier.padding(top = 4.dp, end = 12.dp),
+            )
+        }
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(20.dp),
+        )
     }
 }
 

--- a/feature/splash/src/androidHostTest/kotlin/com/nexters/bandalart/feature/splash/presenter/SplashPresenterTest.kt
+++ b/feature/splash/src/androidHostTest/kotlin/com/nexters/bandalart/feature/splash/presenter/SplashPresenterTest.kt
@@ -16,6 +16,10 @@
 
 package com.nexters.bandalart.feature.splash.presenter
 
+import com.nexters.bandalart.core.domain.backup.BackupMetadata
+import com.nexters.bandalart.core.domain.backup.StartupBackupDecision
+import com.nexters.bandalart.core.domain.backup.StartupBackupPolicy
+import com.nexters.bandalart.core.navigation.CloudBackupScreen
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.nexters.bandalart.feature.onboarding.OnboardingScreen
 import com.nexters.bandalart.feature.splash.SplashScreen
@@ -44,7 +48,7 @@ class SplashPresenterTest {
         runTest {
             val repository = FakeOnboardingRepository(initialCompletedStatus = true)
             val navigator = FakeNavigator(SplashScreen)
-            val presenter = SplashPresenter(navigator, repository)
+            val presenter = SplashPresenter(navigator, repository, continuePolicy())
 
             presenter.test {
                 val state = awaitItem()
@@ -58,13 +62,41 @@ class SplashPresenterTest {
             }
         }
 
+    @Test
+    fun emptyInstallWithBackupOffersRestoreBeforeHome() =
+        runTest {
+            val metadata = BackupMetadata(2, "2026-08-18T01:00:00Z")
+            val repository = FakeOnboardingRepository(initialCompletedStatus = true)
+            val navigator = FakeNavigator(SplashScreen)
+            val presenter =
+                SplashPresenter(
+                    navigator,
+                    repository,
+                    StartupBackupPolicy { StartupBackupDecision.OfferRestore(metadata) },
+                )
+
+            presenter.test {
+                awaitItem().eventSink(SplashScreen.Event.CheckOnboardingStatus)
+
+                assertEquals(
+                    CloudBackupScreen(
+                        entryPoint = CloudBackupScreen.EntryPoint.STARTUP,
+                        fallback = CloudBackupScreen.Fallback.HOME,
+                        backupCount = 2,
+                        backupUpdatedAt = metadata.updatedAt,
+                    ),
+                    navigator.awaitResetRoot().newRoot,
+                )
+            }
+        }
+
     private suspend fun assertDestination(
         isCompleted: Boolean,
         expected: Screen,
     ) {
         val repository = FakeOnboardingRepository(isCompleted)
         val navigator = FakeNavigator(SplashScreen)
-        val presenter = SplashPresenter(navigator, repository)
+        val presenter = SplashPresenter(navigator, repository, continuePolicy())
 
         presenter.test {
             awaitItem().eventSink(SplashScreen.Event.CheckOnboardingStatus)
@@ -73,4 +105,6 @@ class SplashPresenterTest {
             assertEquals(1, repository.getCallCount)
         }
     }
+
+    private fun continuePolicy() = StartupBackupPolicy { StartupBackupDecision.Continue }
 }

--- a/feature/splash/src/commonMain/kotlin/com/nexters/bandalart/feature/splash/presenter/SplashPresenter.kt
+++ b/feature/splash/src/commonMain/kotlin/com/nexters/bandalart/feature/splash/presenter/SplashPresenter.kt
@@ -22,7 +22,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import com.nexters.bandalart.core.domain.backup.StartupBackupDecision
+import com.nexters.bandalart.core.domain.backup.StartupBackupPolicy
 import com.nexters.bandalart.core.domain.repository.OnboardingRepository
+import com.nexters.bandalart.core.navigation.CloudBackupScreen
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.nexters.bandalart.feature.onboarding.OnboardingScreen
 import com.nexters.bandalart.feature.splash.SplashScreen
@@ -39,6 +42,7 @@ import kotlinx.coroutines.launch
 class SplashPresenter(
     @Assisted private val navigator: Navigator,
     private val repository: OnboardingRepository,
+    private val startupBackupPolicy: StartupBackupPolicy,
 ) : Presenter<SplashScreen.State> {
     @Composable
     override fun present(): SplashScreen.State {
@@ -51,11 +55,24 @@ class SplashPresenter(
                     if (!isChecking) {
                         isChecking = true
                         scope.launch {
+                            val onboardingCompleted = repository.getOnboardingCompletedStatus()
                             val destination =
-                                if (repository.getOnboardingCompletedStatus()) {
-                                    HomeScreen
-                                } else {
-                                    OnboardingScreen
+                                when (val decision = startupBackupPolicy.evaluate()) {
+                                    StartupBackupDecision.Continue -> {
+                                        if (onboardingCompleted) HomeScreen else OnboardingScreen
+                                    }
+                                    is StartupBackupDecision.OfferRestore ->
+                                        CloudBackupScreen(
+                                            entryPoint = CloudBackupScreen.EntryPoint.STARTUP,
+                                            fallback =
+                                                if (onboardingCompleted) {
+                                                    CloudBackupScreen.Fallback.HOME
+                                                } else {
+                                                    CloudBackupScreen.Fallback.ONBOARDING
+                                                },
+                                            backupCount = decision.metadata.bandalartCount,
+                                            backupUpdatedAt = decision.metadata.updatedAt,
+                                        )
                                 }
                             navigator.resetRoot(destination)
                         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,8 +5,8 @@ minSdk = "28"
 targetSdk = "36"
 compileSdk = "37"
 majorVersion = "2"
-minorVersion = "3"
-patchVersion = "3"
+minorVersion = "4"
+patchVersion = "0"
 packageName = "com.nexters.bandalart"
 
 # Gradle Plugin
@@ -21,9 +21,13 @@ kotlin-ktlint-source = "0.50.0"
 
 # Kotlinx
 kotlinx-coroutines = "1.10.1"
-kotlinx-datetime = "0.6.1"
+kotlinx-datetime = "0.6.2"
 kotlinx-serialization = "1.8.1"
 kotlinx-collections-immutable = "0.3.8"
+
+# Network
+ktor = "3.4.3"
+supabase = "3.2.0"
 
 # Compose & UI
 compose-multiplatform = "1.10.3"
@@ -118,6 +122,11 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinx-datetime" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinx-collections-immutable" }
+
+# Network
+ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktor" }
+ktor-client-darwin = { group = "io.ktor", name = "ktor-client-darwin", version.ref = "ktor" }
+supabase-postgrest = { group = "io.github.jan-tennert.supabase", name = "postgrest-kt", version.ref = "supabase" }
 
 # Androidx
 androidx-core = { group = "androidx.core", name = "core", version.ref = "androidx-core" }

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -487,7 +487,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.4.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -533,7 +533,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 2.4.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -567,7 +567,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 2.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.bandalart.iosApp.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -598,7 +598,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 2.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.bandalart.iosApp.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -487,7 +487,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 1.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -533,7 +533,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 1.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -567,7 +567,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.bandalart.iosApp.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -598,7 +598,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.4.0;
+				MARKETING_VERSION = 1.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.nexters.bandalart.iosApp.widget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -13,6 +13,7 @@ struct ComposeView: UIViewControllerRepresentable {
     let notificationLaunchBridge: DeadlineNotificationLaunchBridge
     let deadlineReminderLifecycleBridge: DeadlineReminderLifecycleBridge
     let adsBridge: IosAdsBridge
+    let deviceBackupKeyBridge: IosDeviceBackupKeyBridge
     let widgetLaunchBridge: IosWidgetLaunchBridge
     let widgetRuntimeBridge: IosWidgetRuntimeBridge
 
@@ -21,6 +22,7 @@ struct ComposeView: UIViewControllerRepresentable {
             notificationLaunchBridge: notificationLaunchBridge,
             deadlineReminderLifecycleBridge: deadlineReminderLifecycleBridge,
             adsBridge: adsBridge,
+            deviceBackupKeyBridge: deviceBackupKeyBridge,
             widgetLaunchBridge: widgetLaunchBridge,
             widgetRuntimeBridge: widgetRuntimeBridge
         )
@@ -33,6 +35,7 @@ struct ContentView: View {
     let notificationLaunchBridge: DeadlineNotificationLaunchBridge
     let deadlineReminderLifecycleBridge: DeadlineReminderLifecycleBridge
     let adsBridge: IosAdsBridge
+    let deviceBackupKeyBridge: IosDeviceBackupKeyBridge
     let widgetLaunchBridge: IosWidgetLaunchBridge
     let widgetRuntimeBridge: IosWidgetRuntimeBridge
 
@@ -41,6 +44,7 @@ struct ContentView: View {
             notificationLaunchBridge: notificationLaunchBridge,
             deadlineReminderLifecycleBridge: deadlineReminderLifecycleBridge,
             adsBridge: adsBridge,
+            deviceBackupKeyBridge: deviceBackupKeyBridge,
             widgetLaunchBridge: widgetLaunchBridge,
             widgetRuntimeBridge: widgetRuntimeBridge
         )

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -36,7 +36,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.4.0</string>
+    <string>1.3.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CADisableMinimumFrameDurationOnPhone</key>

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -36,7 +36,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.2.0</string>
+    <string>2.4.0</string>
     <key>CFBundleVersion</key>
     <string>1</string>
     <key>CADisableMinimumFrameDurationOnPhone</key>

--- a/iosApp/iosApp/IosDeviceBackupKeyBridgeImpl.swift
+++ b/iosApp/iosApp/IosDeviceBackupKeyBridgeImpl.swift
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ComposeApp
+import CryptoKit
+import Foundation
+import Security
+
+final class IosDeviceBackupKeyBridgeImpl: NSObject, IosDeviceBackupKeyBridge {
+    private let service = "com.nexters.bandalart.cloud-backup"
+    private let account = "device-seed.v1"
+
+    func getDeviceKey() -> String? {
+        guard let seed = loadSeed() ?? createSeed() else { return nil }
+        let namespace = Bundle.main.bundleIdentifier ?? "com.nexters.bandalart.iosApp"
+        let digest = SHA256.hash(data: Data("\(namespace):\(seed)".utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func loadSeed() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        var result: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess,
+              let data = result as? Data else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private func createSeed() -> String? {
+        let seed = UUID().uuidString.lowercased()
+        let attributes: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            kSecValueData as String: Data(seed.utf8),
+        ]
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        if status == errSecSuccess {
+            return seed
+        }
+        if status == errSecDuplicateItem {
+            return loadSeed()
+        }
+        return nil
+    }
+}

--- a/iosApp/iosApp/iosApp.swift
+++ b/iosApp/iosApp/iosApp.swift
@@ -22,6 +22,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     let notificationLaunchBridge = DeadlineNotificationLaunchBridge()
     let deadlineReminderLifecycleBridge = DeadlineReminderLifecycleBridge()
     let adsBridge = IosAdsBridgeImpl()
+    let deviceBackupKeyBridge = IosDeviceBackupKeyBridgeImpl()
     let widgetLaunchBridge = IosWidgetLaunchBridge()
     let widgetRuntimeBridge = IosWidgetRuntimeBridge(
         selectionWriter: IosWidgetSelectionWriterImpl(),
@@ -138,6 +139,7 @@ struct iosApp: App {
                 notificationLaunchBridge: appDelegate.notificationLaunchBridge,
                 deadlineReminderLifecycleBridge: appDelegate.deadlineReminderLifecycleBridge,
                 adsBridge: appDelegate.adsBridge,
+                deviceBackupKeyBridge: appDelegate.deviceBackupKeyBridge,
                 widgetLaunchBridge: appDelegate.widgetLaunchBridge,
                 widgetRuntimeBridge: appDelegate.widgetRuntimeBridge
             )

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,249 @@
+{
+  "name": "bandalart-project-tools",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bandalart-project-tools",
+      "devDependencies": {
+        "supabase": "2.114.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ecies/ciphers": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.6.tgz",
+      "integrity": "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1",
+        "deno": ">=2.7.10",
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@noble/ciphers": "^1.0.0"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@supabase/cli-darwin-arm64": {
+      "version": "2.114.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-arm64/-/cli-darwin-arm64-2.114.0.tgz",
+      "integrity": "sha512-zdZA+hf8W2sMDQkWWJKYcgOS6AAMsc8oMTaspfYrga41paUqSvuXZ4uAhBaNm3DiNeJmQ0ddb9EaLo0lPxaQpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@supabase/cli-darwin-x64": {
+      "version": "2.114.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-darwin-x64/-/cli-darwin-x64-2.114.0.tgz",
+      "integrity": "sha512-r89Go+y0IyBS+8pHsBZcs9s1W7xB8IL60k97INn0EYgPlE99Bgy7aZF+FQd+c1e3RAXLPS4/Znf7fheXKuNCtg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@supabase/cli-linux-arm64": {
+      "version": "2.114.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64/-/cli-linux-arm64-2.114.0.tgz",
+      "integrity": "sha512-vYFAP+gI6BOcwjZ+Zs9kpqtUt3KTE5kL56H65CTCdwRBJ/fXU+vCW3WvhLyFmKmJ8sDzjCvMcHwuhjKPbTmM7A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@supabase/cli-linux-arm64-musl": {
+      "version": "2.114.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.114.0.tgz",
+      "integrity": "sha512-G5/97+h2CXzoK95jNlWY8CyOt+Zm0k3A9/d1r/jDYoB/y1P5cQmK1TYPPfI+ErWYQeoiQ6okfftAAg8bZEGqcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@supabase/cli-linux-x64": {
+      "version": "2.114.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64/-/cli-linux-x64-2.114.0.tgz",
+      "integrity": "sha512-MKgeafQEWYVKCtJgOgGJo1SqiKI4dd5eN460FbLOg01j1sYh7zGqhHk8WxF3enc4WeFQpVMpv147UyrOueHheg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@supabase/cli-linux-x64-musl": {
+      "version": "2.114.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-linux-x64-musl/-/cli-linux-x64-musl-2.114.0.tgz",
+      "integrity": "sha512-87e8MzkKZryXOsmMSbrS4b4jX95uPohS/AplJb2QWwTzLuOXZ+G60e0NR9tkuYYc7TIrDAHhFxcGaQweRIERug==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@supabase/cli-windows-arm64": {
+      "version": "2.114.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-arm64/-/cli-windows-arm64-2.114.0.tgz",
+      "integrity": "sha512-nhF/H5tPs0YsuKcdX5gGV6Ku7pFpSobXubt0y3rHfmR4itG6hhGE2We1hCyc7it0ozlDsA2NxOb1m9YlmY38+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@supabase/cli-windows-x64": {
+      "version": "2.114.0",
+      "resolved": "https://registry.npmjs.org/@supabase/cli-windows-x64/-/cli-windows-x64-2.114.0.tgz",
+      "integrity": "sha512-JtdgR9HvhgUxyd+GMpTECHCSFbAFP67/FJIWybYOVt5Qh6g4rqlLSWmT5zWFCQBSBw0dSw7xf2V3YB1+HESmiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/eciesjs": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.5.0.tgz",
+      "integrity": "sha512-s0J9SEVYAEPg7J63GFMApLYzPH9VNIQIyC6s15JpnqVc0TqcKWdbgFlnAweEBRyMmko2dcs2sfC83Hj4J43tuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ecies/ciphers": "^0.2.6",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.8.0"
+      },
+      "engines": {
+        "bun": ">=1",
+        "deno": ">=2.7.10",
+        "node": ">=16"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/supabase": {
+      "version": "2.114.0",
+      "resolved": "https://registry.npmjs.org/supabase/-/supabase-2.114.0.tgz",
+      "integrity": "sha512-JtCR+eDgVs2YtmZl5THdkaTeXex80lax+3V2SXRSuj280SWJPTIKxMLc82iDKjZlqXnt9zrGnJkrWb7DwHGPhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eciesjs": "^0.5.0",
+        "jose": "^6.2.4"
+      },
+      "bin": {
+        "supabase": "dist/supabase.js"
+      },
+      "optionalDependencies": {
+        "@supabase/cli-darwin-arm64": "2.114.0",
+        "@supabase/cli-darwin-x64": "2.114.0",
+        "@supabase/cli-linux-arm64": "2.114.0",
+        "@supabase/cli-linux-arm64-musl": "2.114.0",
+        "@supabase/cli-linux-x64": "2.114.0",
+        "@supabase/cli-linux-x64-musl": "2.114.0",
+        "@supabase/cli-windows-arm64": "2.114.0",
+        "@supabase/cli-windows-x64": "2.114.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "bandalart-project-tools",
+  "private": true,
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "supabase": "supabase",
+    "supabase:start": "supabase start",
+    "supabase:stop": "supabase stop",
+    "supabase:status": "supabase status",
+    "supabase:reset": "supabase db reset",
+    "supabase:lint": "supabase db lint --local --level error",
+    "supabase:test": "supabase test db supabase/tests/database --local"
+  },
+  "devDependencies": {
+    "supabase": "2.114.0"
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -49,6 +49,7 @@ include(":core:navigation")
 include(":core:ui")
 
 include(":feature:complete")
+include(":feature:backup")
 include(":feature:home")
 include(":feature:onboarding")
 include(":feature:splash")

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,414 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "Bandalart"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. When unset, new entities are NOT auto-exposed, matching the new cloud
+# default. Set to `true` to keep the legacy behaviour of auto-exposing new entities; this is
+# deprecated and the field is removed on 2026-10-30 once the always-revoked behaviour is permanent.
+# auto_expose_new_tables = true
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files, directories, or glob patterns that describe your database.
+# Supports paths relative to supabase directory: "./schemas/*.sql", "./database".
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[local_smtp]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# pg-delta is the schema diff engine for db diff / db pull / db remote commit.
+# Set enabled = false to fall back to the legacy migra engine.
+[experimental.pgdelta]
+enabled = true
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260818065303_create_device_backups.sql
+++ b/supabase/migrations/20260818065303_create_device_backups.sql
@@ -1,0 +1,145 @@
+create table public.device_backups (
+    device_key text primary key,
+    schema_version integer not null,
+    payload jsonb not null,
+    bandalart_count integer not null,
+    updated_at timestamp with time zone not null default now(),
+    constraint device_backups_device_key_format
+        check (device_key ~ '^[0-9a-f]{64}$'),
+    constraint device_backups_schema_version_range
+        check (schema_version between 1 and 1000),
+    constraint device_backups_payload_object
+        check (jsonb_typeof(payload) = 'object'),
+    constraint device_backups_payload_size
+        check (octet_length(payload::text) <= 1048576),
+    constraint device_backups_bandalart_count_range
+        check (bandalart_count between 0 and 10000)
+);
+
+comment on table public.device_backups is
+    'Latest manual BandalArt backup for a SHA-256 device key.';
+comment on column public.device_backups.device_key is
+    'Lowercase SHA-256 hex derived from the app namespace and Android SSAID.';
+comment on column public.device_backups.payload is
+    'Versioned Room and DataStore backup envelope. Limited to 1 MiB.';
+
+alter table public.device_backups enable row level security;
+
+revoke all on table public.device_backups from public, anon, authenticated;
+grant all on table public.device_backups to service_role;
+
+create or replace function public.get_device_backup(p_device_key text)
+returns table (
+    schema_version integer,
+    payload jsonb,
+    bandalart_count integer,
+    updated_at timestamp with time zone
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+    select
+        backups.schema_version,
+        backups.payload,
+        backups.bandalart_count,
+        backups.updated_at
+    from public.device_backups as backups
+    where p_device_key ~ '^[0-9a-f]{64}$'
+      and backups.device_key = p_device_key;
+$$;
+
+create or replace function public.put_device_backup(
+    p_device_key text,
+    p_schema_version integer,
+    p_payload jsonb,
+    p_bandalart_count integer
+)
+returns table (
+    schema_version integer,
+    bandalart_count integer,
+    updated_at timestamp with time zone
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+    if p_device_key is null or p_device_key !~ '^[0-9a-f]{64}$' then
+        raise exception 'invalid device key' using errcode = '22023';
+    end if;
+
+    if p_schema_version is null or p_schema_version not between 1 and 1000 then
+        raise exception 'invalid schema version' using errcode = '22023';
+    end if;
+
+    if p_payload is null
+        or jsonb_typeof(p_payload) <> 'object'
+        or octet_length(p_payload::text) > 1048576
+    then
+        raise exception 'invalid backup payload' using errcode = '22023';
+    end if;
+
+    if p_bandalart_count is null or p_bandalart_count not between 0 and 10000 then
+        raise exception 'invalid bandalart count' using errcode = '22023';
+    end if;
+
+    insert into public.device_backups as backups (
+        device_key,
+        schema_version,
+        payload,
+        bandalart_count,
+        updated_at
+    )
+    values (
+        p_device_key,
+        p_schema_version,
+        p_payload,
+        p_bandalart_count,
+        now()
+    )
+    on conflict (device_key) do update
+    set schema_version = excluded.schema_version,
+        payload = excluded.payload,
+        bandalart_count = excluded.bandalart_count,
+        updated_at = excluded.updated_at;
+
+    return query
+    select
+        backups.schema_version,
+        backups.bandalart_count,
+        backups.updated_at
+    from public.device_backups as backups
+    where backups.device_key = p_device_key;
+end;
+$$;
+
+create or replace function public.delete_device_backup(p_device_key text)
+returns boolean
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+    affected_rows integer;
+begin
+    if p_device_key is null or p_device_key !~ '^[0-9a-f]{64}$' then
+        raise exception 'invalid device key' using errcode = '22023';
+    end if;
+
+    delete from public.device_backups as backups
+    where backups.device_key = p_device_key;
+
+    get diagnostics affected_rows = row_count;
+    return affected_rows = 1;
+end;
+$$;
+
+revoke all on function public.get_device_backup(text) from public;
+revoke all on function public.put_device_backup(text, integer, jsonb, integer) from public;
+revoke all on function public.delete_device_backup(text) from public;
+
+grant execute on function public.get_device_backup(text) to anon, authenticated, service_role;
+grant execute on function public.put_device_backup(text, integer, jsonb, integer) to anon, authenticated, service_role;
+grant execute on function public.delete_device_backup(text) to anon, authenticated, service_role;

--- a/supabase/migrations/20260818110000_document_ios_device_backup_key.sql
+++ b/supabase/migrations/20260818110000_document_ios_device_backup_key.sql
@@ -1,0 +1,2 @@
+comment on column public.device_backups.device_key is
+    'Lowercase SHA-256 hex derived from the app namespace and an Android SSAID or iOS Keychain seed.';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,1 @@
+-- Intentionally empty. Backup tests create and roll back their own fixtures.

--- a/supabase/tests/database/device_backups.test.sql
+++ b/supabase/tests/database/device_backups.test.sql
@@ -1,0 +1,126 @@
+begin;
+
+create extension if not exists pgtap with schema extensions;
+
+select plan(17);
+
+select has_table('public', 'device_backups', 'device_backups table exists');
+select has_function(
+    'public',
+    'get_device_backup',
+    array['text'],
+    'get_device_backup RPC exists'
+);
+select has_function(
+    'public',
+    'put_device_backup',
+    array['text', 'integer', 'jsonb', 'integer'],
+    'put_device_backup RPC exists'
+);
+select has_function(
+    'public',
+    'delete_device_backup',
+    array['text'],
+    'delete_device_backup RPC exists'
+);
+
+select ok(
+    not has_table_privilege('anon', 'public.device_backups', 'select'),
+    'anon cannot select the backup table directly'
+);
+select ok(
+    not has_table_privilege('anon', 'public.device_backups', 'insert'),
+    'anon cannot insert into the backup table directly'
+);
+select ok(
+    has_function_privilege('anon', 'public.get_device_backup(text)', 'execute'),
+    'anon can execute get_device_backup'
+);
+select ok(
+    has_function_privilege(
+        'anon',
+        'public.put_device_backup(text,integer,jsonb,integer)',
+        'execute'
+    ),
+    'anon can execute put_device_backup'
+);
+select ok(
+    has_function_privilege('anon', 'public.delete_device_backup(text)', 'execute'),
+    'anon can execute delete_device_backup'
+);
+
+select lives_ok(
+    $$
+        select *
+        from public.put_device_backup(
+            repeat('a', 64),
+            1,
+            '{"bandalarts": []}'::jsonb,
+            0
+        )
+    $$,
+    'a valid backup can be stored'
+);
+
+select results_eq(
+    $$
+        select schema_version, bandalart_count
+        from public.get_device_backup(repeat('a', 64))
+    $$,
+    $$ values (1, 0) $$,
+    'the stored backup metadata can be read'
+);
+
+select is(
+    (
+        select payload
+        from public.get_device_backup(repeat('a', 64))
+    ),
+    '{"bandalarts": []}'::jsonb,
+    'the stored backup payload can be read'
+);
+
+select lives_ok(
+    $$
+        select *
+        from public.put_device_backup(
+            repeat('a', 64),
+            2,
+            '{"bandalarts": [{"id": 1}]}'::jsonb,
+            1
+        )
+    $$,
+    'an existing backup can be replaced'
+);
+
+select results_eq(
+    $$
+        select schema_version, bandalart_count
+        from public.get_device_backup(repeat('a', 64))
+    $$,
+    $$ values (2, 1) $$,
+    'replacement metadata is returned'
+);
+
+select throws_like(
+    $$
+        select *
+        from public.put_device_backup('raw-ssaid', 1, '{}'::jsonb, 0)
+    $$,
+    '%invalid device key%',
+    'raw or malformed device keys are rejected'
+);
+
+select is(
+    public.delete_device_backup(repeat('a', 64)),
+    true,
+    'an existing backup can be deleted'
+);
+select is(
+    public.delete_device_backup(repeat('a', 64)),
+    false,
+    'deleting an absent backup is idempotent'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #86

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- Supabase 기반 수동 백업과 `백업에서 복원` 전용 화면을 추가했습니다.
- 앱 시작 시 원격 백업을 조회하고 로컬 데이터가 비어 있을 때 복원을 제안합니다.
- Android는 namespace와 SSAID, iOS는 Keychain seed에서 SHA-256 기기 키를 생성합니다.
- Room·DataStore 스냅샷 복원과 마감 알림 재구성을 지원합니다.
- Android와 iOS 앱 버전을 2.4.0으로 업데이트했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- 백업 repository, Room, DataStore, 시작 정책, Presenter Android Host 테스트 통과
- Android debug 및 iOS Simulator Arm64 KMP 컴파일 통과
- ComposeApp iOS framework 링크와 Keychain Swift bridge 타입 검사 통과
- 관련 Spotless·Detekt 및 Supabase 원격 schema lint 통과

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

| 기능 | 미리보기 | 기능 | 미리보기 |
|:---:|:---:|:---:|:---:|
| 클라우드 백업 | 미첨부 | 백업에서 복원 | 미첨부 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- 저민감도 MVP로 Supabase RPC와 플랫폼별 기기 키를 사용합니다.
- iOS Keychain seed는 `ThisDeviceOnly`로 저장해 새 기기 이전은 지원하지 않습니다.
- 실제 Android/iOS 삭제·재설치 흐름은 기기에서 추가 확인이 필요합니다.
