### PR TITLE
feat: 클라우드 백업 보상형 광고 게이트 추가

### DIFF
--- a/.github/workflows/release-cd.yml
+++ b/.github/workflows/release-cd.yml
@@ -20,7 +20,7 @@ on:
             ios_ads_mode:
                 description: iOS ad configuration (test for testing, production for the App Store release candidate)
                 required: true
-                default: test
+                default: production
                 type: choice
                 options:
                     - test

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -87,7 +87,7 @@ android {
                 if (useTestAds) {
                     "ca-app-pub-3940256099942544/5224354917"
                 } else {
-                    "ca-app-pub-5570932833347277/6659503579"
+                    "ca-app-pub-5570932833347277/7686378276"
                 },
             )
             resValue(

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -57,7 +57,8 @@ android {
             isDebuggable = true
             applicationIdSuffix = ".dev"
             resValue("string", "admob_app_id", "ca-app-pub-3940256099942544~3347511713")
-            resValue("string", "admob_rewarded_ad_unit_id", "ca-app-pub-3940256099942544/5224354917")
+            resValue("string", "admob_rewarded_bandalart_creation_ad_unit_id", "ca-app-pub-3940256099942544/5224354917")
+            resValue("string", "admob_rewarded_cloud_backup_ad_unit_id", "ca-app-pub-3940256099942544/5224354917")
             resValue("string", "admob_banner_ad_unit_id", "ca-app-pub-3940256099942544/6300978111")
             manifestPlaceholders +=
                 mapOf(
@@ -73,7 +74,16 @@ android {
             resValue("string", "admob_app_id", "ca-app-pub-5570932833347277~6079637815")
             resValue(
                 "string",
-                "admob_rewarded_ad_unit_id",
+                "admob_rewarded_bandalart_creation_ad_unit_id",
+                if (useTestAds) {
+                    "ca-app-pub-3940256099942544/5224354917"
+                } else {
+                    "ca-app-pub-5570932833347277/6659503579"
+                },
+            )
+            resValue(
+                "string",
+                "admob_rewarded_cloud_backup_ad_unit_id",
                 if (useTestAds) {
                     "ca-app-pub-3940256099942544/5224354917"
                 } else {

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AdsInitializer.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AdsInitializer.kt
@@ -50,20 +50,24 @@ class AdsInitializer(
                 )
                 MobileAds.putPublisherFirstPartyIdEnabled(false)
 
-                val adUnitId = context.getString(R.string.admob_rewarded_ad_unit_id)
-                runCatching {
-                    RewardedAdPreloader.start(
-                        adUnitId,
-                        PreloadConfiguration(
-                            AdRequest
-                                .Builder(adUnitId)
-                                .setGoogleExtrasBundle(nonPersonalizedAdExtras())
-                                .build(),
-                        ),
-                    )
-                }.onFailure { exception ->
-                    Log.e("AdsInitializer", "Rewarded ad preloader failed to start", exception)
-                    Napier.e("Rewarded ad preloader failed to start", exception, tag = "AdsInitializer")
+                distinctRewardedAdUnitIds(
+                    context.getString(R.string.admob_rewarded_bandalart_creation_ad_unit_id),
+                    context.getString(R.string.admob_rewarded_cloud_backup_ad_unit_id),
+                ).forEach { adUnitId ->
+                    runCatching {
+                        RewardedAdPreloader.start(
+                            adUnitId,
+                            PreloadConfiguration(
+                                AdRequest
+                                    .Builder(adUnitId)
+                                    .setGoogleExtrasBundle(nonPersonalizedAdExtras())
+                                    .build(),
+                            ),
+                        )
+                    }.onFailure { exception ->
+                        Log.e("AdsInitializer", "Rewarded ad preloader failed to start", exception)
+                        Napier.e("Rewarded ad preloader failed to start", exception, tag = "AdsInitializer")
+                    }
                 }
 
                 initialization.complete(true)
@@ -81,3 +85,5 @@ class AdsInitializer(
         return initialization.await()
     }
 }
+
+internal fun distinctRewardedAdUnitIds(vararg adUnitIds: String): Set<String> = adUnitIds.toSet()

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidRewardedAdGateway.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidRewardedAdGateway.kt
@@ -30,6 +30,7 @@ import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdEventCallb
 import com.google.android.libraries.ads.mobile.sdk.rewarded.RewardedAdPreloader
 import com.nexters.bandalart.R
 import com.nexters.bandalart.core.common.RewardedAdGateway
+import com.nexters.bandalart.core.common.RewardedAdPurpose
 import com.nexters.bandalart.core.common.RewardedAdResult
 import java.lang.ref.WeakReference
 import kotlinx.coroutines.CompletableDeferred
@@ -49,84 +50,99 @@ class AndroidRewardedAdGateway(
     private val application = application
     private val mainHandler = Handler(Looper.getMainLooper())
     private val recordingScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val rewardPolicy = AndroidRewardedAdRewardPolicy(recordReward)
     private var resumedActivity = WeakReference<Activity>(null)
-    private val requests = mutableMapOf<Long, CompletableDeferred<RewardedAdResult>>()
-    private val pendingLoadedAds = mutableMapOf<CompletableDeferred<RewardedAdResult>, PendingLoadedAd>()
+    private val requests = mutableMapOf<Long, RewardedAdRequest>()
+    private val pendingLoadedAds = mutableMapOf<RewardedAdRequest, RewardedAd>()
 
     init {
         application.registerActivityLifecycleCallbacks(this)
     }
 
-    override suspend fun show(requestId: Long): RewardedAdResult =
+    override suspend fun show(
+        requestId: Long,
+        purpose: RewardedAdPurpose,
+    ): RewardedAdResult =
         withContext(Dispatchers.Main.immediate) {
             if (!awaitAdsInitialized()) return@withContext RewardedAdResult.FAILED
-            requests
-                .getOrPut(requestId) {
-                    CompletableDeferred<RewardedAdResult>().also { result -> load(requestId, result) }
-                }.await()
+            val request =
+                requests[requestId]
+                    ?: RewardedAdRequest(requestId, purpose).also { newRequest ->
+                        requests[requestId] = newRequest
+                        load(newRequest)
+                    }
+            request.result.await()
         }
 
     override fun consume(requestId: Long) {
         if (Looper.myLooper() == Looper.getMainLooper()) {
-            requests.remove(requestId)
+            consumeOnMain(requestId)
         } else {
-            application.mainExecutor.execute { requests.remove(requestId) }
+            application.mainExecutor.execute { consumeOnMain(requestId) }
         }
     }
 
-    private fun load(
-        requestId: Long,
-        result: CompletableDeferred<RewardedAdResult>,
-    ) {
-        if (resumedActivity.get() == null) {
-            result.complete(RewardedAdResult.FAILED)
-            return
+    private fun consumeOnMain(requestId: Long) {
+        val request = requests[requestId] ?: return
+        when (request.lifecycle.consume()) {
+            RewardedAdConsumeAction.CANCEL -> {
+                requests.remove(requestId, request)
+                pendingLoadedAds.remove(request)
+                request.result.cancel()
+            }
+            RewardedAdConsumeAction.ABANDON_SHOWING,
+            RewardedAdConsumeAction.IGNORE,
+            -> Unit
         }
+    }
 
-        fun finish(rewardedAdResult: RewardedAdResult) {
-            result.complete(rewardedAdResult)
+    private fun load(request: RewardedAdRequest) {
+        if (resumedActivity.get() == null) {
+            finishRequest(request, RewardedAdResult.FAILED)
+            return
         }
 
         val adRequest =
             AdRequest
-                .Builder(application.getString(R.string.admob_rewarded_ad_unit_id))
+                .Builder(application.getString(request.purpose.adUnitResource))
                 .setGoogleExtrasBundle(nonPersonalizedAdExtras())
                 .build()
         val preloadedAd = RewardedAdPreloader.pollAd(adRequest.adUnitId)
         if (preloadedAd != null) {
-            showWhenActivityAvailable(requestId, preloadedAd, result)
+            showWhenActivityAvailable(request, preloadedAd)
             return
         }
         RewardedAd.load(
             adRequest,
             object : AdLoadCallback<RewardedAd> {
                 override fun onAdLoaded(ad: RewardedAd) {
-                    mainHandler.post { showWhenActivityAvailable(requestId, ad, result) }
+                    mainHandler.post { showWhenActivityAvailable(request, ad) }
                 }
 
                 override fun onAdFailedToLoad(adError: LoadAdError) {
-                    mainHandler.post { finish(RewardedAdResult.FAILED) }
+                    mainHandler.post { finishRequest(request, RewardedAdResult.FAILED) }
                 }
             },
         )
     }
 
     private fun showWhenActivityAvailable(
-        requestId: Long,
+        request: RewardedAdRequest,
         ad: RewardedAd,
-        result: CompletableDeferred<RewardedAdResult>,
     ) {
+        if (!isCurrent(request)) return
         val activity = resumedActivity.get()
         if (activity != null) {
-            show(requestId, ad, activity, result::complete)
+            show(request, ad, activity)
             return
         }
 
-        pendingLoadedAds[result] = PendingLoadedAd(requestId, ad)
+        if (!request.lifecycle.tryMarkPendingActivity()) return
+        pendingLoadedAds[request] = ad
         mainHandler.postDelayed(
             {
-                if (pendingLoadedAds.remove(result) != null) {
-                    result.complete(RewardedAdResult.FAILED)
+                if (pendingLoadedAds.remove(request) != null) {
+                    finishRequest(request, RewardedAdResult.FAILED)
                 }
             },
             ACTIVITY_REATTACH_GRACE_PERIOD_MILLIS,
@@ -134,14 +150,14 @@ class AndroidRewardedAdGateway(
     }
 
     private fun show(
-        requestId: Long,
+        request: RewardedAdRequest,
         ad: RewardedAd,
         activity: Activity,
-        finish: (RewardedAdResult) -> Unit,
     ) {
+        if (!isCurrent(request) || !request.lifecycle.tryMarkShowing()) return
         val callbackCoordinator =
             RewardedAdCallbackCoordinator(
-                finish = finish,
+                finish = { result -> finishRequest(request, result) },
                 scheduleDismissed = { action ->
                     mainHandler.postDelayed(action, DISMISS_CALLBACK_GRACE_PERIOD_MILLIS)
                 },
@@ -159,7 +175,9 @@ class AndroidRewardedAdGateway(
         ad.show(activity) {
             mainHandler.post { callbackCoordinator.onRewardRecordingStarted() }
             recordingScope.launch(start = CoroutineStart.UNDISPATCHED) {
-                val recorded = runCatching { recordReward(requestId) }.getOrDefault(false)
+                val recorded =
+                    runCatching { rewardPolicy.complete(request.requestId, request.purpose) }
+                        .getOrDefault(false)
                 withContext(Dispatchers.Main.immediate) {
                     if (recorded) {
                         callbackCoordinator.onRewardEarned()
@@ -175,10 +193,8 @@ class AndroidRewardedAdGateway(
         resumedActivity = WeakReference(activity)
         val adsToShow = pendingLoadedAds.toMap()
         pendingLoadedAds.clear()
-        adsToShow.forEach { (result, pendingAd) ->
-            if (!result.isCompleted) {
-                show(pendingAd.requestId, pendingAd.ad, activity, result::complete)
-            }
+        adsToShow.forEach { (request, ad) ->
+            show(request, ad, activity)
         }
     }
 
@@ -202,15 +218,130 @@ class AndroidRewardedAdGateway(
 
     override fun onActivityDestroyed(activity: Activity) = Unit
 
+    private fun isCurrent(request: RewardedAdRequest): Boolean =
+        requests[request.requestId] === request && request.lifecycle.acceptsPresentationCallbacks
+
+    private fun finishRequest(
+        request: RewardedAdRequest,
+        result: RewardedAdResult,
+    ) {
+        if (requests[request.requestId] !== request) return
+        when (request.lifecycle.finish()) {
+            RewardedAdFinishAction.COMPLETE -> request.result.complete(result)
+            RewardedAdFinishAction.COMPLETE_AND_REMOVE -> {
+                request.result.complete(result)
+                requests.remove(request.requestId, request)
+            }
+            RewardedAdFinishAction.IGNORE -> Unit
+        }
+    }
+
     private companion object {
         const val DISMISS_CALLBACK_GRACE_PERIOD_MILLIS = 1_000L
         const val ACTIVITY_REATTACH_GRACE_PERIOD_MILLIS = 2_000L
     }
 
-    private data class PendingLoadedAd(
+    private class RewardedAdRequest(
         val requestId: Long,
-        val ad: RewardedAd,
-    )
+        val purpose: RewardedAdPurpose,
+    ) {
+        val result = CompletableDeferred<RewardedAdResult>()
+        val lifecycle = RewardedAdRequestLifecycle()
+    }
+}
+
+internal class RewardedAdRequestLifecycle {
+    private var stage = Stage.LOADING
+    private var abandonedWhileShowing = false
+
+    val acceptsPresentationCallbacks: Boolean
+        get() = stage == Stage.LOADING || stage == Stage.PENDING_ACTIVITY
+
+    fun tryMarkPendingActivity(): Boolean {
+        if (stage != Stage.LOADING) return false
+        stage = Stage.PENDING_ACTIVITY
+        return true
+    }
+
+    fun tryMarkShowing(): Boolean {
+        if (stage != Stage.LOADING && stage != Stage.PENDING_ACTIVITY) return false
+        stage = Stage.SHOWING
+        return true
+    }
+
+    fun consume(): RewardedAdConsumeAction =
+        when (stage) {
+            Stage.SHOWING -> {
+                abandonedWhileShowing = true
+                RewardedAdConsumeAction.ABANDON_SHOWING
+            }
+            Stage.CANCELLED -> RewardedAdConsumeAction.IGNORE
+            Stage.LOADING,
+            Stage.PENDING_ACTIVITY,
+            Stage.FINISHED,
+            -> {
+                stage = Stage.CANCELLED
+                RewardedAdConsumeAction.CANCEL
+            }
+        }
+
+    fun finish(): RewardedAdFinishAction =
+        when (stage) {
+            Stage.LOADING,
+            Stage.PENDING_ACTIVITY,
+            Stage.SHOWING,
+            -> {
+                stage = Stage.FINISHED
+                if (abandonedWhileShowing) {
+                    RewardedAdFinishAction.COMPLETE_AND_REMOVE
+                } else {
+                    RewardedAdFinishAction.COMPLETE
+                }
+            }
+            Stage.FINISHED,
+            Stage.CANCELLED,
+            -> RewardedAdFinishAction.IGNORE
+        }
+
+    private enum class Stage {
+        LOADING,
+        PENDING_ACTIVITY,
+        SHOWING,
+        FINISHED,
+        CANCELLED,
+    }
+}
+
+internal enum class RewardedAdConsumeAction {
+    CANCEL,
+    ABANDON_SHOWING,
+    IGNORE,
+}
+
+internal enum class RewardedAdFinishAction {
+    COMPLETE,
+    COMPLETE_AND_REMOVE,
+    IGNORE,
+}
+
+private val RewardedAdPurpose.adUnitResource: Int
+    get() =
+        when (this) {
+            RewardedAdPurpose.BANDALART_CREATION -> R.string.admob_rewarded_bandalart_creation_ad_unit_id
+            RewardedAdPurpose.CLOUD_BACKUP -> R.string.admob_rewarded_cloud_backup_ad_unit_id
+        }
+
+internal class AndroidRewardedAdRewardPolicy(
+    private val recordReward: suspend (Long) -> Boolean,
+) {
+    suspend fun complete(
+        requestId: Long,
+        purpose: RewardedAdPurpose,
+    ): Boolean =
+        when (purpose) {
+            RewardedAdPurpose.BANDALART_CREATION -> recordReward(requestId)
+            RewardedAdPurpose.CLOUD_BACKUP -> true
+        }
 }
 
 internal class RewardedAdCallbackCoordinator(

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/DelegatingRewardedAdGateway.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/DelegatingRewardedAdGateway.kt
@@ -17,12 +17,16 @@
 package com.nexters.bandalart.ads
 
 import com.nexters.bandalart.core.common.RewardedAdGateway
+import com.nexters.bandalart.core.common.RewardedAdPurpose
 import com.nexters.bandalart.core.common.RewardedAdResult
 
 class DelegatingRewardedAdGateway : RewardedAdGateway {
     lateinit var delegate: RewardedAdGateway
 
-    override suspend fun show(requestId: Long): RewardedAdResult = delegate.show(requestId)
+    override suspend fun show(
+        requestId: Long,
+        purpose: RewardedAdPurpose,
+    ): RewardedAdResult = delegate.show(requestId, purpose)
 
     override fun consume(requestId: Long) {
         delegate.consume(requestId)

--- a/androidApp/src/test/kotlin/com/nexters/bandalart/ads/AndroidRewardedAdPolicyTest.kt
+++ b/androidApp/src/test/kotlin/com/nexters/bandalart/ads/AndroidRewardedAdPolicyTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.ads
+
+import com.nexters.bandalart.core.common.RewardedAdPurpose
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AndroidRewardedAdPolicyTest {
+    @Test
+    fun bandalartCreationRecordsTheReward() =
+        runTest {
+            val recordedRequestIds = mutableListOf<Long>()
+            val policy =
+                AndroidRewardedAdRewardPolicy { requestId ->
+                    recordedRequestIds += requestId
+                    true
+                }
+
+            assertTrue(policy.complete(42L, RewardedAdPurpose.BANDALART_CREATION))
+            assertEquals(listOf(42L), recordedRequestIds)
+        }
+
+    @Test
+    fun cloudBackupDoesNotRecordABandalartSlotReward() =
+        runTest {
+            val recordedRequestIds = mutableListOf<Long>()
+            val policy =
+                AndroidRewardedAdRewardPolicy { requestId ->
+                    recordedRequestIds += requestId
+                    true
+                }
+
+            assertTrue(policy.complete(42L, RewardedAdPurpose.CLOUD_BACKUP))
+            assertTrue(recordedRequestIds.isEmpty())
+        }
+
+    @Test
+    fun duplicateAdUnitIdsArePreloadedOnce() {
+        assertEquals(
+            setOf("shared", "other"),
+            distinctRewardedAdUnitIds("shared", "shared", "other"),
+        )
+    }
+
+    @Test
+    fun cancellingALoadingRequestRejectsLateLoadCallbacks() {
+        val lifecycle = RewardedAdRequestLifecycle()
+
+        assertEquals(RewardedAdConsumeAction.CANCEL, lifecycle.consume())
+
+        assertFalse(lifecycle.acceptsPresentationCallbacks)
+        assertFalse(lifecycle.tryMarkPendingActivity())
+        assertFalse(lifecycle.tryMarkShowing())
+        assertEquals(RewardedAdFinishAction.IGNORE, lifecycle.finish())
+    }
+
+    @Test
+    fun cancellingAnActivityPendingRequestPreventsItFromShowingLater() {
+        val lifecycle = RewardedAdRequestLifecycle()
+        assertTrue(lifecycle.tryMarkPendingActivity())
+
+        assertEquals(RewardedAdConsumeAction.CANCEL, lifecycle.consume())
+
+        assertFalse(lifecycle.acceptsPresentationCallbacks)
+        assertFalse(lifecycle.tryMarkShowing())
+        assertEquals(RewardedAdFinishAction.IGNORE, lifecycle.finish())
+    }
+
+    @Test
+    fun abandoningAnAlreadyShowingRequestCompletesAndRemovesIt() {
+        val lifecycle = RewardedAdRequestLifecycle()
+        assertTrue(lifecycle.tryMarkShowing())
+
+        assertEquals(RewardedAdConsumeAction.ABANDON_SHOWING, lifecycle.consume())
+
+        assertEquals(RewardedAdFinishAction.COMPLETE_AND_REMOVE, lifecycle.finish())
+        assertEquals(RewardedAdFinishAction.IGNORE, lifecycle.finish())
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/ads/IosAdsBridge.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/ads/IosAdsBridge.kt
@@ -16,6 +16,7 @@
 
 package com.nexters.bandalart.ads
 
+import com.nexters.bandalart.core.common.RewardedAdPurpose
 import com.nexters.bandalart.core.common.RewardedAdResult
 import platform.UIKit.UIView
 
@@ -25,6 +26,7 @@ interface IosAdsBridge {
 
     fun showRewarded(
         requestId: Long,
+        purpose: RewardedAdPurpose,
         completion: (RewardedAdResult) -> Unit,
     )
 

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/ads/IosRewardedAdGateway.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/ads/IosRewardedAdGateway.kt
@@ -17,6 +17,7 @@
 package com.nexters.bandalart.ads
 
 import com.nexters.bandalart.core.common.RewardedAdGateway
+import com.nexters.bandalart.core.common.RewardedAdPurpose
 import com.nexters.bandalart.core.common.RewardedAdResult
 import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -24,9 +25,12 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 class IosRewardedAdGateway(
     private val adsBridge: IosAdsBridge,
 ) : RewardedAdGateway {
-    override suspend fun show(requestId: Long): RewardedAdResult =
+    override suspend fun show(
+        requestId: Long,
+        purpose: RewardedAdPurpose,
+    ): RewardedAdResult =
         suspendCancellableCoroutine { continuation ->
-            adsBridge.showRewarded(requestId) { result ->
+            adsBridge.showRewarded(requestId, purpose) { result ->
                 if (continuation.isActive) continuation.resume(result)
             }
             continuation.invokeOnCancellation {

--- a/core/common/src/commonMain/kotlin/com/nexters/bandalart/core/common/RewardedAdGateway.kt
+++ b/core/common/src/commonMain/kotlin/com/nexters/bandalart/core/common/RewardedAdGateway.kt
@@ -22,14 +22,25 @@ enum class RewardedAdResult {
     FAILED,
 }
 
+enum class RewardedAdPurpose {
+    BANDALART_CREATION,
+    CLOUD_BACKUP,
+}
+
 interface RewardedAdGateway {
-    suspend fun show(requestId: Long): RewardedAdResult
+    suspend fun show(
+        requestId: Long,
+        purpose: RewardedAdPurpose,
+    ): RewardedAdResult
 
     fun consume(requestId: Long)
 }
 
 object NoOpRewardedAdGateway : RewardedAdGateway {
-    override suspend fun show(requestId: Long): RewardedAdResult = RewardedAdResult.FAILED
+    override suspend fun show(
+        requestId: Long,
+        purpose: RewardedAdPurpose,
+    ): RewardedAdResult = RewardedAdResult.FAILED
 
     override fun consume(requestId: Long) = Unit
 }

--- a/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
@@ -67,6 +67,10 @@
     <string name="backup_status_existing">%1$d BandalArts · backed up %2$s</string>
     <string name="backup_not_supported">Cloud backup is unavailable on this device.</string>
     <string name="backup_now">Back up now</string>
+    <string name="backup_create_confirm_title">Back up to the cloud?</string>
+    <string name="backup_create_confirm_body">To use cloud backup, please watch the ad to the end.</string>
+    <string name="backup_create_confirm">Watch ad and back up</string>
+    <string name="backup_create_cancel">Cancel</string>
     <string name="backup_restore">Restore from backup</string>
     <string name="backup_start_fresh">Start fresh</string>
     <string name="backup_loading">Working…</string>

--- a/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
@@ -67,6 +67,10 @@
     <string name="backup_status_existing">BandalArt %1$d件・%2$sにバックアップ</string>
     <string name="backup_not_supported">この端末ではクラウドバックアップを利用できません。</string>
     <string name="backup_now">今すぐバックアップ</string>
+    <string name="backup_create_confirm_title">クラウドにバックアップしますか？</string>
+    <string name="backup_create_confirm_body">クラウドバックアップを利用するには、広告を最後まで視聴してください。</string>
+    <string name="backup_create_confirm">広告を見てバックアップ</string>
+    <string name="backup_create_cancel">キャンセル</string>
     <string name="backup_restore">バックアップから復元</string>
     <string name="backup_start_fresh">新しく始める</string>
     <string name="backup_loading">処理中です…</string>

--- a/core/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -67,6 +67,10 @@
     <string name="backup_status_existing">반다라트 %1$d개 · %2$s 백업</string>
     <string name="backup_not_supported">이 기기에서는 클라우드 백업을 사용할 수 없어요.</string>
     <string name="backup_now">지금 백업하기</string>
+    <string name="backup_create_confirm_title">클라우드에 백업할까요?</string>
+    <string name="backup_create_confirm_body">클라우드 백업을 위해 광고를 끝까지 시청해 주세요.</string>
+    <string name="backup_create_confirm">광고 보고 백업하기</string>
+    <string name="backup_create_cancel">취소</string>
     <string name="backup_restore">백업에서 복원</string>
     <string name="backup_start_fresh">새로 시작</string>
     <string name="backup_loading">처리 중이에요…</string>

--- a/docs/features/backup/SUPABASE_BACKUP_STRATEGY.md
+++ b/docs/features/backup/SUPABASE_BACKUP_STRATEGY.md
@@ -24,6 +24,8 @@ Android 또는 iOS 동일 기기에서 앱 데이터 삭제 또는 재설치 후
 - `bandalart_count`: 복원 안내에 표시할 반다라트 개수
 - `updated_at`: 마지막 백업 시각
 
+테마 선택값 `themeMode`(`system`, `light`, `dark`)도 `payload` 안의 DataStore 복원 대상에 포함한다. 백업을 불러오면 현재 기기의 테마 선택을 백업 값으로 덮어쓰고 앱에 즉시 반영한다. `themeMode`가 `null`이면 저장된 선택을 지우고 시스템 설정 모드를 사용한다.
+
 테이블 직접 권한은 닫고 `get_device_backup`, `put_device_backup`, `delete_device_backup` RPC만 공개한다. 이 구조는 SSAID 파생 키를 인증 자격 증명으로 사용한다는 한계를 받아들이는 저민감도 MVP이며 원본 SSAID를 저장하거나 로그에 남기지 않는다.
 
 ## 저장소 구성

--- a/fastlane/test/testflight_test_ads_test.rb
+++ b/fastlane/test/testflight_test_ads_test.rb
@@ -54,8 +54,8 @@ unless workflow.include?("IOS_ADS_MODE: ${{ inputs.ios_ads_mode }}")
   raise "Release CD must pass the selected iOS ad mode to Fastlane"
 end
 
-unless workflow.match?(/ios_ads_mode:.*?default: test.*?- test.*?- production/m)
-  raise "Release CD must default to test ads and offer an explicit production mode"
+unless workflow.match?(/ios_ads_mode:.*?default: production.*?- test.*?- production/m)
+  raise "Release CD must default to production ads and offer an explicit test mode"
 end
 
 puts "iOS TestFlight ad mode configuration test passed"

--- a/feature/backup/build.gradle.kts
+++ b/feature/backup/build.gradle.kts
@@ -18,9 +18,11 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
+            implementation(projects.core.common)
             implementation(projects.core.designsystem)
             implementation(projects.core.domain)
             implementation(projects.core.navigation)
+            implementation(projects.core.ui)
             implementation(projects.feature.home)
             implementation(projects.feature.onboarding)
 

--- a/feature/backup/src/androidHostTest/kotlin/com/nexters/bandalart/feature/backup/presenter/CloudBackupPresenterTest.kt
+++ b/feature/backup/src/androidHostTest/kotlin/com/nexters/bandalart/feature/backup/presenter/CloudBackupPresenterTest.kt
@@ -16,6 +16,7 @@
 
 package com.nexters.bandalart.feature.backup.presenter
 
+import com.nexters.bandalart.core.common.RewardedAdResult
 import com.nexters.bandalart.core.domain.backup.BackupMetadata
 import com.nexters.bandalart.core.domain.backup.CloudBackupRepository
 import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
@@ -27,6 +28,7 @@ import com.nexters.bandalart.feature.onboarding.OnboardingScreen
 import com.slack.circuit.test.FakeNavigator
 import com.slack.circuit.test.test
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -69,6 +71,126 @@ class CloudBackupPresenterTest {
                 assertFalse(restored.showRestoreConfirmation)
                 assertEquals(CloudBackupUiState.Result.RESTORED, restored.result)
                 assertEquals(1, repository.restoreCalls)
+            }
+        }
+
+    @Test
+    fun settingsCreateBackupRequiresRewardedAdConfirmation() =
+        runTest {
+            val repository = FakeCloudBackupRepository()
+            val presenter = presenter(CloudBackupScreen.EntryPoint.SETTINGS, repository)
+
+            presenter.test {
+                awaitItem()
+                val state = awaitItem()
+                state.eventSink(CloudBackupUiState.Event.CreateBackup)
+                val confirmation = awaitItem()
+
+                assertTrue(confirmation.showCreateBackupConfirmation)
+                assertEquals(0, repository.createCalls)
+            }
+        }
+
+    @Test
+    fun rewardedAdCreatesBackupExactlyOnce() =
+        runTest {
+            val repository = FakeCloudBackupRepository()
+            val presenter = presenter(CloudBackupScreen.EntryPoint.SETTINGS, repository)
+
+            presenter.test {
+                awaitItem()
+                awaitItem().eventSink(CloudBackupUiState.Event.CreateBackup)
+                val confirmation = awaitItem()
+                confirmation.eventSink(CloudBackupUiState.Event.ConfirmCreateBackup)
+                var awaitingAd = awaitItem()
+                while (awaitingAd.rewardedAdRequestId == null) awaitingAd = awaitItem()
+                val requestId = requireNotNull(awaitingAd.rewardedAdRequestId)
+
+                awaitingAd.eventSink(
+                    CloudBackupUiState.Event.RewardedAdFinished(requestId, RewardedAdResult.REWARDED),
+                )
+                var completed = awaitItem()
+                while (completed.result != CloudBackupUiState.Result.BACKUP_CREATED) completed = awaitItem()
+
+                completed.eventSink(
+                    CloudBackupUiState.Event.RewardedAdFinished(requestId, RewardedAdResult.REWARDED),
+                )
+                yield()
+                assertEquals(1, repository.createCalls)
+            }
+        }
+
+    @Test
+    fun dismissedRewardedAdDoesNotCreateBackup() =
+        runTest {
+            val repository = FakeCloudBackupRepository()
+            val presenter = presenter(CloudBackupScreen.EntryPoint.SETTINGS, repository)
+
+            presenter.test {
+                awaitItem()
+                awaitItem().eventSink(CloudBackupUiState.Event.CreateBackup)
+                val confirmation = awaitItem()
+                confirmation.eventSink(CloudBackupUiState.Event.ConfirmCreateBackup)
+                var awaitingAd = awaitItem()
+                while (awaitingAd.rewardedAdRequestId == null) awaitingAd = awaitItem()
+                val requestId = requireNotNull(awaitingAd.rewardedAdRequestId)
+
+                awaitingAd.eventSink(
+                    CloudBackupUiState.Event.RewardedAdFinished(requestId, RewardedAdResult.DISMISSED),
+                )
+                val dismissed = awaitItem()
+
+                assertEquals(null, dismissed.rewardedAdRequestId)
+                assertEquals(0, repository.createCalls)
+            }
+        }
+
+    @Test
+    fun restoreIsIgnoredWhileRewardedAdIsActive() =
+        runTest {
+            val repository = FakeCloudBackupRepository(existing = BackupMetadata(1, "now"))
+            val presenter = presenter(CloudBackupScreen.EntryPoint.SETTINGS, repository)
+
+            presenter.test {
+                awaitItem()
+                awaitItem().eventSink(CloudBackupUiState.Event.CreateBackup)
+                val confirmation = awaitItem()
+                confirmation.eventSink(CloudBackupUiState.Event.ConfirmCreateBackup)
+                var awaitingAd = awaitItem()
+                while (awaitingAd.rewardedAdRequestId == null) awaitingAd = awaitItem()
+
+                awaitingAd.eventSink(CloudBackupUiState.Event.RestoreBackup)
+                yield()
+
+                expectNoEvents()
+                assertFalse(awaitingAd.showRestoreConfirmation)
+                assertEquals(0, repository.restoreCalls)
+            }
+        }
+
+    @Test
+    fun failedRewardedAdShowsUnavailableMessageAndCreatesBackup() =
+        runTest {
+            val repository = FakeCloudBackupRepository()
+            val presenter = presenter(CloudBackupScreen.EntryPoint.SETTINGS, repository)
+
+            presenter.test {
+                awaitItem()
+                awaitItem().eventSink(CloudBackupUiState.Event.CreateBackup)
+                val confirmation = awaitItem()
+                confirmation.eventSink(CloudBackupUiState.Event.ConfirmCreateBackup)
+                var awaitingAd = awaitItem()
+                while (awaitingAd.rewardedAdRequestId == null) awaitingAd = awaitItem()
+                val requestId = requireNotNull(awaitingAd.rewardedAdRequestId)
+
+                awaitingAd.eventSink(
+                    CloudBackupUiState.Event.RewardedAdFinished(requestId, RewardedAdResult.FAILED),
+                )
+                var completed = awaitItem()
+                while (completed.result != CloudBackupUiState.Result.BACKUP_CREATED) completed = awaitItem()
+
+                assertEquals(CloudBackupUiState.Effect.ShowAdUnavailableSnackbar, completed.effect)
+                assertEquals(1, repository.createCalls)
             }
         }
 
@@ -137,13 +259,18 @@ private class FakeCloudBackupRepository(
     private var existing: BackupMetadata? = null,
 ) : CloudBackupRepository {
     override val isSupported = true
+    var createCalls = 0
     var restoreCalls = 0
 
     override suspend fun hasLocalData(): Boolean = true
 
     override suspend fun findBackup(): BackupMetadata? = existing
 
-    override suspend fun createBackup(): BackupMetadata = BackupMetadata(3, "created").also { existing = it }
+    override suspend fun createBackup(): BackupMetadata =
+        BackupMetadata(3, "created").also {
+            createCalls += 1
+            existing = it
+        }
 
     override suspend fun restoreBackup(): BackupMetadata? {
         restoreCalls += 1

--- a/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/CloudBackupScreenUi.kt
+++ b/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/CloudBackupScreenUi.kt
@@ -39,6 +39,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -48,6 +51,10 @@ import androidx.compose.ui.unit.sp
 import bandalart.core.designsystem.generated.resources.Res
 import bandalart.core.designsystem.generated.resources.backup_back
 import bandalart.core.designsystem.generated.resources.backup_created
+import bandalart.core.designsystem.generated.resources.backup_create_cancel
+import bandalart.core.designsystem.generated.resources.backup_create_confirm
+import bandalart.core.designsystem.generated.resources.backup_create_confirm_body
+import bandalart.core.designsystem.generated.resources.backup_create_confirm_title
 import bandalart.core.designsystem.generated.resources.backup_description
 import bandalart.core.designsystem.generated.resources.backup_error
 import bandalart.core.designsystem.generated.resources.backup_loading
@@ -64,9 +71,15 @@ import bandalart.core.designsystem.generated.resources.backup_start_fresh
 import bandalart.core.designsystem.generated.resources.backup_status_existing
 import bandalart.core.designsystem.generated.resources.backup_status_none
 import bandalart.core.designsystem.generated.resources.backup_title
+import bandalart.core.designsystem.generated.resources.ic_cloud_download
 import bandalart.core.designsystem.generated.resources.ic_history
+import bandalart.core.designsystem.generated.resources.rewarded_ad_unavailable
+import com.nexters.bandalart.core.common.RewardedAdGateway
+import com.nexters.bandalart.core.common.RewardedAdPurpose
+import com.nexters.bandalart.core.common.RewardedAdResult
 import com.nexters.bandalart.core.designsystem.theme.pretendardFontFamily
 import com.nexters.bandalart.core.navigation.CloudBackupScreen
+import com.nexters.bandalart.core.ui.LocalShowSnackbar
 import com.nexters.bandalart.feature.home.ui.bandalart.BandalartActionAlertDialog
 import com.slack.circuit.codegen.annotations.CircuitInject
 import dev.zacsweers.metro.AppScope
@@ -74,15 +87,54 @@ import dev.zacsweers.metro.Inject
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
+
+private const val SNACKBAR_DURATION_MILLIS = 1500L
 
 @CircuitInject(CloudBackupScreen::class, AppScope::class)
 @Inject
 @Composable
 internal fun CloudBackup(
     state: CloudBackupUiState,
+    rewardedAdGateway: RewardedAdGateway,
     modifier: Modifier = Modifier,
 ) {
+    val showSnackbar = LocalShowSnackbar.current
+    val latestEventSink by rememberUpdatedState(state.eventSink)
+    LaunchedEffect(state.rewardedAdRequestId) {
+        val requestId = state.rewardedAdRequestId ?: return@LaunchedEffect
+        try {
+            val result =
+                try {
+                    rewardedAdGateway.show(requestId, RewardedAdPurpose.CLOUD_BACKUP)
+                } catch (exception: CancellationException) {
+                    throw exception
+                } catch (_: Exception) {
+                    RewardedAdResult.FAILED
+                }
+            latestEventSink(CloudBackupUiState.Event.RewardedAdFinished(requestId, result))
+        } finally {
+            rewardedAdGateway.consume(requestId)
+        }
+    }
+    LaunchedEffect(state.effect) {
+        when (state.effect) {
+            CloudBackupUiState.Effect.ShowAdUnavailableSnackbar -> {
+                showSnackbarForDuration(getString(Res.string.rewarded_ad_unavailable), showSnackbar)
+                state.eventSink(CloudBackupUiState.Event.ConsumeEffect)
+            }
+            null -> Unit
+        }
+    }
+
+    if (state.showCreateBackupConfirmation) {
+        CreateBackupConfirmationDialog(state.eventSink)
+    }
     if (state.showRestoreConfirmation) {
         RestoreConfirmationDialog(state.eventSink)
     }
@@ -170,7 +222,7 @@ internal fun CloudBackup(
             if (state.entryPoint == CloudBackupScreen.EntryPoint.SETTINGS) {
                 Button(
                     onClick = { state.eventSink(CloudBackupUiState.Event.CreateBackup) },
-                    enabled = state.isSupported && !state.isLoading,
+                    enabled = state.isSupported && !state.isLoading && state.rewardedAdRequestId == null,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(
@@ -181,7 +233,11 @@ internal fun CloudBackup(
             }
             OutlinedButton(
                 onClick = { state.eventSink(CloudBackupUiState.Event.RestoreBackup) },
-                enabled = state.isSupported && !state.isLoading && state.metadata != null,
+                enabled =
+                    state.isSupported &&
+                        !state.isLoading &&
+                        state.rewardedAdRequestId == null &&
+                        state.metadata != null,
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(
@@ -247,6 +303,31 @@ private fun RestoreConfirmationDialog(eventSink: (CloudBackupUiState.Event) -> U
         onConfirmClick = { eventSink(CloudBackupUiState.Event.ConfirmRestore) },
         onCancelClick = { eventSink(CloudBackupUiState.Event.DismissRestoreConfirmation) },
     )
+}
+
+@Composable
+private fun CreateBackupConfirmationDialog(eventSink: (CloudBackupUiState.Event) -> Unit) {
+    BandalartActionAlertDialog(
+        icon = Res.drawable.ic_cloud_download,
+        iconContentDescription = stringResource(Res.string.backup_now),
+        title = stringResource(Res.string.backup_create_confirm_title),
+        message = stringResource(Res.string.backup_create_confirm_body),
+        confirmLabel = stringResource(Res.string.backup_create_confirm),
+        cancelLabel = stringResource(Res.string.backup_create_cancel),
+        onConfirmClick = { eventSink(CloudBackupUiState.Event.ConfirmCreateBackup) },
+        onCancelClick = { eventSink(CloudBackupUiState.Event.DismissCreateBackupConfirmation) },
+    )
+}
+
+private suspend fun showSnackbarForDuration(
+    message: String,
+    showSnackbar: suspend (String) -> Boolean,
+) {
+    coroutineScope {
+        val snackbarJob = launch { showSnackbar(message) }
+        delay(SNACKBAR_DURATION_MILLIS)
+        snackbarJob.cancel()
+    }
 }
 
 private fun String.toDisplayDateTime(): String =

--- a/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/CloudBackupUiState.kt
+++ b/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/CloudBackupUiState.kt
@@ -17,6 +17,7 @@
 package com.nexters.bandalart.feature.backup
 
 import com.nexters.bandalart.core.domain.backup.BackupMetadata
+import com.nexters.bandalart.core.common.RewardedAdResult
 import com.nexters.bandalart.core.navigation.CloudBackupScreen
 import com.slack.circuit.runtime.CircuitUiEvent
 import com.slack.circuit.runtime.CircuitUiState
@@ -26,7 +27,10 @@ data class CloudBackupUiState(
     val isSupported: Boolean,
     val isLoading: Boolean,
     val metadata: BackupMetadata?,
+    val showCreateBackupConfirmation: Boolean,
     val showRestoreConfirmation: Boolean,
+    val rewardedAdRequestId: Long?,
+    val effect: Effect?,
     val result: Result?,
     val eventSink: (Event) -> Unit,
 ) : CircuitUiState {
@@ -37,10 +41,23 @@ data class CloudBackupUiState(
         ERROR,
     }
 
+    sealed interface Effect {
+        data object ShowAdUnavailableSnackbar : Effect
+    }
+
     sealed interface Event : CircuitUiEvent {
         data object Back : Event
 
         data object CreateBackup : Event
+
+        data object ConfirmCreateBackup : Event
+
+        data object DismissCreateBackupConfirmation : Event
+
+        data class RewardedAdFinished(
+            val requestId: Long,
+            val result: RewardedAdResult,
+        ) : Event
 
         data object RestoreBackup : Event
 
@@ -51,5 +68,7 @@ data class CloudBackupUiState(
         data object StartFresh : Event
 
         data object ConsumeResult : Event
+
+        data object ConsumeEffect : Event
     }
 }

--- a/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/presenter/CloudBackupPresenter.kt
+++ b/feature/backup/src/commonMain/kotlin/com/nexters/bandalart/feature/backup/presenter/CloudBackupPresenter.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import com.nexters.bandalart.core.common.RewardedAdResult
 import com.nexters.bandalart.core.domain.backup.BackupMetadata
 import com.nexters.bandalart.core.domain.backup.CloudBackupRepository
 import com.nexters.bandalart.core.domain.notification.DeadlineReminderReconciler
@@ -40,6 +41,7 @@ import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
+import kotlin.random.Random
 
 @AssistedInject
 class CloudBackupPresenter(
@@ -59,7 +61,11 @@ class CloudBackupPresenter(
             )
         }
         var isLoading by remember { mutableStateOf(screen.entryPoint == CloudBackupScreen.EntryPoint.SETTINGS) }
+        var showCreateBackupConfirmation by remember { mutableStateOf(false) }
         var showRestoreConfirmation by remember { mutableStateOf(false) }
+        // Backup rewards are screen-scoped; recreation cancels the request and requires a retry.
+        var rewardedAdRequestId by remember { mutableStateOf<Long?>(null) }
+        var effect by remember { mutableStateOf<CloudBackupUiState.Effect?>(null) }
         var result by remember { mutableStateOf<CloudBackupUiState.Result?>(null) }
 
         LaunchedEffect(screen.entryPoint, repository.isSupported) {
@@ -115,12 +121,32 @@ class CloudBackupPresenter(
             }
         }
 
+        fun createBackup() {
+            isLoading = true
+            result = null
+            scope.launch {
+                try {
+                    metadata = repository.createBackup()
+                    result = CloudBackupUiState.Result.BACKUP_CREATED
+                } catch (exception: CancellationException) {
+                    throw exception
+                } catch (_: Exception) {
+                    result = CloudBackupUiState.Result.ERROR
+                } finally {
+                    isLoading = false
+                }
+            }
+        }
+
         return CloudBackupUiState(
             entryPoint = screen.entryPoint,
             isSupported = repository.isSupported,
             isLoading = isLoading,
             metadata = metadata,
+            showCreateBackupConfirmation = showCreateBackupConfirmation,
             showRestoreConfirmation = showRestoreConfirmation,
+            rewardedAdRequestId = rewardedAdRequestId,
+            effect = effect,
             result = result,
         ) { event ->
             when (event) {
@@ -128,32 +154,44 @@ class CloudBackupPresenter(
                     if (screen.entryPoint == CloudBackupScreen.EntryPoint.SETTINGS) navigator.pop() else navigateToFallback()
                 }
                 CloudBackupUiState.Event.CreateBackup -> {
-                    isLoading = true
-                    result = null
-                    scope.launch {
-                        try {
-                            metadata = repository.createBackup()
-                            result = CloudBackupUiState.Result.BACKUP_CREATED
-                        } catch (exception: CancellationException) {
-                            throw exception
-                        } catch (_: Exception) {
-                            result = CloudBackupUiState.Result.ERROR
-                        } finally {
-                            isLoading = false
+                    if (!isLoading && rewardedAdRequestId == null) showCreateBackupConfirmation = true
+                }
+                CloudBackupUiState.Event.ConfirmCreateBackup -> {
+                    if (showCreateBackupConfirmation && rewardedAdRequestId == null) {
+                        showCreateBackupConfirmation = false
+                        rewardedAdRequestId = Random.nextLong()
+                    }
+                }
+                CloudBackupUiState.Event.DismissCreateBackupConfirmation -> showCreateBackupConfirmation = false
+                is CloudBackupUiState.Event.RewardedAdFinished -> {
+                    if (event.requestId == rewardedAdRequestId) {
+                        rewardedAdRequestId = null
+                        when (event.result) {
+                            RewardedAdResult.REWARDED -> createBackup()
+                            RewardedAdResult.DISMISSED -> Unit
+                            RewardedAdResult.FAILED -> {
+                                effect = CloudBackupUiState.Effect.ShowAdUnavailableSnackbar
+                                createBackup()
+                            }
                         }
                     }
                 }
                 CloudBackupUiState.Event.RestoreBackup -> {
-                    if (screen.entryPoint == CloudBackupScreen.EntryPoint.SETTINGS) {
-                        showRestoreConfirmation = true
-                    } else {
-                        restore()
+                    if (rewardedAdRequestId == null) {
+                        if (screen.entryPoint == CloudBackupScreen.EntryPoint.SETTINGS) {
+                            showRestoreConfirmation = true
+                        } else {
+                            restore()
+                        }
                     }
                 }
-                CloudBackupUiState.Event.ConfirmRestore -> restore()
+                CloudBackupUiState.Event.ConfirmRestore -> {
+                    if (rewardedAdRequestId == null) restore()
+                }
                 CloudBackupUiState.Event.DismissRestoreConfirmation -> showRestoreConfirmation = false
                 CloudBackupUiState.Event.StartFresh -> navigateToFallback()
                 CloudBackupUiState.Event.ConsumeResult -> result = null
+                CloudBackupUiState.Event.ConsumeEffect -> effect = null
             }
         }
     }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
@@ -57,6 +57,7 @@ import com.nexters.bandalart.core.common.AppVersionProvider
 import com.nexters.bandalart.core.common.BannerAdHost
 import com.nexters.bandalart.core.common.ImageHandlerProvider
 import com.nexters.bandalart.core.common.RewardedAdGateway
+import com.nexters.bandalart.core.common.RewardedAdPurpose
 import com.nexters.bandalart.core.common.RewardedAdResult
 import com.nexters.bandalart.core.common.SupportMailDraft
 import com.nexters.bandalart.core.common.SupportMailLauncher
@@ -110,7 +111,7 @@ internal fun Home(
         val requestId = state.rewardedAdRequestId ?: return@LaunchedEffect
         val result =
             try {
-                rewardedAdGateway.show(requestId)
+                rewardedAdGateway.show(requestId, RewardedAdPurpose.BANDALART_CREATION)
             } catch (exception: CancellationException) {
                 throw exception
             } catch (_: Exception) {

--- a/iosApp/iosApp/IosAdsBridgeImpl.swift
+++ b/iosApp/iosApp/IosAdsBridgeImpl.swift
@@ -26,7 +26,7 @@ private enum AdUnitID {
 #else
     static let banner = "ca-app-pub-5570932833347277/4693940934"
     static let rewardedBandalartCreation = "ca-app-pub-5570932833347277/2754173309"
-    static let rewardedCloudBackup = "ca-app-pub-5570932833347277/2754173309"
+    static let rewardedCloudBackup = "ca-app-pub-5570932833347277/5251786621"
 #endif
 
     static let rewardedUnitIDs = Set([rewardedBandalartCreation, rewardedCloudBackup])
@@ -37,6 +37,8 @@ private enum AdUnitID {
             rewardedBandalartCreation
         case .cloudBackup:
             rewardedCloudBackup
+        default:
+            fatalError("Unsupported rewarded ad purpose")
         }
     }
 }

--- a/iosApp/iosApp/IosAdsBridgeImpl.swift
+++ b/iosApp/iosApp/IosAdsBridgeImpl.swift
@@ -21,11 +21,24 @@ import UIKit
 private enum AdUnitID {
 #if DEBUG || BANDALART_TEST_ADS
     static let banner = "ca-app-pub-3940256099942544/2435281174"
-    static let rewarded = "ca-app-pub-3940256099942544/1712485313"
+    static let rewardedBandalartCreation = "ca-app-pub-3940256099942544/1712485313"
+    static let rewardedCloudBackup = "ca-app-pub-3940256099942544/1712485313"
 #else
     static let banner = "ca-app-pub-5570932833347277/4693940934"
-    static let rewarded = "ca-app-pub-5570932833347277/2754173309"
+    static let rewardedBandalartCreation = "ca-app-pub-5570932833347277/2754173309"
+    static let rewardedCloudBackup = "ca-app-pub-5570932833347277/2754173309"
 #endif
+
+    static let rewardedUnitIDs = Set([rewardedBandalartCreation, rewardedCloudBackup])
+
+    static func rewarded(for purpose: CommonRewardedAdPurpose) -> String {
+        switch purpose {
+        case .bandalartCreation:
+            rewardedBandalartCreation
+        case .cloudBackup:
+            rewardedCloudBackup
+        }
+    }
 }
 
 @MainActor
@@ -33,10 +46,12 @@ final class IosAdsBridgeImpl: NSObject, @preconcurrency IosAdsBridge, FullScreen
     private let bannerViews = NSHashTable<IosBannerAdView>.weakObjects()
 
     private var isInitialized = false
-    private var isRewardedLoading = false
-    private var rewardedAd: RewardedAd?
+    private var loadingRewardedAdUnitIDs = Set<String>()
+    private var rewardedAds: [String: RewardedAd] = [:]
     private var activeRewardedAd: RewardedAd?
+    private var activeRewardedAdUnitID: String?
     private var pendingRequestID: Int64?
+    private var pendingRewardedAdUnitID: String?
     private var pendingCompletion: ((CommonRewardedAdResult) -> Void)?
     private var didEarnReward = false
     private var isRewardedDismissed = false
@@ -51,7 +66,7 @@ final class IosAdsBridgeImpl: NSObject, @preconcurrency IosAdsBridge, FullScreen
                 guard let self else { return }
                 self.isInitialized = true
                 self.bannerViews.allObjects.forEach { $0.loadAdIfNeeded() }
-                self.loadRewardedIfNeeded()
+                AdUnitID.rewardedUnitIDs.forEach { self.loadRewardedIfNeeded(adUnitID: $0) }
             }
         }
     }
@@ -67,6 +82,7 @@ final class IosAdsBridgeImpl: NSObject, @preconcurrency IosAdsBridge, FullScreen
 
     func showRewarded(
         requestId: Int64,
+        purpose: CommonRewardedAdPurpose,
         completion: @escaping (CommonRewardedAdResult) -> Void
     ) {
         guard pendingRequestID == nil, activeRewardedAd == nil else {
@@ -75,6 +91,7 @@ final class IosAdsBridgeImpl: NSObject, @preconcurrency IosAdsBridge, FullScreen
         }
 
         pendingRequestID = requestId
+        pendingRewardedAdUnitID = AdUnitID.rewarded(for: purpose)
         pendingCompletion = completion
         presentRewardedIfReady()
     }
@@ -84,6 +101,7 @@ final class IosAdsBridgeImpl: NSObject, @preconcurrency IosAdsBridge, FullScreen
         pendingCompletion = nil
         if activeRewardedAd == nil {
             pendingRequestID = nil
+            pendingRewardedAdUnitID = nil
         }
     }
 
@@ -113,13 +131,14 @@ final class IosAdsBridgeImpl: NSObject, @preconcurrency IosAdsBridge, FullScreen
 
     private func presentRewardedIfReady() {
         guard isInitialized else { return }
-        guard let rewardedAd else {
-            loadRewardedIfNeeded()
+        guard let pendingRewardedAdUnitID else { return }
+        guard let rewardedAd = rewardedAds.removeValue(forKey: pendingRewardedAdUnitID) else {
+            loadRewardedIfNeeded(adUnitID: pendingRewardedAdUnitID)
             return
         }
 
-        self.rewardedAd = nil
         activeRewardedAd = rewardedAd
+        activeRewardedAdUnitID = pendingRewardedAdUnitID
         didEarnReward = false
         isRewardedDismissed = false
         rewardedAd.present(from: nil) { [weak self] in
@@ -131,29 +150,32 @@ final class IosAdsBridgeImpl: NSObject, @preconcurrency IosAdsBridge, FullScreen
         }
     }
 
-    private func loadRewardedIfNeeded() {
-        guard isInitialized, rewardedAd == nil, activeRewardedAd == nil, !isRewardedLoading else {
+    private func loadRewardedIfNeeded(adUnitID: String) {
+        guard isInitialized,
+              rewardedAds[adUnitID] == nil,
+              activeRewardedAdUnitID != adUnitID,
+              !loadingRewardedAdUnitIDs.contains(adUnitID) else {
             return
         }
 
-        isRewardedLoading = true
+        loadingRewardedAdUnitIDs.insert(adUnitID)
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
                 let ad = try await RewardedAd.load(
-                    with: AdUnitID.rewarded,
+                    with: adUnitID,
                     request: Request()
                 )
                 ad.fullScreenContentDelegate = self
-                self.rewardedAd = ad
-                self.isRewardedLoading = false
-                if self.pendingCompletion != nil {
+                self.rewardedAds[adUnitID] = ad
+                self.loadingRewardedAdUnitIDs.remove(adUnitID)
+                if self.pendingRewardedAdUnitID == adUnitID {
                     self.presentRewardedIfReady()
                 }
             } catch {
-                self.isRewardedLoading = false
+                self.loadingRewardedAdUnitIDs.remove(adUnitID)
                 NSLog("Rewarded ad failed to load: %@", error.localizedDescription)
-                if self.pendingCompletion != nil {
+                if self.pendingRewardedAdUnitID == adUnitID {
                     self.finishRewarded(with: .failed)
                 }
             }
@@ -162,13 +184,18 @@ final class IosAdsBridgeImpl: NSObject, @preconcurrency IosAdsBridge, FullScreen
 
     private func finishRewarded(with result: CommonRewardedAdResult) {
         let completion = pendingCompletion
+        let completedAdUnitID = activeRewardedAdUnitID ?? pendingRewardedAdUnitID
         pendingRequestID = nil
+        pendingRewardedAdUnitID = nil
         pendingCompletion = nil
         activeRewardedAd = nil
+        activeRewardedAdUnitID = nil
         didEarnReward = false
         isRewardedDismissed = false
         completion?(result)
-        loadRewardedIfNeeded()
+        if let completedAdUnitID {
+            loadRewardedIfNeeded(adUnitID: completedAdUnitID)
+        }
     }
 }
 

--- a/scripts/tests/test_play_release_scripts.py
+++ b/scripts/tests/test_play_release_scripts.py
@@ -143,7 +143,23 @@ class ValidateAabTest(unittest.TestCase):
                     "base/resources.pb",
                     validate_play_aab.TEST_REWARDED_ID
                     + validate_play_aab.TEST_BANNER_ID
-                    + validate_play_aab.PRODUCTION_REWARDED_ID
+                    + b"ca-app-pub-5570932833347277/6659503579"
+                    + validate_play_aab.REQUIRED_NAMESPACE[0],
+                )
+
+            with self.assertRaisesRegex(ValueError, "production rewarded ad ID"):
+                validate_play_aab.verify_archive(aab)
+
+    def test_rejects_production_cloud_backup_rewarded_id(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            aab = Path(directory) / "app.aab"
+            with zipfile.ZipFile(aab, "w") as archive:
+                archive.writestr("base/manifest/AndroidManifest.xml", b"manifest")
+                archive.writestr(
+                    "base/resources.pb",
+                    validate_play_aab.TEST_REWARDED_ID
+                    + validate_play_aab.TEST_BANNER_ID
+                    + b"ca-app-pub-5570932833347277/7686378276"
                     + validate_play_aab.REQUIRED_NAMESPACE[0],
                 )
 

--- a/scripts/validate_play_aab.py
+++ b/scripts/validate_play_aab.py
@@ -13,7 +13,10 @@ from pathlib import Path
 
 PACKAGE_NAME = "com.nexters.bandalart"
 TEST_REWARDED_ID = b"ca-app-pub-3940256099942544/5224354917"
-PRODUCTION_REWARDED_ID = b"ca-app-pub-5570932833347277/6659503579"
+PRODUCTION_REWARDED_IDS = (
+    b"ca-app-pub-5570932833347277/6659503579",
+    b"ca-app-pub-5570932833347277/7686378276",
+)
 TEST_BANNER_ID = b"ca-app-pub-3940256099942544/6300978111"
 PRODUCTION_BANNER_ID = b"ca-app-pub-5570932833347277/1215605203"
 ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
@@ -75,7 +78,9 @@ def verify_archive(path: Path) -> None:
                 continue
             content = archive.read(info)
             test_rewarded_id_found = test_rewarded_id_found or TEST_REWARDED_ID in content
-            production_rewarded_id_found = production_rewarded_id_found or PRODUCTION_REWARDED_ID in content
+            production_rewarded_id_found = production_rewarded_id_found or any(
+                ad_unit_id in content for ad_unit_id in PRODUCTION_REWARDED_IDS
+            )
             test_banner_id_found = test_banner_id_found or TEST_BANNER_ID in content
             production_banner_id_found = production_banner_id_found or PRODUCTION_BANNER_ID in content
             required_namespace_found = required_namespace_found or any(


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #355
- Android 운영 광고 수정: #356

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- 클라우드 백업 실행 전 보상형 광고 안내 다이얼로그와 광고 시청 흐름을 추가했습니다.
- 반다라트 생성과 클라우드 백업의 광고 목적을 분리해 백업 광고가 생성 슬롯에 영향을 주지 않도록 했습니다.
- 광고 중복 콜백, 화면 이탈, 백업·복원 동시 실행을 방지했습니다.
- Android와 iOS에 클라우드 백업 전용 운영 광고 단위 ID를 적용했습니다.
- Internal Testing AAB에 테스트 광고 ID가 포함되거나 생성·백업 운영 Rewarded ID 중 하나라도 누락되면 실패하도록 검증을 보강했습니다.
- Kotlin enum을 사용하는 iOS Swift switch에 기본 분기를 추가해 host app CI 컴파일 오류를 수정했습니다.
- iOS TestFlight의 기본 광고 모드를 운영 광고로 변경했습니다.
- 클라우드 백업에 테마 선택값이 포함되고 복원 시 즉시 반영되는 동작을 문서화했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- CloudBackup Presenter 테스트 9개 통과
- Android 광고 정책 및 콜백 테스트 11개 통과
- Home 보상형 광고 회귀 테스트 통과
- iOS TestFlight 광고 모드 회귀 테스트 통과
- Play 배포 검증 스크립트 테스트 12개 통과
- 관련 Spotless, detekt 및 Swift 구문 검사 통과
- GitHub Actions 필수 검사 6개 통과

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

- 별도 첨부 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- Android와 iOS의 클라우드 백업 운영 광고 단위는 기존 반다라트 생성 광고와 분리했습니다.
- #356 정책을 반영해 Android release 광고는 운영 ID로 고정했습니다.