### PR TITLE
docs: AdMob 광고 ID 적용·검증 정책 정리

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 
 ## 현재 기준 가이드
 
+- [AdMob 광고 ID와 운영 검증 가이드](features/ads/ADMOB_AD_ID_POLICY_GUIDE.md)
 - [Compose와 Circuit 상태 수명 가이드](architecture/state/COMPOSE_STATE_LIFETIME_GUIDE.md)
 - [Coordinator 패턴과 현재 적용 위치](architecture/coordinator/COORDINATOR_PATTERN_GUIDE.md)
 - [Compose Multiplatform 마이그레이션 문제 해결](architecture/kmp/COMPOSE_MULTIPLATFORM_MIGRATION_TROUBLESHOOTING.md)
@@ -61,6 +62,7 @@
 
 ### Ads
 
+- [AdMob 광고 ID와 운영 검증 가이드](features/ads/ADMOB_AD_ID_POLICY_GUIDE.md)
 - [Android AdMob 미노출 트러블슈팅](features/ads/ADMOB_ANDROID_TROUBLESHOOTING.md)
 - [AdMob 홈 하단 배너](features/ads/ADMOB_HOME_BANNER_STRATEGY.md)
 - [AdMob 보상형 생성 gate](features/ads/ADMOB_REWARDED_CREATE_GATE_STRATEGY.md)

