### PR TITLE
test: 마감일 테스트 알림 전송 지원

### DIFF
--- a/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/notification/AndroidDeadlineReminderSchedulerTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/notification/AndroidDeadlineReminderSchedulerTest.kt
@@ -17,6 +17,7 @@
 package com.nexters.bandalart.notification
 
 import android.app.Application
+import android.app.NotificationManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.work.Configuration
 import androidx.work.WorkInfo
@@ -32,6 +33,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -85,5 +87,43 @@ class AndroidDeadlineReminderSchedulerTest {
 
             val afterClear = workManager.getWorkInfosByTagFlow(DeadlineReminderWork.FEATURE_TAG).first()
             assertTrue(afterClear.all { info -> info.state == WorkInfo.State.CANCELLED })
+        }
+
+    @Test
+    fun testNotificationPostsWithoutReplacingScheduledDeadlineWork() =
+        runTest {
+            val dueDate =
+                Clock.System
+                    .now()
+                    .plus(2, DateTimeUnit.DAY, TimeZone.currentSystemDefault())
+                    .toLocalDateTime(TimeZone.currentSystemDefault())
+                    .date
+            val batch = DeadlineReminderBatch(bandalartId = 3, dueDate = dueDate, items = emptyList())
+            scheduler.replaceAll(listOf(batch))
+
+            val result = scheduler.postTestNotification()
+
+            assertEquals(1, result.scheduledCount)
+            assertEquals(null, result.lastErrorCategory)
+            val activeWork =
+                workManager
+                    .getWorkInfosByTagFlow(DeadlineReminderWork.FEATURE_TAG)
+                    .first()
+                    .filterNot { info -> info.state == WorkInfo.State.CANCELLED }
+            assertEquals(1, activeWork.size)
+            val notificationManager = application.getSystemService(NotificationManager::class.java)
+            assertTrue(
+                notificationManager.activeNotifications.any { notification ->
+                    notification.tag == DeadlineReminderWork.TEST_NOTIFICATION_TAG
+                },
+            )
+
+            scheduler.clearAll()
+
+            assertFalse(
+                notificationManager.activeNotifications.any { notification ->
+                    notification.tag == DeadlineReminderWork.TEST_NOTIFICATION_TAG
+                },
+            )
         }
 }

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/notification/AndroidDeadlineReminderScheduler.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/notification/AndroidDeadlineReminderScheduler.kt
@@ -17,7 +17,9 @@
 package com.nexters.bandalart.notification
 
 import android.app.Application
+import android.app.NotificationChannel
 import android.app.NotificationManager
+import androidx.core.app.NotificationCompat
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
@@ -27,6 +29,7 @@ import com.nexters.bandalart.core.domain.notification.DeadlineReminderBatch
 import com.nexters.bandalart.core.domain.notification.DeadlineReminderScheduler
 import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingErrorCategory
 import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingResult
+import com.nexters.bandalart.shared.R
 import kotlinx.coroutines.CancellationException
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDateTime
@@ -99,9 +102,48 @@ class AndroidDeadlineReminderScheduler(
             )
         }
 
