### PR TITLE
chore: Circuit 0.36.1 업데이트 및 README 최신화

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
 - 목표, 하위 목표, 실천 항목으로 구성된 만다라트 계획 작성과 달성 관리
 - 취업 준비, 운동 습관, 공부 계획, 재테크 습관, 여행 준비 템플릿 제공
 - 여러 반다라트 생성, 전환, 삭제와 이미지 저장·공유
-- 마감일 당일 오전 9시부터 전달되는 Android·iOS 로컬 알림
+- 동일 기기에서 앱을 다시 설치한 뒤 복원할 수 있는 수동 클라우드 백업
+- 마감일 당일 오전 9시를 목표로 전달되는 Android·iOS 로컬 알림
 - 마지막으로 본 반다라트의 진행률과 실천 항목을 확인하고 완료 상태를 변경할 수 있는 Android·iOS 홈 화면 위젯
 - 시스템 설정, 라이트 모드, 다크 모드와 목표 완료 시 진동 피드백
 - 한국어, 영어, 일본어 인터페이스
@@ -46,14 +47,14 @@
 ![image](https://github.com/user-attachments/assets/c45b3830-95b2-4b20-9280-7004fc812350)
 
 ```text
-├── androidApp          # Android 애플리케이션과 플랫폼 연동
-├── composeApp          # 공통 앱 조립, Android·iOS 플랫폼 구현
-├── iosApp              # Swift 호스트 앱과 iOS 네이티브 브리지
+├── androidApp          # Android 애플리케이션, 홈 화면 위젯과 플랫폼 연동
+├── composeApp          # 공통 앱 조립, Android·iOS 알림과 플랫폼 구현
+├── iosApp              # Swift 호스트 앱, WidgetKit과 iOS 네이티브 브리지
 ├── baselineprofile     # Android Baseline Profile 생성
 ├── build-logic         # Gradle convention plugin
 ├── core
 │   ├── common          # 공통 유틸리티와 플랫폼 계약
-│   ├── data            # Repository 구현
+│   ├── data            # Repository 구현과 Supabase 원격 백업 연결
 │   ├── database        # Room KMP 데이터베이스
 │   ├── datastore       # 설정과 앱 상태 저장
 │   ├── designsystem    # 테마, Pretendard, 공통 컴포넌트와 리소스
@@ -61,6 +62,7 @@
 │   ├── navigation      # Circuit Screen과 내비게이션 계약
 │   └── ui              # 공통 UI 도구
 ├── feature
+│   ├── backup          # 클라우드 백업과 복원
 │   ├── complete        # 목표 달성 화면
 │   ├── home            # 계획 작성, 템플릿, 설정과 광고 흐름
 │   ├── onboarding      # 온보딩
@@ -78,13 +80,16 @@
 | --- | --- |
 | 언어·빌드 | Kotlin 2.4.10, Swift, Gradle 9.5.0, Android Gradle Plugin 9.3.0, Java Development Kit (JDK) 21 |
 | UI | Compose Multiplatform 1.10.3, Material 3, Pretendard, Compottie, Coil 3, Landscapist |
-| 상태·내비게이션 | [Circuit 0.35.1](https://slackhq.github.io/circuit/) |
+| 상태·내비게이션 | [Circuit 0.36.1](https://slackhq.github.io/circuit/) |
 | 의존성 주입 | [Metro 1.1.1](https://zacsweers.github.io/metro/) |
-| 데이터 | Room KMP, SQLite, DataStore |
-| 비동기·직렬화 | Kotlin Coroutines, Kotlinx Serialization, Kotlinx DateTime, Immutable Collections |
-| 서비스 | Firebase Analytics·Crashlytics·Remote Config, Google AdMob |
-| Android | WorkManager, In-app Updates, Baseline Profiles, R8 |
-| iOS | Swift 호스트 앱, Swift Package Manager, UserNotifications |
+| 로컬 데이터 | Room KMP 2.7.2, SQLite 2.5.0, DataStore 1.1.4 |
+| 네트워크·클라우드 | Ktor 3.4.3, Supabase KMP 3.2.0과 PostgREST RPC |
+| 비동기·직렬화 | Kotlin Coroutines 1.10.1, Kotlinx Serialization 1.8.1, Kotlinx DateTime 0.6.2, Immutable Collections 0.3.8 |
+| 백그라운드·알림 | AndroidX WorkManager 2.11.2, AndroidX Core 1.16.0의 NotificationCompat, iOS UserNotifications |
+| 홈 화면 위젯 | AndroidX Glance 1.1.1, WidgetKit |
+| 서비스 | GitLive Firebase Kotlin SDK 2.1.0의 Analytics·Crashlytics·Remote Config, Google Mobile Ads Next-Gen SDK 1.3.0 |
+| Android | AndroidX Activity·Fragment·Lifecycle·SplashScreen, Play In-App Updates, Baseline Profiles, R8 |
+| iOS | Swift 호스트 앱, Swift Package Manager |
 | 로깅·도구 | Napier, Ding, uri-kmp, CMPToast, Jindong |
 | 테스트 | JUnit 5, Circuit Test, Turbine, MockK, Robolectric, Kotest |
 | 코드 품질 | Spotless, ktlint, Detekt |

--- a/docs/architecture/kmp/KMP_TESTING_GUIDE.md
+++ b/docs/architecture/kmp/KMP_TESTING_GUIDE.md
@@ -2,7 +2,7 @@
 
 - 작성 기준: 2026-08-06, `docs/kmp-testing-guide`
 - 관련 이슈: [#209](https://github.com/Nexters/BandalArt-KMP/issues/209)
-- 대상 구성: AGP 9 Android-KMP plugin, Kotlin Multiplatform, Circuit 0.35.1, JUnit 5
+- 대상 구성: AGP 9 Android-KMP plugin, Kotlin Multiplatform, Circuit 0.36.1, JUnit 5
 
 ## 결론
 
@@ -71,7 +71,7 @@ runTest {
 
 - [Circuit 공식 Testing 문서](https://slackhq.github.io/circuit/docs/testing/)
 
-프로젝트가 소비 중인 `circuit-test:0.35.1` Gradle Module Metadata를 확인한 결과는 다음과 같다.
+프로젝트가 소비 중인 `circuit-test:0.36.1` Gradle Module Metadata를 확인한 결과는 다음과 같다.
 
 - common metadata와 Android/JVM/iOS/JS/Wasm/macOS 변형을 게시한다.
 - `molecule-runtime:2.2.0`과 `turbine:1.2.1`을 전이 의존성으로 제공한다.

--- a/docs/architecture/state/COMPOSE_STATE_LIFETIME_GUIDE.md
+++ b/docs/architecture/state/COMPOSE_STATE_LIFETIME_GUIDE.md
@@ -1,6 +1,6 @@
 # Compose와 Circuit 상태 수명 가이드
 
-- 작성 기준: 2026-08-08, Circuit 0.35.1
+- 작성 기준: 2026-08-19, Circuit 0.36.1
 - 적용 범위: Compose Multiplatform UI, Circuit Presenter, Android saved state, repository persistence
 
 ## 한 줄 원칙
@@ -38,7 +38,7 @@ Circuit back stack 보존은 해당 화면 record가 stack에 남아 있을 때�
 
 `rememberSaveable`의 process 복원은 Android saved-state 동작이다. iOS 앱 종료·재실행까지 보장하는 KMP 영속성으로 해석하지 않는다. 플랫폼을 넘어 복구해야 하는 값은 repository에 저장한다.
 
-현재 프로젝트는 Circuit 0.35.1을 사용하며 Android에서는 기본 ViewModel-backed retained registry를 사용하고 `CircuitRetainedSettings.useFirstParty`를 켜지 않았다. Compose의 first-party retain API와 Circuit retained API를 한 화면에서 임의로 섞지 않고, 전환이 필요하면 별도 마이그레이션으로 플랫폼별 수명과 테스트 계약을 다시 고정한다.
+현재 프로젝트는 Circuit 0.36.1을 사용하며 Android에서는 기본 ViewModel-backed retained registry를 사용하고 `CircuitRetainedSettings.useFirstParty`를 켜지 않았다. Compose의 first-party retain API와 Circuit retained API를 한 화면에서 임의로 섞지 않고, 전환이 필요하면 별도 마이그레이션으로 플랫폼별 수명과 테스트 계약을 다시 고정한다.
 
 ## API별 기준
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ androidx-sqlite = "2.5.0"
 
 # DI
 metro = "1.1.1"
-circuit = "0.35.1"
+circuit = "0.36.1"
 
 # Image Load
 coil3 = "3.1.0"


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- 없음

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- Circuit 의존성을 0.35.1에서 0.36.1로 업데이트했습니다.
- README의 주요 기능과 프로젝트 구조에 클라우드 백업 모듈을 반영했습니다.
- Ktor, Supabase KMP, WorkManager, NotificationCompat, Glance, UserNotifications와 WidgetKit을 기술 스택에 추가했습니다.
- KMP 테스트 및 Compose 상태 수명 가이드의 Circuit 버전을 동기화했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- Circuit/Metro Android Host 대표 테스트 5개
- `./gradlew :composeApp:compileKotlinIosSimulatorArm64`
- `git diff --check`

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

- UI 변경 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- Circuit 0.36.1 Android 및 iOS 아티팩트 해석과 컴파일을 확인했습니다.
- 과거 마이그레이션 기록의 Circuit 0.35.1 고정 링크는 유지했습니다.
- Android 마감일 알림은 AlarmManager가 아닌 WorkManager 기반입니다.