--- a/docs/features/ads/ADMOB_AD_ID_POLICY_GUIDE.md
+++ b/docs/features/ads/ADMOB_AD_ID_POLICY_GUIDE.md
@@ -1,0 +1,89 @@
+# AdMob 광고 ID와 운영 검증 가이드
+
+## 문서 목적
+
+Android와 iOS 빌드에 Google 테스트 광고 단위 ID와 BandalArt 운영 광고 단위 ID 중 무엇이 들어가는지 정의한다. 배포 채널, 스토어 테스터 계정과 AdMob 테스트 기기를 혼동하지 않고 운영 광고를 안전하게 검증하기 위한 현재 기준이다.
+
+관련 이슈는 [#354](https://github.com/Nexters/BandalArt-KMP/issues/354), [#363](https://github.com/Nexters/BandalArt-KMP/issues/363)이다.
+
+## 광고 ID 선택표
+
+스토어의 테스트 트랙 여부가 광고 ID를 결정하지 않는다. Android는 build type, iOS는 build configuration과 `ios_ads_mode`가 광고 단위 ID를 결정한다.
+
+| 플랫폼 | 빌드·배포 경로 | 광고 단위 ID | 용도와 주의사항 |
+| --- | --- | --- | --- |
+| Android | `debug` | Google 공식 테스트 ID | 로컬 개발과 기능 테스트용이다. 광고를 눌러야 하는 테스트는 이 빌드를 사용한다. |
+| Android | 로컬 `release` | BandalArt 운영 ID | 운영과 같은 요청을 확인하는 빌드다. 실제 광고를 클릭하지 않는다. |
+| Android | Play Internal Testing | BandalArt 운영 ID | Internal도 `release` AAB를 사용한다. 스토어 내부 테스터 여부는 광고 모드를 바꾸지 않는다. |
+| Android | Play Closed/Open/Production | BandalArt 운영 ID | Internal과 같은 release 광고 정책을 사용한다. |
+| iOS | Xcode `Debug` | Google 공식 테스트 ID | `DEBUG` 컴파일 조건으로 테스트 ID를 선택한다. Simulator는 별도로도 자동 테스트 기기다. |
+| iOS | 로컬 `Release` | BandalArt 운영 ID | `BANDALART_TEST_ADS` 조건을 추가하지 않으면 운영 ID를 선택한다. |
+| iOS | TestFlight, `ios_ads_mode=test` | Google 공식 테스트 ID | 광고 클릭·보상 등 기능 검증용이다. `BANDALART_TEST_ADS` 조건을 추가해 아카이브한다. |
+| iOS | TestFlight, `ios_ads_mode=production` | BandalArt 운영 ID | App Store 릴리스 후보 검증용이다. 실제 광고를 클릭하지 않는다. |
+| iOS | App Store | BandalArt 운영 ID | `production` 모드로 올린 TestFlight 빌드만 심사·출시 대상으로 선택한다. |
+
+현재 Release CD의 `ios_ads_mode` 기본값은 `production`이다. 테스트 광고가 필요한 TestFlight를 만들 때만 dispatch 입력을 `test`로 명시한다. 업로드된 바이너리의 광고 모드는 App Store Connect에서 바꿀 수 없다.
+
+## 설정의 기준 파일
+
+문서에 광고 ID 문자열을 복제하지 않고 다음 파일을 단일 기준으로 사용한다.
+
+| 플랫폼 | 기준 파일 | 보장하는 계약 |
+| --- | --- | --- |
+| Android | `androidApp/build.gradle.kts` | Debug의 Google 테스트 App·광고 단위 ID와 release의 BandalArt 운영 App·광고 단위 ID를 정의한다. |
+| Android | `scripts/validate_play_aab.py` | Play에 올릴 AAB에서 프로젝트가 현재 사용하는 Google 테스트 Fixed Banner·Rewarded ID를 거부하고 운영 홈 배너·반다라트 생성 Rewarded·클라우드 백업 Rewarded ID를 모두 요구한다. |
+| iOS | `iosApp/iosApp/IosAdsBridgeImpl.swift` | `DEBUG` 또는 `BANDALART_TEST_ADS` 조건에 따라 Banner와 목적별 Rewarded 광고 단위 ID를 선택한다. |
+| iOS | `fastlane/lib/ios_ads_mode.rb` | `ios_ads_mode=test`일 때만 `BANDALART_TEST_ADS` 조건을 Release archive에 추가한다. |
+| iOS | `.github/workflows/release-cd.yml` | 선택한 `ios_ads_mode`를 Fastlane에 전달한다. 현재 기본값은 `production`이다. |
+
+Google 테스트 광고 단위 ID는 여러 테스트 목적에서 재사용할 수 있지만 운영 ID는 플랫폼과 광고 위치·목적별로 구분한다. Android App ID도 build type에 따라 테스트와 운영으로 나뉜다. iOS의 `GADApplicationIdentifier`는 모든 구성에서 BandalArt 운영 App ID를 사용하며, 실제 테스트·운영 creative 선택은 광고 단위 ID와 테스트 기기 설정으로 구분한다.
+
+## 운영 ID인데 `Test Ad`가 보이는 경우
+
+광고 단위 ID와 기기의 테스트 모드는 독립적이다.
+
+| 광고 단위 ID | 기기 상태 | 예상 결과 |
+| --- | --- | --- |
+| Google 테스트 ID | 모든 기기 | 테스트 광고 |
+| BandalArt 운영 ID | 일반 실기기 | 실제 광고 또는 광고 재고에 따른 no-fill |
+| BandalArt 운영 ID | AdMob에 등록한 테스트 기기 | 테스트 모드 광고 |
+| BandalArt 운영 ID | Android Emulator 또는 iOS Simulator | 자동 테스트 기기로 처리된 광고 |
+
+Play Internal 테스터나 TestFlight 테스터에서 계정을 제거해도 AdMob 테스트 기기 등록은 해제되지 않는다. 운영 빌드에서 `Test Ad`가 보이면 설치 버전과 산출물의 광고 ID를 확인한 다음 AdMob 콘솔의 테스트 기기 목록을 별도로 확인한다.
+
+## 실제 광고를 클릭하면 안 되는 이유
+
+Google은 게시자가 자신의 실제 광고를 클릭해 만든 클릭이나 노출, 한 명 이상의 사용자가 만든 반복 클릭·노출을 무효 트래픽의 예로 든다. 개발자·테스터의 의도가 단순 검증이더라도 운영 광고 클릭은 광고주의 비용과 게시자의 수입을 인위적으로 만들 수 있다.
+
+무효 트래픽은 다음 결과로 이어질 수 있다.
+
+- 예상 수입에서 무효 활동 금액 공제
+- 광고 게재 제한 또는 중지
+- AdMob 계정 정지 또는 사용 중지
+
+따라서 운영 광고는 절대 직접 클릭하지 않고 개발자·테스터 기기에서 반복 노출도 만들지 않는다. 광고 클릭, 보상 완료, dismiss와 callback 검증이 필요하면 Google 테스트 ID를 쓰는 Debug 또는 `ios_ads_mode=test` 빌드, 혹은 AdMob 테스트 기기를 사용한다.
+
+## 안전한 검증 절차
+
+### 개발·기능 검증
+
+1. Android Debug 또는 iOS Debug/TestFlight `test` 모드를 사용한다.
+2. 운영 광고 단위 ID를 함께 검증해야 하면 실기기를 AdMob 테스트 기기로 등록한다.
+3. 배너 클릭, Rewarded 보상·닫기·실패 흐름은 테스트 광고에서만 실행한다.
+
+### 스토어 운영 후보 검증
+
+1. 버전과 build 번호를 기록하고 의도한 release/production 빌드인지 확인한다.
+2. Android는 AAB validator로 현재 정의된 운영 광고 단위 ID 3개가 있고 프로젝트가 사용하는 Google 테스트 Fixed Banner·Rewarded ID가 없는지 검사한다.
+3. 개발자·테스터 실기기는 AdMob 테스트 기기로 등록한 상태에서 요청과 UI만 확인한다. 운영 ID가 들어 있어도 이 기기에는 테스트 모드 광고가 표시되는 것이 정상이다.
+4. 실제 운영 광고 게재와 수익은 개발자 기기에서 인위적으로 만들지 않고, 배포 뒤 자연 사용자 트래픽과 AdMob 보고서 반영으로 확인한다.
+
+Android Play 배포는 `scripts/validate_play_aab.py`가 현재 프로젝트에서 사용하는 테스트 광고 단위 ID 유입과 운영 광고 단위 ID 누락을 업로드 전에 차단한다.
+
+iOS는 현재 IPA 실행 파일 안의 광고 단위 ID를 직접 검사하는 validator가 없다. Release CD 로그의 `IOS_ADS_MODE`와 TestFlight 테스트 메모는 선택한 빌드 의도를 기록하지만 실제 바이너리 내용을 증명하지는 않는다. App Store에는 `production`으로 아카이브한 빌드만 선택하는 수동 운영 정책을 따르고, IPA 광고 단위 ID 검증 자동화는 별도 작업으로 보강한다.
+
+## 공식 참고
+
+- [Google AdMob 무효 트래픽](https://support.google.com/admob/answer/3342054?hl=ko)
+- [Android 테스트 광고 사용](https://developers.google.com/admob/android/test-ads)
+- [iOS 테스트 광고 사용](https://developers.google.com/admob/ios/test-ads)

--- a/docs/features/ads/ADMOB_ANDROID_TROUBLESHOOTING.md
+++ b/docs/features/ads/ADMOB_ANDROID_TROUBLESHOOTING.md
@@ -4,7 +4,7 @@
 
 Play Internal Testing에서 홈 배너와 보상형 광고가 모두 나타나지 않았던 사건의 진단 과정과 재발 방지 절차를 기록한다. 같은 증상이 생기면 광고 크기나 광고 단위 ID부터 바꾸지 말고, 설치 산출물과 SDK 초기화부터 요청·표시까지의 생명주기를 아래 순서로 확인한다.
 
-관련 초기화 이슈는 [#289](https://github.com/Nexters/BandalArt-KMP/issues/289), 최종 원인 수정은 [#297](https://github.com/Nexters/BandalArt-KMP/pull/297)이다. `2.2.26 (20226)`은 당시 Google 테스트 광고 ID로 Internal Testing에 배포해 테스트 creative를 확인했다. 이후 [#354](https://github.com/Nexters/BandalArt-KMP/issues/354)부터는 Internal Testing도 운영 수익 집계를 검증할 수 있도록 release와 같은 운영 광고 ID를 사용한다.
+관련 초기화 이슈는 [#289](https://github.com/Nexters/BandalArt-KMP/issues/289), 최종 원인 수정은 [#297](https://github.com/Nexters/BandalArt-KMP/pull/297)이다. `2.2.26 (20226)`은 당시 Google 테스트 광고 ID로 Internal Testing에 배포해 테스트 creative를 확인했다. 이후 [#354](https://github.com/Nexters/BandalArt-KMP/issues/354)부터는 Internal Testing도 운영 수익 집계를 검증할 수 있도록 release와 같은 운영 광고 ID를 사용한다. 현재 플랫폼·배포 경로별 ID 선택과 클릭 금지 정책은 [AdMob 광고 ID와 운영 검증 가이드](ADMOB_AD_ID_POLICY_GUIDE.md)를 따른다.
 
 ## 사건 요약
 
@@ -82,7 +82,8 @@ unzip -p /tmp/bandalart-base.apk resources.arsc | strings | grep 'ca-app-pub-'
 
 현재 Internal AAB에는 운영 광고 ID가 들어가야 한다.
 
-- Rewarded: `ca-app-pub-5570932833347277/6659503579`
+- Bandalart Creation Rewarded: `ca-app-pub-5570932833347277/6659503579`
+- Cloud Backup Rewarded: `ca-app-pub-5570932833347277/7686378276`
 - Fixed Size Banner: `ca-app-pub-5570932833347277/1215605203`
 
 공식 Google 테스트 광고 단위 ID가 하나라도 들어 있으면 Internal 검증용 산출물로 업로드하지 않는다. Debug 빌드는 계속 공식 테스트 ID를 사용하고, Play에 올리는 release AAB만 운영 ID를 사용한다. Internal 설치본에서는 실제 광고를 클릭하지 않는다.
@@ -190,7 +191,7 @@ Anchored Adaptive 테스트 ID를 Fixed Size Banner 테스트 ID로 맞춘 [#290
 - [ ] fail-open 생성과 광고 성공을 구분했다.
 - [ ] release에서 초기화·preloader·배너 load 실패를 확인할 수 있다.
 - [ ] Presenter의 fail-open, dismiss, exactly-once, 템플릿 보존 테스트가 통과한다.
-- [ ] Internal AAB에는 Rewarded와 Banner 운영 ID가 모두 포함되고 공식 테스트 ID는 포함되지 않는다.
+- [ ] Internal AAB에는 반다라트 생성 Rewarded, 클라우드 백업 Rewarded와 Banner 운영 ID가 모두 포함되고 공식 테스트 ID는 포함되지 않는다.
 - [ ] Debug 빌드에는 공식 테스트 ID만 포함한다.
 - [ ] Internal 실기기에서 실제 광고 응답을 확인하되 광고를 클릭하지 않는다.
 


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #363

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- Android와 iOS의 빌드·배포 경로별 테스트/운영 광고 ID 선택 정책을 표로 정리합니다.
- 스토어 테스터 계정과 AdMob 테스트 기기가 별개임을 설명합니다.
- 운영 광고 직접 클릭과 반복 노출의 무효 트래픽 위험 및 안전한 검증 절차를 문서화합니다.
- Android 트러블슈팅 문서에 클라우드 백업 Rewarded 운영 ID와 최신 정책 링크를 반영합니다.

## 🧪 테스트 내역 (선택)

- [ ] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- Android build type 및 AAB validator 정책 대조: 통과
- iOS 광고 모드와 Release CD 기본값 대조: 통과
- `ruby fastlane/test/testflight_test_ads_test.rb`: 통과
- `python3 -m unittest scripts.tests.test_play_release_scripts`: 12/12 통과
- Markdown 로컬 링크 및 `git diff --check`: 통과
- 독립 문서 리뷰: 승인

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

| 기능 | 미리보기 | 기능 | 미리보기 |
|:---:|:---:|:---:|:---:|
| 해당 없음 | 문서 변경 | 해당 없음 | UI 변경 없음 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- Android validator는 프로젝트가 현재 사용하는 특정 테스트 ID를 차단하고 운영 광고 단위 ID 3개를 요구합니다.
- iOS에는 아직 IPA 내부 광고 단위 ID validator가 없으므로, 로그는 선택 의도를 기록할 뿐 바이너리 내용을 증명하지 않는다고 명시했습니다.