+    override suspend fun postTestNotification(): DeadlineReminderSchedulingResult =
+        try {
+            val notificationManager = application.getSystemService(NotificationManager::class.java)
+            notificationManager.createNotificationChannel(
+                NotificationChannel(
+                    DeadlineReminderWork.CHANNEL_ID,
+                    application.getString(R.string.deadline_reminder_channel_name),
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                ).apply {
+                    description = application.getString(R.string.deadline_reminder_channel_description)
+                },
+            )
+            val notification =
+                NotificationCompat
+                    .Builder(application, DeadlineReminderWork.CHANNEL_ID)
+                    .setSmallIcon(android.R.drawable.ic_dialog_info)
+                    .setContentTitle(application.getString(R.string.deadline_reminder_test_title))
+                    .setContentText(application.getString(R.string.deadline_reminder_test_body))
+                    .setAutoCancel(true)
+                    .build()
+            notificationManager.notify(
+                DeadlineReminderWork.TEST_NOTIFICATION_TAG,
+                DeadlineReminderWork.NOTIFICATION_ID,
+                notification,
+            )
+            DeadlineReminderSchedulingResult(scheduledCount = 1)
+        } catch (exception: CancellationException) {
+            throw exception
+        } catch (_: Exception) {
+            DeadlineReminderSchedulingResult(
+                scheduledCount = 0,
+                lastErrorCategory = DeadlineReminderSchedulingErrorCategory.SCHEDULING,
+            )
+        }
+
     private suspend fun clearFeatureState() {
         workManager.cancelAllWorkByTag(DeadlineReminderWork.FEATURE_TAG).await()
         val notificationManager = application.getSystemService(NotificationManager::class.java)
+        notificationManager.cancel(
+            DeadlineReminderWork.TEST_NOTIFICATION_TAG,
+            DeadlineReminderWork.NOTIFICATION_ID,
+        )
         notificationManager.activeNotifications
             .asSequence()
             .mapNotNull { notification -> notification.tag }
@@ -118,6 +160,7 @@ internal object DeadlineReminderWork {
     const val KEY_DUE_DATE = "due_date"
     const val NOTIFICATION_ID = 0
     const val CHANNEL_ID = "deadline_reminder"
+    const val TEST_NOTIFICATION_TAG = "deadline.v1.test"
 
     fun uniqueWorkName(batchId: String): String = "deadline.v1.work.$batchId"
 

--- a/composeApp/src/androidMain/res/values-ja/strings.xml
+++ b/composeApp/src/androidMain/res/values-ja/strings.xml
@@ -5,4 +5,6 @@
     <string name="deadline_reminder_title">今日が締め切りの目標があります</string>
     <string name="deadline_reminder_single_body">%1$sを完了する時間です。</string>
     <string name="deadline_reminder_multiple_body">%1$d個の目標が今日締切です。</string>
+    <string name="deadline_reminder_test_title">締切日リマインダーのテスト</string>
+    <string name="deadline_reminder_test_body">この通知が表示されれば、通知は正しく設定されています。</string>
 </resources>

--- a/composeApp/src/androidMain/res/values-ko/strings.xml
+++ b/composeApp/src/androidMain/res/values-ko/strings.xml
@@ -5,4 +5,6 @@
     <string name="deadline_reminder_title">오늘 마감인 목표가 있어요</string>
     <string name="deadline_reminder_single_body">%1$s을(를) 완료할 시간이에요.</string>
     <string name="deadline_reminder_multiple_body">%1$d개의 목표가 오늘 마감이에요.</string>
+    <string name="deadline_reminder_test_title">마감일 알림 테스트</string>
+    <string name="deadline_reminder_test_body">이 알림이 보이면 알림 설정이 정상이에요.</string>
 </resources>

--- a/composeApp/src/androidMain/res/values/strings.xml
+++ b/composeApp/src/androidMain/res/values/strings.xml
@@ -5,4 +5,6 @@
     <string name="deadline_reminder_title">You have goals due today</string>
     <string name="deadline_reminder_single_body">Time to complete %1$s.</string>
     <string name="deadline_reminder_multiple_body">%1$d goals are due today.</string>
+    <string name="deadline_reminder_test_title">Deadline reminder test</string>
+    <string name="deadline_reminder_test_body">If you can see this, notifications are set up correctly.</string>
 </resources>

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/notification/IosDeadlineReminderScheduler.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/notification/IosDeadlineReminderScheduler.kt
@@ -38,6 +38,7 @@ import platform.UserNotifications.UNMutableNotificationContent
 import platform.UserNotifications.UNNotification
 import platform.UserNotifications.UNNotificationRequest
 import platform.UserNotifications.UNNotificationSound
+import platform.UserNotifications.UNTimeIntervalNotificationTrigger
 import platform.UserNotifications.UNUserNotificationCenter
 
 class IosDeadlineReminderScheduler(
@@ -68,6 +69,26 @@ class IosDeadlineReminderScheduler(
     override suspend fun clearAll(): DeadlineReminderSchedulingResult {
         clearFeatureNotifications()
         return DeadlineReminderSchedulingResult(scheduledCount = 0)
+    }
+
+    override suspend fun postTestNotification(): DeadlineReminderSchedulingResult {
+        val content =
+            UNMutableNotificationContent().apply {
+                setTitle(localized(DEADLINE_REMINDER_TEST_TITLE_KEY))
+                setBody(localized(DEADLINE_REMINDER_TEST_BODY_KEY))
+                setSound(UNNotificationSound.defaultSound)
+            }
+        val trigger = UNTimeIntervalNotificationTrigger.triggerWithTimeInterval(1.0, repeats = false)
+        val request = UNNotificationRequest.requestWithIdentifier(DEADLINE_REMINDER_TEST_IDENTIFIER, content, trigger)
+        val error = notificationCenter.add(request)
+        return if (error == null) {
+            DeadlineReminderSchedulingResult(scheduledCount = 1)
+        } else {
+            DeadlineReminderSchedulingResult(
+                scheduledCount = 0,
+                lastErrorCategory = error.toSchedulingErrorCategory(),
+            )
+        }
     }
 
     private suspend fun clearFeatureNotifications() {
@@ -162,3 +183,6 @@ private const val DEADLINE_REMINDER_HOUR = 9L
 private const val DEADLINE_REMINDER_TITLE_KEY = "deadline_reminder_title"
 private const val DEADLINE_REMINDER_SINGLE_BODY_KEY = "deadline_reminder_single_body"
 private const val DEADLINE_REMINDER_MULTIPLE_BODY_KEY = "deadline_reminder_multiple_body"
+private const val DEADLINE_REMINDER_TEST_IDENTIFIER = "deadline.v1.test"
+private const val DEADLINE_REMINDER_TEST_TITLE_KEY = "deadline_reminder_test_title"
+private const val DEADLINE_REMINDER_TEST_BODY_KEY = "deadline_reminder_test_body"

--- a/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
@@ -207,6 +207,9 @@
     <string name="settings_deadline_reminder_dialog_body">Goal titles may appear on your lock screen. Reminders are delivered from 9 AM on the due date depending on device conditions.</string>
     <string name="settings_deadline_reminder_confirm">Turn on</string>
     <string name="settings_deadline_reminder_cancel">Cancel</string>
+    <string name="settings_deadline_reminder_test_sent">Test notification sent.</string>
+    <string name="settings_deadline_reminder_test_failed">Couldn’t send a test notification. Check system notification settings.</string>
+    <string name="settings_deadline_reminder_test">Send test notification</string>
 
     <!-- template catalog -->
     <string name="bandalart_create_title">Create a Bandalart</string>

--- a/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
@@ -208,6 +208,9 @@
     <string name="settings_deadline_reminder_dialog_body">目標のタイトルがロック画面に表示される場合があります。締切日当日の午前9時以降、端末の状態に応じて通知されます。</string>
     <string name="settings_deadline_reminder_confirm">オンにする</string>
     <string name="settings_deadline_reminder_cancel">キャンセル</string>
+    <string name="settings_deadline_reminder_test_sent">テスト通知を送信しました。</string>
+    <string name="settings_deadline_reminder_test_failed">テスト通知を送信できませんでした。システムの通知設定を確認してください。</string>
+    <string name="settings_deadline_reminder_test">テスト通知を送信</string>
 
     <!-- template catalog -->
     <string name="bandalart_create_title">新しいバンダラート</string>

--- a/core/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -209,6 +209,9 @@
     <string name="settings_deadline_reminder_dialog_body">목표 제목이 잠금 화면에 보일 수 있으며, 마감일 당일 오전 9시부터 기기 상태에 따라 알림이 전달돼요.</string>
     <string name="settings_deadline_reminder_confirm">알림 켜기</string>
     <string name="settings_deadline_reminder_cancel">취소</string>
+    <string name="settings_deadline_reminder_test_sent">테스트 알림을 보냈어요.</string>
+    <string name="settings_deadline_reminder_test_failed">테스트 알림을 보내지 못했어요. 시스템 알림 설정을 확인해 주세요.</string>
+    <string name="settings_deadline_reminder_test">테스트 알림 보내기</string>
 
     <!-- template catalog -->
     <string name="bandalart_create_title">새 반다라트 만들기</string>

--- a/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/notification/DeadlineReminderContracts.kt
+++ b/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/notification/DeadlineReminderContracts.kt
@@ -24,6 +24,12 @@ interface DeadlineReminderScheduler {
     suspend fun replaceAll(batches: List<DeadlineReminderBatch>): DeadlineReminderSchedulingResult
 
     suspend fun clearAll(): DeadlineReminderSchedulingResult
+
+    suspend fun postTestNotification(): DeadlineReminderSchedulingResult =
+        DeadlineReminderSchedulingResult(
+            scheduledCount = 0,
+            lastErrorCategory = DeadlineReminderSchedulingErrorCategory.UNSUPPORTED,
+        )
 }
 
 object NoOpDeadlineReminderScheduler : DeadlineReminderScheduler {

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterDeadlineReminderTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterDeadlineReminderTest.kt
@@ -22,7 +22,11 @@ import com.nexters.bandalart.core.domain.notification.BufferedDeadlineNotificati
 import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorization
 import com.nexters.bandalart.core.domain.notification.DeadlineNotificationAuthorizationStatus
 import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderScheduler
 import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingHealth
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingErrorCategory
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderSchedulingResult
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderBatch
 import com.nexters.bandalart.feature.home.HomeScreen
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
@@ -462,12 +466,59 @@ class HomePresenterDeadlineReminderTest {
             }
         }
 
+    @Test
+    fun sendingTestNotificationDelegatesToSchedulerAndReportsSuccess() =
+        runTest {
+            val scheduler = RecordingScheduler()
+            val presenter = presenter(repository = repository(), scheduler = scheduler)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData == null || state.isLoading) state = awaitItem()
+
+                state.eventSink(HomeScreen.Event.SendDeadlineReminderTestNotification)
+                while (state.effect != HomeScreen.Effect.ShowDeadlineReminderTestSentSnackbar) {
+                    state = awaitItem()
+                }
+
+                assertEquals(1, scheduler.testNotificationCalls)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun failedTestNotificationReportsFailure() =
+        runTest {
+            val scheduler =
+                RecordingScheduler(
+                    DeadlineReminderSchedulingResult(
+                        scheduledCount = 0,
+                        lastErrorCategory = DeadlineReminderSchedulingErrorCategory.SCHEDULING,
+                    ),
+                )
+            val presenter = presenter(repository = repository(), scheduler = scheduler)
+
+            presenter.test {
+                var state = awaitItem()
+                while (state.bandalartData == null || state.isLoading) state = awaitItem()
+
+                state.eventSink(HomeScreen.Event.SendDeadlineReminderTestNotification)
+                while (state.effect != HomeScreen.Effect.ShowDeadlineReminderTestFailedSnackbar) {
+                    state = awaitItem()
+                }
+
+                assertEquals(1, scheduler.testNotificationCalls)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     private fun presenter(
         repository: FakeBandalartRepository,
         settings: FakeSettingsRepository = FakeSettingsRepository(),
         authorization: DeadlineNotificationAuthorization =
             FakeAuthorization(DeadlineNotificationAuthorizationStatus.REQUESTABLE),
         reconciler: DeadlineReminderReconciler = RecordingReconciler(),
+        scheduler: DeadlineReminderScheduler = RecordingScheduler(),
         launchTarget: BufferedDeadlineNotificationLaunchTarget = BufferedDeadlineNotificationLaunchTarget(),
     ) = HomePresenter(
         navigator = FakeNavigator(HomeScreen),
@@ -477,6 +528,7 @@ class HomePresenterDeadlineReminderTest {
         settingsRepository = settings,
         deadlineNotificationAuthorization = authorization,
         deadlineReminderReconciler = reconciler,
+        deadlineReminderScheduler = scheduler,
         deadlineNotificationLaunchTarget = launchTarget,
     )
 
@@ -535,6 +587,22 @@ class HomePresenterDeadlineReminderTest {
 
         override suspend fun reconcileAll() {
             reconcileCalls += 1
+        }
+    }
+
+    private class RecordingScheduler(
+        private val testResult: DeadlineReminderSchedulingResult = DeadlineReminderSchedulingResult(scheduledCount = 1),
+    ) : DeadlineReminderScheduler {
+        var testNotificationCalls = 0
+
+        override suspend fun replaceAll(batches: List<DeadlineReminderBatch>) =
+            DeadlineReminderSchedulingResult(scheduledCount = batches.size)
+
+        override suspend fun clearAll() = DeadlineReminderSchedulingResult(scheduledCount = 0)
+
+        override suspend fun postTestNotification(): DeadlineReminderSchedulingResult {
+            testNotificationCalls += 1
+            return testResult
         }
     }
 }

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterDeadlineReminderTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterDeadlineReminderTest.kt
@@ -595,8 +595,7 @@ class HomePresenterDeadlineReminderTest {
     ) : DeadlineReminderScheduler {
         var testNotificationCalls = 0
 
-        override suspend fun replaceAll(batches: List<DeadlineReminderBatch>) =
-            DeadlineReminderSchedulingResult(scheduledCount = batches.size)
+        override suspend fun replaceAll(batches: List<DeadlineReminderBatch>) = DeadlineReminderSchedulingResult(scheduledCount = batches.size)
 
         override suspend fun clearAll() = DeadlineReminderSchedulingResult(scheduledCount = 0)
 

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
@@ -104,6 +104,10 @@ data object HomeScreen : ParcelableScreen, StaticScreen {
 
         data object ShowSlotErrorSnackbar : Effect
 
+        data object ShowDeadlineReminderTestSentSnackbar : Effect
+
+        data object ShowDeadlineReminderTestFailedSnackbar : Effect
+
         data object ShowMainGoalToast : Effect
 
         data object OpenSupportMail : Effect
@@ -240,6 +244,8 @@ data object HomeScreen : ParcelableScreen, StaticScreen {
         data object DeadlineReminderPermissionResult : Event
 
         data object DeadlineReminderForegrounded : Event
+
+        data object SendDeadlineReminderTestNotification : Event
 
         data object ContactSupport : Event
 

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
@@ -51,6 +51,8 @@ import bandalart.core.designsystem.generated.resources.save_bandalart_image
 import bandalart.core.designsystem.generated.resources.settings_contact_body
 import bandalart.core.designsystem.generated.resources.settings_contact_fallback
 import bandalart.core.designsystem.generated.resources.settings_contact_subject
+import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_test_sent
+import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_test_failed
 import com.nexters.bandalart.core.common.AppVersionProvider
 import com.nexters.bandalart.core.common.BannerAdHost
 import com.nexters.bandalart.core.common.ImageHandlerProvider
@@ -208,6 +210,14 @@ private fun HandleHomeEffects(
 
             HomeScreen.Effect.ShowSlotErrorSnackbar -> {
                 showSnackbarForDuration(getString(Res.string.rewarded_slot_error), showSnackbar)
+            }
+
+            HomeScreen.Effect.ShowDeadlineReminderTestSentSnackbar -> {
+                showSnackbarForDuration(getString(Res.string.settings_deadline_reminder_test_sent), showSnackbar)
+            }
+
+            HomeScreen.Effect.ShowDeadlineReminderTestFailedSnackbar -> {
+                showSnackbarForDuration(getString(Res.string.settings_deadline_reminder_test_failed), showSnackbar)
             }
 
             HomeScreen.Effect.ShowMainGoalToast -> {

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -40,6 +40,8 @@ import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
 import com.nexters.bandalart.core.domain.notification.BufferedDeadlineNotificationLaunchTarget
 import com.nexters.bandalart.core.domain.notification.NoOpDeadlineNotificationAuthorization
 import com.nexters.bandalart.core.domain.notification.NoOpDeadlineReminderReconciler
+import com.nexters.bandalart.core.domain.notification.DeadlineReminderScheduler
+import com.nexters.bandalart.core.domain.notification.NoOpDeadlineReminderScheduler
 import com.nexters.bandalart.core.domain.repository.BandalartRepository
 import com.nexters.bandalart.core.domain.repository.BandalartSlotRepository
 import com.nexters.bandalart.core.domain.repository.InAppUpdateRepository
@@ -82,6 +84,7 @@ class HomePresenter(
     private val deadlineNotificationAuthorization: DeadlineNotificationAuthorization =
         NoOpDeadlineNotificationAuthorization,
     private val deadlineReminderReconciler: DeadlineReminderReconciler = NoOpDeadlineReminderReconciler,
+    private val deadlineReminderScheduler: DeadlineReminderScheduler = NoOpDeadlineReminderScheduler,
     private val deadlineNotificationLaunchTarget: DeadlineNotificationLaunchTarget =
         BufferedDeadlineNotificationLaunchTarget(),
     private val bandalartWidgetLaunchTarget: BandalartWidgetLaunchTarget =
@@ -1053,6 +1056,17 @@ class HomePresenter(
                             settingsRepository.setDeadlineReminderEnabled(true)
                         }
                         deadlineReminderReconciler.reconcileAll()
+                    }
+                }
+
+                HomeScreen.Event.SendDeadlineReminderTestNotification -> {
+                    scope.launch {
+                        val result = deadlineReminderScheduler.postTestNotification()
+                        if (result.scheduledCount > 0 && result.lastErrorCategory == null) {
+                            emitEffect(HomeScreen.Effect.ShowDeadlineReminderTestSentSnackbar)
+                        } else {
+                            emitEffect(HomeScreen.Effect.ShowDeadlineReminderTestFailedSnackbar)
+                        }
                     }
                 }
 

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/settings/SettingsBottomSheet.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/settings/SettingsBottomSheet.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -73,6 +74,7 @@ import bandalart.core.designsystem.generated.resources.settings_deadline_reminde
 import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_dialog_title
 import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_overflow
 import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_section
+import bandalart.core.designsystem.generated.resources.settings_deadline_reminder_test
 import bandalart.core.designsystem.generated.resources.settings_contact
 import bandalart.core.designsystem.generated.resources.settings_theme_dark
 import bandalart.core.designsystem.generated.resources.settings_theme_light
@@ -170,6 +172,20 @@ internal fun SettingsBottomSheet(
                         }
                     },
                 )
+                if (
+                    deadlineReminderEnabled &&
+                    (
+                        deadlineNotificationAuthorizationStatus == DeadlineNotificationAuthorizationStatus.GRANTED ||
+                            deadlineNotificationAuthorizationStatus == DeadlineNotificationAuthorizationStatus.QUIET
+                    )
+                ) {
+                    TextButton(
+                        onClick = { onHomeUiAction(HomeScreen.Event.SendDeadlineReminderTestNotification) },
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    ) {
+                        Text(text = stringResource(Res.string.settings_deadline_reminder_test))
+                    }
+                }
                 Spacer(modifier = Modifier.height(16.dp))
                 HorizontalDivider(
                     color = MaterialTheme.colorScheme.outlineVariant,

--- a/iosApp/iosApp/en.lproj/Localizable.strings
+++ b/iosApp/iosApp/en.lproj/Localizable.strings
@@ -1,3 +1,5 @@
 "deadline_reminder_title" = "You have goals due today";
 "deadline_reminder_single_body" = "Time to complete %@.";
 "deadline_reminder_multiple_body" = "%ld goals are due today.";
+"deadline_reminder_test_title" = "Deadline reminder test";
+"deadline_reminder_test_body" = "If you can see this, notifications are set up correctly.";

--- a/iosApp/iosApp/ja.lproj/Localizable.strings
+++ b/iosApp/iosApp/ja.lproj/Localizable.strings
@@ -1,3 +1,5 @@
 "deadline_reminder_title" = "今日が締め切りの目標があります";
 "deadline_reminder_single_body" = "%@を完了する時間です。";
 "deadline_reminder_multiple_body" = "%ld個の目標が今日締切です。";
+"deadline_reminder_test_title" = "締切日リマインダーのテスト";
+"deadline_reminder_test_body" = "この通知が表示されれば、通知は正しく設定されています。";

--- a/iosApp/iosApp/ko.lproj/Localizable.strings
+++ b/iosApp/iosApp/ko.lproj/Localizable.strings
@@ -1,3 +1,5 @@
 "deadline_reminder_title" = "오늘 마감인 목표가 있어요";
 "deadline_reminder_single_body" = "%@을(를) 완료할 시간이에요.";
 "deadline_reminder_multiple_body" = "%ld개의 목표가 오늘 마감이에요.";
+"deadline_reminder_test_title" = "마감일 알림 테스트";
+"deadline_reminder_test_body" = "이 알림이 보이면 알림 설정이 정상이에요.";


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #211

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 알림이 허용된 설정 화면에서 마감일 테스트 알림을 전송할 수 있도록 추가했습니다.
- Android는 실제 마감 알림 채널에 즉시 게시하고, iOS는 동일 namespace의 1초 로컬 알림을 예약합니다.
- 테스트 알림이 기존 마감 예약을 교체하지 않으며 알림 OFF 시 함께 정리되도록 했습니다.
- 한국어·영어·일본어 문구와 전송 성공·실패 피드백을 추가했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인 — Android Internal 배포 후 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `./gradlew :core:domain:testAndroidHostTest :feature:home:testAndroidHostTest :composeApp:testAndroidHostTest`
- `./gradlew :composeApp:compileKotlinIosSimulatorArm64 :feature:home:compileKotlinIosSimulatorArm64`
- `./gradlew :core:domain:detekt :feature:home:detekt :composeApp:detekt`

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 테스트 알림 | Internal 배포 후 실기기 확인 | 알림 결과 | Internal 배포 후 실기기 확인 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 이 PR은 테스트 알림 진단 경로만 추가하며 #211을 다시 닫지 않습니다.
- Internal artifact에는 클라우드 백업 작업과 후속 수정이 병합된 최신 `main`이 함께 포함됩니다.
