### PR TITLE
fix: Android 배포 앱 홈 배너 테스트 광고 노출 수정

### DIFF
--- a/.github/workflows/release-cd.yml
+++ b/.github/workflows/release-cd.yml
@@ -13,7 +13,7 @@ on:
                     - android
                     - ios
             confirm_release:
-                description: I confirm main deployment to Play Internal/TestFlight (Android uses test ads; iOS uses the selected ad mode)
+                description: I confirm main deployment to Play Internal/TestFlight (Android uses production ads; iOS uses the selected ad mode)
                 required: true
                 default: false
                 type: boolean

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -12,7 +12,6 @@ plugins {
     alias(libs.plugins.play.publisher)
 }
 
-val useTestAds = providers.gradleProperty("bandalart.useTestAds").orNull.toBoolean()
 val localProperties =
     Properties().apply {
         rootProject
@@ -71,24 +70,8 @@ android {
             isShrinkResources = true
             signingConfig = signingConfigs.getByName("release")
             resValue("string", "admob_app_id", "ca-app-pub-5570932833347277~6079637815")
-            resValue(
-                "string",
-                "admob_rewarded_ad_unit_id",
-                if (useTestAds) {
-                    "ca-app-pub-3940256099942544/5224354917"
-                } else {
-                    "ca-app-pub-5570932833347277/6659503579"
-                },
-            )
-            resValue(
-                "string",
-                "admob_banner_ad_unit_id",
-                if (useTestAds) {
-                    "ca-app-pub-3940256099942544/6300978111"
-                } else {
-                    "ca-app-pub-5570932833347277/1215605203"
-                },
-            )
+            resValue("string", "admob_rewarded_ad_unit_id", "ca-app-pub-5570932833347277/6659503579")
+            resValue("string", "admob_banner_ad_unit_id", "ca-app-pub-5570932833347277/1215605203")
             manifestPlaceholders +=
                 mapOf(
                     "appName" to "@string/app_name",

--- a/docs/features/ads/ADMOB_ANDROID_TROUBLESHOOTING.md
+++ b/docs/features/ads/ADMOB_ANDROID_TROUBLESHOOTING.md
@@ -4,7 +4,7 @@
 
 Play Internal Testing에서 홈 배너와 보상형 광고가 모두 나타나지 않았던 사건의 진단 과정과 재발 방지 절차를 기록한다. 같은 증상이 생기면 광고 크기나 광고 단위 ID부터 바꾸지 말고, 설치 산출물과 SDK 초기화부터 요청·표시까지의 생명주기를 아래 순서로 확인한다.
 
-관련 이슈는 [#289](https://github.com/Nexters/BandalArt-KMP/issues/289), 최종 원인 수정은 [#297](https://github.com/Nexters/BandalArt-KMP/pull/297)이다. `2.2.26 (20226)`은 Google 테스트 광고 ID로 Internal Testing에 배포했으며, 이슈는 실기기에서 테스트 creative를 확인한 뒤 닫는다.
+관련 초기화 이슈는 [#289](https://github.com/Nexters/BandalArt-KMP/issues/289), 최종 원인 수정은 [#297](https://github.com/Nexters/BandalArt-KMP/pull/297)이다. `2.2.26 (20226)`은 당시 Google 테스트 광고 ID로 Internal Testing에 배포해 테스트 creative를 확인했다. 이후 [#354](https://github.com/Nexters/BandalArt-KMP/issues/354)부터는 Internal Testing도 운영 수익 집계를 검증할 수 있도록 release와 같은 운영 광고 ID를 사용한다.
 
 ## 사건 요약
 
@@ -80,12 +80,12 @@ adb pull /data/app/.../base.apk /tmp/bandalart-base.apk
 unzip -p /tmp/bandalart-base.apk resources.arsc | strings | grep 'ca-app-pub-'
 ```
 
-Internal AAB에는 Google 공식 테스트 ID가 들어가야 한다.
+현재 Internal AAB에는 운영 광고 ID가 들어가야 한다.
 
-- Rewarded: `ca-app-pub-3940256099942544/5224354917`
-- Fixed Size Banner: `ca-app-pub-3940256099942544/6300978111`
+- Rewarded: `ca-app-pub-5570932833347277/6659503579`
+- Fixed Size Banner: `ca-app-pub-5570932833347277/1215605203`
 
-운영 광고 단위 ID가 하나라도 들어 있으면 Internal 검증용 산출물로 업로드하지 않는다. 테스트 광고 AAB도 Production으로 승급하지 않고, 운영 ID와 새 versionCode로 다시 빌드한다.
+공식 Google 테스트 광고 단위 ID가 하나라도 들어 있으면 Internal 검증용 산출물로 업로드하지 않는다. Debug 빌드는 계속 공식 테스트 ID를 사용하고, Play에 올리는 release AAB만 운영 ID를 사용한다. Internal 설치본에서는 실제 광고를 클릭하지 않는다.
 
 ### 3. 한 번의 cold start를 관찰한다
 
@@ -190,9 +190,9 @@ Anchored Adaptive 테스트 ID를 Fixed Size Banner 테스트 ID로 맞춘 [#290
 - [ ] fail-open 생성과 광고 성공을 구분했다.
 - [ ] release에서 초기화·preloader·배너 load 실패를 확인할 수 있다.
 - [ ] Presenter의 fail-open, dismiss, exactly-once, 템플릿 보존 테스트가 통과한다.
-- [ ] Internal AAB에는 공식 테스트 ID만 포함한다.
-- [ ] 테스트 광고가 포함된 AAB을 Production으로 승급하지 않는다.
-- [ ] 실기기에서 배너 `Test Ad`와 보상형 테스트 creative를 각각 확인했다.
+- [ ] Internal AAB에는 Rewarded와 Banner 운영 ID가 모두 포함되고 공식 테스트 ID는 포함되지 않는다.
+- [ ] Debug 빌드에는 공식 테스트 ID만 포함한다.
+- [ ] Internal 실기기에서 실제 광고 응답을 확인하되 광고를 클릭하지 않는다.
 
 ## 블로그 작성용 구성
 
@@ -211,7 +211,7 @@ Anchored Adaptive 테스트 ID를 Fixed Size Banner 테스트 ID로 맞춘 [#290
 5. **원인 확인:** Next-Gen SDK binary와 공식 문서로 초기화 전 API 호출의 예외와 동기식 초기화 계약을 확인했다.
 6. **수정:** `initialize`를 먼저 호출하고 release-safe 실패 로그를 최소한으로 추가했다.
 7. **제품 정책:** 광고 장애 시 fail-open과 사용자의 자발적 dismiss를 다르게 취급한 이유를 설명한다.
-8. **운영 교훈:** 정확한 산출물 검증, 상태 판별표, 테스트 광고 AAB의 Production 승급 금지를 체크리스트로 정리한다.
+8. **운영 교훈:** 정확한 산출물 검증, 상태 판별표, release 운영 ID와 debug 테스트 ID의 분리를 체크리스트로 정리한다.
 
 ## 공식 참고
 

--- a/docs/features/ads/ADMOB_HOME_BANNER_STRATEGY.md
+++ b/docs/features/ads/ADMOB_HOME_BANNER_STRATEGY.md
@@ -12,7 +12,7 @@
 - 홈의 공유 버튼과 Snackbar는 배너 위에 배치하고 시스템 navigation bar safe area를 유지한다.
 - bottom sheet, dialog, 이미지 capture, 보상형 광고 표시 및 loading 중에는 배너 creative와 클릭·접근성 focus를 숨긴다.
 - iOS는 광고 SDK를 추가하지 않고 no-op host를 유지한다.
-- Internal Testing AAB에서는 Rewarded와 Banner 모두 Google 공식 테스트 광고 단위 ID만 사용한다.
+- Debug 빌드에서는 Rewarded와 Banner 모두 Google 공식 테스트 광고 단위 ID를 사용한다. Play Internal Testing에 배포하는 release AAB는 운영 광고 단위 ID를 사용한다.
 
 ## 플랫폼 경계
 
@@ -48,10 +48,10 @@
 ## Internal Testing
 
 - Android 버전을 `2.2.18 (20218)`로 올린다. Play 전체 track의 현재 최대 versionCode는 `20217`이다.
-- `-Pbandalart.useTestAds=true`가 release Rewarded와 Banner ID를 각각 Google 공식 테스트 ID로 바꿔야 한다.
-- clean bundle과 publish task 모두 같은 property를 전달한다.
-- AAB 검증 시 Rewarded 테스트 ID `ca-app-pub-3940256099942544/5224354917`와 Fixed Size Banner 테스트 ID `ca-app-pub-3940256099942544/6300978111`의 존재를 확인하고 두 production ad unit ID가 있으면 업로드하지 않는다.
-- 이 테스트 광고 artifact는 production으로 promote하지 않는다. production 광고 ID를 쓰는 다음 배포는 새 versionCode로 다시 빌드한다.
+- 이 기능을 처음 검증한 `2.2.18 (20218)`은 `-Pbandalart.useTestAds=true`로 release Rewarded와 Banner ID를 Google 공식 테스트 ID로 바꿔 배포했다.
+- 이 정책 때문에 이후 Internal 설치본에도 테스트 광고가 계속 노출된 문제는 [#354](https://github.com/Nexters/BandalArt-KMP/issues/354)에서 수정했다.
+- 현재 clean bundle과 publish task는 별도 광고 override 없이 release의 운영 Rewarded와 Banner ID를 사용한다.
+- AAB 검증은 두 운영 광고 ID가 모두 존재하고 공식 Google 테스트 광고 ID가 하나도 없는지 확인한다.
 
 ## 검증
 
@@ -60,16 +60,16 @@
 - Home banner visibility 규칙을 각 overlay/capture/loading/rewarded 상태별로 검증한다.
 - Android graph가 실제 host를, iOS graph와 Preview/Test가 no-op host를 제공하는지 컴파일과 graph test로 확인한다.
 - 관련 Android host tests, Detekt, Android lint/build와 iOS framework CI를 통과한다.
-- Internal AAB의 package/version, 서명, Compose resource namespace와 두 테스트 광고 ID를 검증한다.
+- Internal AAB의 package/version, 서명, Compose resource namespace와 두 운영 광고 ID를 검증하고 테스트 광고 ID 유입을 거부한다.
 
 ### Internal 수동 검증
 
-- 홈 하단에 `Test Ad` 표시가 있는 배너 creative가 실제로 노출된다.
+- 홈 하단에 실제 배너 creative가 노출되고 `Test Ad` 라벨이 없는지 확인한다. 실제 광고는 클릭하지 않는다.
 - 320dp 이상 화면에서 고정형 배너가 중앙에 표시되고 navigation bar, 공유 버튼과 겹치지 않는다. 320dp 미만 가용 폭에서는 광고 요청과 빈 공간이 모두 없어야 한다. 현재 앱은 portrait 고정이므로 orientation lock 해제는 이번 범위에 포함하지 않는다.
 - Snackbar가 배너 위에 표시된다.
 - bottom sheet, dialog, 공유·저장 capture와 보상형 광고 표시 중 배너가 숨겨진다.
 - light/dark theme에서 광고 주변 container가 홈 배경과 어색하게 분리되지 않는다.
-- 보상형 광고는 안내 dialog 뒤에 Google 테스트 creative가 표시되고, reward 완료 시 정확히 1개 생성되며 reward 전 종료 시 생성하지 않는다.
+- 보상형 광고는 안내 dialog 뒤에 실제 creative가 표시되고, reward 완료 시 정확히 1개 생성되며 reward 전 종료 시 생성하지 않는다. 실제 광고는 클릭하지 않는다.
 - 광고 unavailable snackbar 뒤 fail-open 생성만 발생했다면 AdMob 활성화 성공으로 판단하지 않는다.
 
 ## 비범위

--- a/docs/features/ads/ADMOB_REWARDED_CREATE_GATE_STRATEGY.md
+++ b/docs/features/ads/ADMOB_REWARDED_CREATE_GATE_STRATEGY.md
@@ -65,13 +65,13 @@ AdMob 슬롯 기반 작업(PR #241)은 무료 슬롯 3개와 영구 확장 슬�
 - granted 요청을 가진 process 재실행 시 누락 생성 복구 및 이미 생성된 요청 중복 방지
 - Room Flow 반영이 지연된 동안 연속 Add 차단
 - Android host unit test, Android lint, 관련 컴파일을 통과한다.
-- Play Internal Testing은 `-Pbandalart.useTestAds=true`로 공식 Google 테스트 Rewarded ID를 사용해 무효 트래픽 없이 검증한다. production 배포 기본값은 실제 광고 단위 ID를 유지한다.
+- 이 기능을 처음 배포했을 때는 Play Internal Testing에 `-Pbandalart.useTestAds=true`를 전달해 공식 Google 테스트 Rewarded ID를 사용했다. [#354](https://github.com/Nexters/BandalArt-KMP/issues/354) 이후에는 debug만 테스트 ID를 사용하고 Internal release는 운영 광고 ID를 사용한다.
 
 ## Android Internal Testing 배포
 
 - 앱 버전은 `2.2.17 (20217)`로 올린다.
 - 한국어, 영어, 일본어 Internal release notes를 보상형 생성 흐름에 맞게 갱신한다.
-- clean AAB와 upload 명령 모두 `-Pbandalart.useTestAds=true`를 전달한다.
+- 현재 clean AAB와 upload 명령에는 광고 ID override를 전달하지 않는다. release 운영 ID가 포함되고 테스트 ID가 없는 AAB만 업로드한다.
 
 ## 비범위
 

--- a/docs/releases/automation/FASTLANE_CD_RECOVERY_STRATEGY.md
+++ b/docs/releases/automation/FASTLANE_CD_RECOVERY_STRATEGY.md
@@ -13,7 +13,7 @@
 - GitHub Actions `workflow_dispatch`에서 `android`, `ios`, `both`를 선택한다.
 - 배포 소스는 `main`의 최신 커밋으로 제한한다.
 - 상태를 변경하는 Android/iOS lane은 GitHub Actions에서만 실행하고, 로컬에서는 iOS read-only preflight만 허용한다.
-- Android는 공식 Google 테스트 Rewarded·Banner 광고 ID가 포함된 AAB만 Play Internal Testing에 올린다.
+- Android는 운영 Rewarded·Banner 광고 ID가 포함된 AAB만 Play Internal Testing에 올린다.
 - iOS는 App Store Connect Individual API Key와 수동 배포 서명 자산으로 TestFlight에 올린다.
 - 버전 충돌, 서명 자산 누락, 잘못된 광고 ID 또는 잘못된 브랜치는 업로드 전에 실패시킨다.
 - 자격증명은 GitHub Secrets에서 runner 임시 파일로만 복원하고 항상 삭제한다.
@@ -39,9 +39,9 @@
    - Fastlane `android internal`을 실행한다.
    - lane은 전체 Play track의 versionCode를 조회하고 현재 버전이 더 큰지 검증한다.
    - Play API Python 의존성은 exact version과 uv script lock으로 고정하고 `--frozen`으로 실행한다.
-   - clean release AAB를 `bandalart.useTestAds=true`로 생성한다.
-   - bundletool manifest의 package·version, ZIP 무결성, Compose 리소스 namespace, 테스트/운영 Rewarded·Banner 광고 ID를 검사한다.
-   - 같은 속성으로 Gradle Play Publisher의 `publishReleaseBundle`을 실행하고 Internal track 반영을 확인한다.
+   - clean release AAB를 생성한다.
+   - bundletool manifest의 package·version, ZIP 무결성, Compose 리소스 namespace와 운영 Rewarded·Banner 광고 ID 포함 여부를 검사하고 테스트 광고 ID 유입을 차단한다.
+   - 같은 산출물로 Gradle Play Publisher의 `publishReleaseBundle`을 실행하고 Internal track 반영을 확인한다.
 
 2. iOS job (`macos-latest`, `ios-testflight` environment)
    - JDK/Android SDK/Gradle/Ruby를 준비한다. Xcode shell phase가 KMP framework를 만들기 위해 필요하다.
@@ -110,7 +110,7 @@ App Group, App ID, 두 profile과 GitHub Environment secret 등록 절차는 [iO
 - 계산 충돌을 막기 위해 `MINOR`와 `PATCH`는 각각 `0..99` 범위에서 관리한다.
 - 모든 AAB는 Play 전체 track의 기존 최댓값보다 큰 새 versionCode를 사용해야 한다.
 - workflow는 버전을 자동 증가시키거나 source를 커밋하지 않는다. 배포 PR에서 버전과 3개 locale release notes를 함께 변경한다.
-- Internal Testing의 테스트 광고 AAB를 Production으로 승격하지 않는다. 운영 광고 빌드는 새 versionCode로 별도 생성한다.
+- Internal Testing AAB도 운영 광고를 사용하므로 내부 테스트 중 실제 광고를 클릭하지 않는다.
 
 ### iOS
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -194,7 +194,7 @@ def append_github_summary(lines)
 end
 
 platform :android do
-  desc "Build, validate, and upload a test-ad release AAB to Play Internal Testing"
+  desc "Build, validate, and upload a production-ad release AAB to Play Internal Testing"
   lane :internal do
     verify_ci_source!
     service_account_path = required_env!("PLAY_SERVICE_ACCOUNT_PATH")
@@ -221,7 +221,6 @@ platform :android do
     gradle(
       task: "clean :androidApp:bundleRelease",
       project_dir: REPO_ROOT,
-      properties: { "bandalart.useTestAds" => "true" },
       flags: "--no-configuration-cache --stacktrace",
     )
 
@@ -253,7 +252,6 @@ platform :android do
     gradle(
       task: ":androidApp:publishReleaseBundle",
       project_dir: REPO_ROOT,
-      properties: { "bandalart.useTestAds" => "true" },
       flags: "--artifact-dir #{Shellwords.escape(artifact_dir)} --update-priority #{update_priority} --no-configuration-cache --stacktrace",
     )
     UI.user_error!("Uploaded AAB changed after validation") unless Digest::SHA256.file(verified_aab).hexdigest == checksum

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -21,7 +21,7 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 [bundle exec] fastlane android internal
 ```
 
-Build, validate, and upload a test-ad release AAB to Play Internal Testing
+Build, validate, and upload a production-ad release AAB to Play Internal Testing
 
 ----
 

--- a/plugins/bandalart/skills/deploy-android-playstore/SKILL.md
+++ b/plugins/bandalart/skills/deploy-android-playstore/SKILL.md
@@ -50,17 +50,17 @@ service account는 `client_email`만 기대 계정과 일치하는지 검사하�
 
 ### 5. Android clean AAB 검증과 업로드
 
-1. `./gradlew clean :androidApp:bundleRelease -Pbandalart.useTestAds=true --no-configuration-cache`로 기존 생성물을 제거하고 공식 Google 테스트 광고 ID가 포함된 release AAB를 먼저 생성한다.
+1. `./gradlew clean :androidApp:bundleRelease --no-configuration-cache`로 기존 생성물을 제거하고 운영 AdMob 광고 ID가 포함된 release AAB를 먼저 생성한다.
 2. 생성된 AAB의 versionName/versionCode, 크기와 Compose resource namespace를 검사한다.
    - 제거된 source set의 generated resource namespace가 남아 있으면 업로드하지 않는다.
    - 저장소가 사용하는 resource namespace가 없으면 업로드하지 않는다.
-   - 공식 Google Rewarded와 Banner 테스트 광고 ID가 모두 포함됐는지 확인하고 두 format의 production 광고 단위 ID가 하나라도 포함됐으면 업로드하지 않는다.
-3. 사전 검증이 통과하면 `./gradlew publishReleaseBundle -Pbandalart.useTestAds=true --no-configuration-cache`로 검증된 소스와 산출물 상태에서 업로드한다.
+   - Rewarded와 Banner 운영 광고 ID가 모두 포함됐는지 확인하고 공식 Google 테스트 광고 단위 ID가 하나라도 포함됐으면 업로드하지 않는다.
+3. 사전 검증이 통과하면 `./gradlew publishReleaseBundle --no-configuration-cache`로 검증된 소스와 산출물 상태에서 업로드한다.
 4. 배포 산출물 생성이 목적이므로 이 workflow에서는 Android release build를 실행할 수 있다.
 5. upload target이 Internal track이고 의도한 release status인지 task 설정과 결과에서 확인한다.
 6. 실패하면 즉시 중단하고 secret을 가린 실패 단계와 원인을 보고한다.
 7. 성공하면 AAB, package, versionName/versionCode, track과 결과를 보고한다.
-8. 테스트 광고 ID가 포함된 Internal artifact는 production으로 promote하지 않는다. production 배포는 실제 광고 ID로 새 AAB와 새 versionCode를 생성한다.
+8. Internal artifact에는 운영 광고 ID가 포함되므로 테스트 중 실제 광고를 클릭하지 않도록 안내한다.
 
 ## 제약
 

--- a/scripts/tests/test_play_release_scripts.py
+++ b/scripts/tests/test_play_release_scripts.py
@@ -80,15 +80,29 @@ class PlayVersionTest(unittest.TestCase):
 
 
 class ValidateAabTest(unittest.TestCase):
-    def test_uses_fixed_size_banner_test_unit(self) -> None:
+    def test_debug_uses_test_ads_and_release_uses_production_ads(self) -> None:
         fixed_size_banner_id = "ca-app-pub-3940256099942544/6300978111"
         anchored_adaptive_banner_id = "ca-app-pub-3940256099942544/9214589741"
-        build_gradle = (
-            Path(__file__).resolve().parents[2] / "androidApp/build.gradle.kts"
-        ).read_text(encoding="utf-8")
+        root = Path(__file__).resolve().parents[2]
+        build_gradle = (root / "androidApp/build.gradle.kts").read_text(
+            encoding="utf-8"
+        )
+        fastfile = (root / "fastlane/Fastfile").read_text(encoding="utf-8")
+        debug_config, release_and_later = build_gradle.split(
+            'getByName("debug")', maxsplit=1
+        )[1].split('getByName("release")', maxsplit=1)
 
         self.assertEqual(fixed_size_banner_id.encode(), validate_play_aab.TEST_BANNER_ID)
-        self.assertIn(fixed_size_banner_id, build_gradle)
+        self.assertIn(validate_play_aab.TEST_REWARDED_ID.decode(), debug_config)
+        self.assertIn(fixed_size_banner_id, debug_config)
+        self.assertNotIn(validate_play_aab.PRODUCTION_REWARDED_ID.decode(), debug_config)
+        self.assertNotIn(validate_play_aab.PRODUCTION_BANNER_ID.decode(), debug_config)
+        self.assertIn(validate_play_aab.PRODUCTION_REWARDED_ID.decode(), release_and_later)
+        self.assertIn(validate_play_aab.PRODUCTION_BANNER_ID.decode(), release_and_later)
+        self.assertNotIn(validate_play_aab.TEST_REWARDED_ID.decode(), release_and_later)
+        self.assertNotIn(fixed_size_banner_id, release_and_later)
+        self.assertNotIn("bandalart.useTestAds", build_gradle)
+        self.assertNotIn("bandalart.useTestAds", fastfile)
         self.assertNotIn(anchored_adaptive_banner_id, build_gradle)
 
     def test_validates_exact_production_package(self) -> None:
@@ -125,16 +139,16 @@ class ValidateAabTest(unittest.TestCase):
                 archive.writestr("base/manifest/AndroidManifest.xml", b"manifest")
                 archive.writestr(
                     "base/dex/classes.dex",
-                    validate_play_aab.TEST_REWARDED_ID
+                    validate_play_aab.PRODUCTION_REWARDED_ID
                     + b"\0"
-                    + validate_play_aab.TEST_BANNER_ID
+                    + validate_play_aab.PRODUCTION_BANNER_ID
                     + b"\0"
                     + validate_play_aab.REQUIRED_NAMESPACE[0],
                 )
 
             validate_play_aab.verify_archive(aab)
 
-    def test_rejects_production_rewarded_id(self) -> None:
+    def test_rejects_test_rewarded_id(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             aab = Path(directory) / "app.aab"
             with zipfile.ZipFile(aab, "w") as archive:
@@ -142,24 +156,52 @@ class ValidateAabTest(unittest.TestCase):
                 archive.writestr(
                     "base/resources.pb",
                     validate_play_aab.TEST_REWARDED_ID
-                    + validate_play_aab.TEST_BANNER_ID
                     + validate_play_aab.PRODUCTION_REWARDED_ID
+                    + validate_play_aab.PRODUCTION_BANNER_ID
+                    + validate_play_aab.REQUIRED_NAMESPACE[0],
+                )
+
+            with self.assertRaisesRegex(ValueError, "test rewarded ad ID"):
+                validate_play_aab.verify_archive(aab)
+
+    def test_rejects_test_banner_id(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            aab = Path(directory) / "app.aab"
+            with zipfile.ZipFile(aab, "w") as archive:
+                archive.writestr("base/manifest/AndroidManifest.xml", b"manifest")
+                archive.writestr(
+                    "base/resources.pb",
+                    validate_play_aab.PRODUCTION_REWARDED_ID
+                    + validate_play_aab.TEST_BANNER_ID
+                    + validate_play_aab.PRODUCTION_BANNER_ID
+                    + validate_play_aab.REQUIRED_NAMESPACE[0],
+                )
+
+            with self.assertRaisesRegex(ValueError, "test banner ad ID"):
+                validate_play_aab.verify_archive(aab)
+
+    def test_requires_production_rewarded_id(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            aab = Path(directory) / "app.aab"
+            with zipfile.ZipFile(aab, "w") as archive:
+                archive.writestr("base/manifest/AndroidManifest.xml", b"manifest")
+                archive.writestr(
+                    "base/resources.pb",
+                    validate_play_aab.PRODUCTION_BANNER_ID
                     + validate_play_aab.REQUIRED_NAMESPACE[0],
                 )
 
             with self.assertRaisesRegex(ValueError, "production rewarded ad ID"):
                 validate_play_aab.verify_archive(aab)
 
-    def test_rejects_production_banner_id(self) -> None:
+    def test_requires_production_banner_id(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             aab = Path(directory) / "app.aab"
             with zipfile.ZipFile(aab, "w") as archive:
                 archive.writestr("base/manifest/AndroidManifest.xml", b"manifest")
                 archive.writestr(
                     "base/resources.pb",
-                    validate_play_aab.TEST_REWARDED_ID
-                    + validate_play_aab.TEST_BANNER_ID
-                    + validate_play_aab.PRODUCTION_BANNER_ID
+                    validate_play_aab.PRODUCTION_REWARDED_ID
                     + validate_play_aab.REQUIRED_NAMESPACE[0],
                 )
 

--- a/scripts/validate_play_aab.py
+++ b/scripts/validate_play_aab.py
@@ -85,14 +85,14 @@ def verify_archive(path: Path) -> None:
                 value in content for value in REMOVED_NAMESPACE
             )
 
-        if not test_rewarded_id_found:
-            fail("official Google rewarded test ad ID is missing")
-        if production_rewarded_id_found:
-            fail("production rewarded ad ID is present")
-        if not test_banner_id_found:
-            fail("official Google banner test ad ID is missing")
-        if production_banner_id_found:
-            fail("production banner ad ID is present")
+        if test_rewarded_id_found:
+            fail("official Google test rewarded ad ID is present")
+        if not production_rewarded_id_found:
+            fail("production rewarded ad ID is missing")
+        if test_banner_id_found:
+            fail("official Google test banner ad ID is present")
+        if not production_banner_id_found:
+            fail("production banner ad ID is missing")
         if not required_namespace_found:
             fail("expected Compose resource namespace is missing")
         if removed_namespace_found:


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #354

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- Android debug는 Google 테스트 광고 ID를 유지하고 release는 운영 Rewarded·Banner ID로 고정합니다.
- Play Internal Fastlane lane에서 release 테스트 광고 override를 제거합니다.
- 업로드 전 AAB에 테스트 ID가 있거나 운영 ID가 누락되면 실패하도록 검증과 회귀 테스트를 추가합니다.
- 관련 배포 workflow, skill 및 광고 운영 문서를 현재 정책에 맞게 갱신합니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `python3 -m unittest discover`: 통과
- `./gradlew :androidApp:testDebugUnitTest`: 29/29 통과
- Release resValues: 운영 ID 포함 및 테스트 ID 미포함 확인
- Fastfile/YAML 문법 검사 및 `git diff --check`: 통과
- Signed AAB와 실기기 광고·AdMob 집계 확인은 배포 후 진행

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 해당 없음 | 설정 및 배포 경로 변경 | 해당 없음 | UI 변경 없음 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- Fastlane이 검증된 운영 광고 AAB만 Play Internal에 업로드하는지 중점적으로 확인해주세요.
- Internal 설치본에서 실제 광고는 클릭하지 않습니다.
