### PR TITLE
fix: 백업 복원 다이얼로그 UI 통일

### DIFF
--- a/core/designsystem/src/commonMain/composeResources/drawable/ic_settings_backup_restore.xml
+++ b/core/designsystem/src/commonMain/composeResources/drawable/ic_settings_backup_restore.xml
@@ -1,0 +1,16 @@
+<!--
+  Adapted from the Google Material Symbol "settings_backup_restore" 48px Outlined SVG
+  to Android/Compose vector XML.
+  Copyright Google LLC. Licensed under the Apache License 2.0.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <group android:translateY="960">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M479.96,-405Q449,-405 427,-427.04q-22,-22.05 -22,-53Q405,-511 427.04,-533q22.05,-22 53,-22Q511,-555 533,-532.96q22,22.05 22,53Q555,-449 532.96,-427q-22.05,22 -53,22Zm0.04,285q-150,0 -255,-105.5T120,-481h60q0,125 87.5,213T480,-180q125.36,0 212.68,-87.32Q780,-354.64 780,-480q0,-125.36 -87.32,-212.68Q605.36,-780 480,-780q-69,0 -129,30.5T246,-667h104v60H142v-208h60v106q53,-62 125.22,-96.5Q399.43,-840 480,-840q75,0 140.5,28.5t114,77q48.5,48.5 77,114T840,-480q0,75 -28.5,140.5t-77,114q-48.5,48.5 -114,77T480,-120Z" />
+  </group>
+</vector>

--- a/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/CloudBackupScreenUi.kt
+++ b/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/CloudBackupScreenUi.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -62,7 +61,9 @@ import bandalart.core.designsystem.generated.resources.backup_start_fresh
 import bandalart.core.designsystem.generated.resources.backup_status_existing
 import bandalart.core.designsystem.generated.resources.backup_status_none
 import bandalart.core.designsystem.generated.resources.backup_title
+import bandalart.core.designsystem.generated.resources.ic_settings_backup_restore
 import com.nexters.bandalart.core.navigation.CloudBackupScreen
+import com.nexters.bandalart.feature.home.ui.bandalart.BandalartActionAlertDialog
 import com.slack.circuit.codegen.annotations.CircuitInject
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
@@ -205,20 +206,15 @@ private fun BackupHeader(
 
 @Composable
 private fun RestoreConfirmationDialog(eventSink: (CloudBackupUiState.Event) -> Unit) {
-    AlertDialog(
-        onDismissRequest = { eventSink(CloudBackupUiState.Event.DismissRestoreConfirmation) },
-        title = { Text(stringResource(Res.string.backup_restore_confirm_title)) },
-        text = { Text(stringResource(Res.string.backup_restore_confirm_body)) },
-        confirmButton = {
-            TextButton(onClick = { eventSink(CloudBackupUiState.Event.ConfirmRestore) }) {
-                Text(stringResource(Res.string.backup_restore_confirm))
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = { eventSink(CloudBackupUiState.Event.DismissRestoreConfirmation) }) {
-                Text(stringResource(Res.string.backup_restore_cancel))
-            }
-        },
+    BandalartActionAlertDialog(
+        icon = Res.drawable.ic_settings_backup_restore,
+        iconContentDescription = stringResource(Res.string.backup_restore),
+        title = stringResource(Res.string.backup_restore_confirm_title),
+        message = stringResource(Res.string.backup_restore_confirm_body),
+        confirmLabel = stringResource(Res.string.backup_restore_confirm),
+        cancelLabel = stringResource(Res.string.backup_restore_cancel),
+        onConfirmClick = { eventSink(CloudBackupUiState.Event.ConfirmRestore) },
+        onCancelClick = { eventSink(CloudBackupUiState.Event.DismissRestoreConfirmation) },
     )
 }
 

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartActionAlertDialog.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartActionAlertDialog.kt
@@ -44,7 +44,7 @@ import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.vectorResource
 
 @Composable
-internal fun BandalartActionAlertDialog(
+fun BandalartActionAlertDialog(
     icon: DrawableResource,
     iconContentDescription: String?,
     title: String,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ targetSdk = "36"
 compileSdk = "37"
 majorVersion = "2"
 minorVersion = "4"
-patchVersion = "1"
+patchVersion = "2"
 packageName = "com.nexters.bandalart"
 
 # Gradle Plugin


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #339

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 백업 복원 확인 팝업을 기존 `BandalartActionAlertDialog` 스타일로 통일했습니다.
- Material Symbol `settings_backup_restore` SVG 경로를 Compose 벡터 리소스로 추가했습니다.
- Android 배포 버전을 `2.4.2 (20402)`로 올렸습니다.

## 🧪 테스트 내역 (선택)

- [x] 관련 모듈 Spotless/Detekt 통과
- [x] `:feature:backup:testAndroidHostTest` 통과
- [ ] 브라우저/기기에서 동작 확인
- [x] Play API에서 `20402`가 다음 사용 가능한 versionCode임을 확인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 복원 확인 팝업 | 내부 테스트 배포 후 확인 | Material 아이콘 | `settings_backup_restore` 벡터 적용 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 전체 Spotless는 기존 `ObserveEvent.kt`, `CellText.kt` 포맷 위반 때문에 로컬에서 완료되지 않아 변경 모듈 검사를 분리했습니다. CI의 ratchet 검증으로 변경 파일 범위를 재확인합니다.