### PR TITLE
fix: Supabase 배포 URL 형식 검증

### DIFF
--- a/.github/workflows/release-cd.yml
+++ b/.github/workflows/release-cd.yml
@@ -161,6 +161,10 @@ jobs:
                 run: |
                     : "${BANDALART_SUPABASE_URL:?BANDALART_SUPABASE_URL is required}"
                     : "${BANDALART_SUPABASE_PUBLISHABLE_KEY:?BANDALART_SUPABASE_PUBLISHABLE_KEY is required}"
+                    case "$BANDALART_SUPABASE_URL" in
+                        https://*) ;;
+                        *) echo "BANDALART_SUPABASE_URL must start with https://" >&2; exit 1 ;;
+                    esac
                     bundle exec fastlane android internal
 
             -   name: Remove Android credentials
@@ -249,6 +253,10 @@ jobs:
                 run: |
                     : "${BANDALART_SUPABASE_URL:?BANDALART_SUPABASE_URL is required}"
                     : "${BANDALART_SUPABASE_PUBLISHABLE_KEY:?BANDALART_SUPABASE_PUBLISHABLE_KEY is required}"
+                    case "$BANDALART_SUPABASE_URL" in
+                        https://*) ;;
+                        *) echo "BANDALART_SUPABASE_URL must start with https://" >&2; exit 1 ;;
+                    esac
                     bundle exec fastlane ios beta
 
             -   name: Remove iOS credentials

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ targetSdk = "36"
 compileSdk = "37"
 majorVersion = "2"
 minorVersion = "4"
-patchVersion = "0"
+patchVersion = "1"
 packageName = "com.nexters.bandalart"
 
 # Gradle Plugin


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #86

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- Release CD가 Supabase URL의 `https://` 형식을 Android와 iOS 빌드 전에 검증하도록 보강했습니다.
- 잘못 등록된 GitHub Actions Supabase URL secret을 정상 HTTPS URL로 갱신했습니다.
- Play Store 재배포를 위해 Android 버전을 `2.4.1 (20401)`로 올렸습니다.

## 🧪 테스트 내역 (선택)

- [ ] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- actionlint로 Android CI와 Release CD workflow 검증 통과
- 잘못된 `https\://` URL 거부와 정상 `https://` URL 허용 확인
- Play release Python 테스트 10개 통과
- provisioning profile, iOS signing, TestFlight 광고 모드, Android update priority Ruby 계약 테스트 통과

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

| 기능 | 미리보기 | 기능 | 미리보기 |
|:---:|:---:|:---:|:---:|
| UI 변경 없음 | 미첨부 | UI 변경 없음 | 미첨부 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- iOS marketing version은 `1.3.0`을 유지하며 재배포 시 TestFlight build number만 자동 증가합니다.
- 병합 후 Android Internal과 iOS TestFlight를 같은 Release CD에서 재배포합니다.
