### PR TITLE
docs: README 기술 스택 버전 표기 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,20 +78,20 @@
 
 | 영역 | 사용 기술 |
 | --- | --- |
-| 언어·빌드 | Kotlin 2.4.10, Swift, Gradle 9.5.0, Android Gradle Plugin 9.3.0, Java Development Kit (JDK) 21 |
-| UI | Compose Multiplatform 1.10.3, Material 3, Pretendard, Compottie, Coil 3, Landscapist |
-| 상태·내비게이션 | [Circuit 0.36.1](https://slackhq.github.io/circuit/) |
-| 의존성 주입 | [Metro 1.1.1](https://zacsweers.github.io/metro/) |
-| 로컬 데이터 | Room KMP 2.7.2, SQLite 2.5.0, DataStore 1.1.4 |
-| 네트워크·클라우드 | Ktor 3.4.3, Supabase KMP 3.2.0과 PostgREST RPC |
-| 비동기·직렬화 | Kotlin Coroutines 1.10.1, Kotlinx Serialization 1.8.1, Kotlinx DateTime 0.6.2, Immutable Collections 0.3.8 |
-| 백그라운드·알림 | AndroidX WorkManager 2.11.2, AndroidX Core 1.16.0의 NotificationCompat, iOS UserNotifications |
-| 홈 화면 위젯 | AndroidX Glance 1.1.1, WidgetKit |
-| 서비스 | GitLive Firebase Kotlin SDK 2.1.0의 Analytics·Crashlytics·Remote Config, Google Mobile Ads Next-Gen SDK 1.3.0 |
-| Android | AndroidX Activity·Fragment·Lifecycle·SplashScreen, Play In-App Updates, Baseline Profiles, R8 |
+| 언어·빌드 | Kotlin, Swift, Gradle, Android Gradle Plugin, Java Development Kit (JDK) |
+| UI | Compose Multiplatform, Material Design, Pretendard, Compottie, Coil, Landscapist |
+| 상태·내비게이션 | [Circuit](https://slackhq.github.io/circuit/) |
+| 의존성 주입 | [Metro](https://zacsweers.github.io/metro/) |
+| 로컬 데이터 | Room KMP, SQLite, DataStore |
+| 네트워크·클라우드 | Ktor, Supabase KMP, PostgREST RPC |
+| 비동기·직렬화 | Kotlin Coroutines, Kotlinx Serialization, Kotlinx DateTime, Immutable Collections |
+| 백그라운드·알림 | AndroidX WorkManager, AndroidX Core NotificationCompat, iOS UserNotifications |
+| 홈 화면 위젯 | AndroidX Glance, WidgetKit |
+| 서비스 | GitLive Firebase Kotlin SDK, Firebase Analytics, Firebase Crashlytics, Firebase Remote Config, Google Mobile Ads Next-Gen SDK |
+| Android | AndroidX Activity, Fragment, Lifecycle, SplashScreen, Play In-App Updates, Baseline Profiles, R8 |
 | iOS | Swift 호스트 앱, Swift Package Manager |
 | 로깅·도구 | Napier, Ding, uri-kmp, CMPToast, Jindong |
-| 테스트 | JUnit 5, Circuit Test, Turbine, MockK, Robolectric, Kotest |
+| 테스트 | JUnit, Circuit Test, Turbine, MockK, Robolectric, Kotest |
 | 코드 품질 | Spotless, ktlint, Detekt |
 
 정확한 의존성 버전은 [Gradle Version Catalog](gradle/libs.versions.toml)를 기준으로 관리합니다. 오픈소스 고지와 라이선스는 [Third-party notices](THIRD_PARTY_NOTICES.md)에서 확인할 수 있습니다.


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- 없음

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- README 기술 스택 표에서 숫자 버전 표기를 제거했습니다.
- 기술 목록의 연결 표현을 쉼표로 통일했습니다.
- 실제 버전은 Gradle Version Catalog에서 관리하도록 README의 역할을 분리했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `git diff --check`

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| UI 변경 없음 | - | UI 변경 없음 | - |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- `Material 3`, `Coil 3`, `JUnit 5`는 버전 없는 명칭으로 정리했습니다.
- `R8`은 제품명 자체이므로 유지했습니다.
