### PR TITLE
feat: 태스크 빠른 완료 툴팁 추가

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,5 +1,14 @@
 # Third-party notices
 
+## Balloon
+
+- Source: https://github.com/skydoves/Balloon
+- Version: `2.0.0`
+- License: Apache License 2.0 ([local license text](licenses/Apache-2.0.txt))
+- Copyright: skydoves
+
+The application links against Balloon to render Compose Multiplatform tooltips on Android and iOS.
+
 ## Microsoft Fluent UI Emoji
 
 - Source: https://github.com/microsoft/fluentui-emoji

--- a/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
@@ -35,6 +35,7 @@
     <string name="home_sub_cell">Sub Goal</string>
     <string name="home_complete_task_long_click">Complete goal</string>
     <string name="home_uncomplete_task_long_click">Mark goal incomplete</string>
+    <string name="home_task_completion_tooltip">Press and hold a task to complete it instantly.</string>
     <string name="please_input_main_goal">Please enter the main goal first.</string>
     <string name="please_input_sub_goal">Please enter the sub goal first.</string>
 

--- a/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
@@ -35,6 +35,7 @@
     <string name="home_sub_cell">サブ目標</string>
     <string name="home_complete_task_long_click">目標を完了</string>
     <string name="home_uncomplete_task_long_click">目標を未完了に戻す</string>
+    <string name="home_task_completion_tooltip">タスクを長押しすると、すぐに完了できます。</string>
     <string name="please_input_main_goal">先にメイン目標を入力してください。</string>
     <string name="please_input_sub_goal">先にサブ目標を入力してください。</string>
 

--- a/core/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="home_sub_cell">서브목표</string>
     <string name="home_complete_task_long_click">목표 완료</string>
     <string name="home_uncomplete_task_long_click">목표 완료 취소</string>
+    <string name="home_task_completion_tooltip">태스크를 길게 누르면 바로 완료할 수 있어요.</string>
     <string name="please_input_main_goal">메인 목표를 먼저 입력해주세요.</string>
     <string name="please_input_sub_goal">서브 목표를 먼저 입력해주세요.</string>
 

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
 
             implementation(libs.uri.kmp)
+            implementation(libs.balloon)
             implementation(libs.cmptoast)
             implementation(libs.jindong.core)
             implementation(libs.jindong.compose)

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
@@ -355,6 +355,31 @@ class HomePresenterTest {
             }
         }
 
+    @Test
+    fun taskCompletionTooltipIsShownOnlyUntilDismissedInTheHomeSession() =
+        runTest {
+            val repository =
+                FakeBandalartRepository(
+                    initialBandalarts = listOf(bandalart(1L)),
+                    recentBandalartId = 1L,
+                )
+
+            presenter(repository).test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != 1L) state = awaitItem()
+
+                assertTrue(state.showTaskCompletionTooltip)
+
+                state.eventSink(HomeScreen.Event.DismissTaskCompletionTooltip)
+                do {
+                    state = awaitItem()
+                } while (state.showTaskCompletionTooltip)
+
+                assertFalse(state.showTaskCompletionTooltip)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     private fun bandalart(
         id: Long,
         isCompleted: Boolean = false,

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartChartTooltipTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartChartTooltipTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.feature.home.ui.bandalart
+
+import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class BandalartChartTooltipTest {
+    @Test
+    fun firstIncompleteTaskWithContentIsSelectedInChartOrder() {
+        val mainCell =
+            cell(
+                id = 1L,
+                children =
+                    listOf(
+                        cell(
+                            id = 10L,
+                            children =
+                                listOf(
+                                    cell(id = 11L, title = ""),
+                                    cell(id = 12L, title = "완료", isCompleted = true),
+                                    cell(id = 13L, title = "첫 미완료"),
+                                ),
+                        ),
+                        cell(
+                            id = 20L,
+                            children = listOf(cell(id = 21L, title = "다음 미완료")),
+                        ),
+                    ),
+            )
+
+        assertEquals(13L, mainCell.firstIncompleteTaskCellId())
+    }
+
+    @Test
+    fun noTaskIsSelectedWhenEveryTaskIsBlankOrCompleted() {
+        val mainCell =
+            cell(
+                id = 1L,
+                children =
+                    listOf(
+                        cell(
+                            id = 10L,
+                            children =
+                                listOf(
+                                    cell(id = 11L, title = " "),
+                                    cell(id = 12L, title = "완료", isCompleted = true),
+                                ),
+                        ),
+                    ),
+            )
+
+        assertNull(mainCell.firstIncompleteTaskCellId())
+    }
+
+    private fun cell(
+        id: Long,
+        title: String? = null,
+        isCompleted: Boolean = false,
+        children: List<BandalartCellEntity> = emptyList(),
+    ) = BandalartCellEntity(
+        id = id,
+        title = title,
+        isCompleted = isCompleted,
+        children = children,
+    )
+}

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeCircuitScreen.kt
@@ -53,6 +53,7 @@ data object HomeScreen : ParcelableScreen, StaticScreen {
             DeadlineNotificationAuthorizationStatus.UNSUPPORTED,
         val deadlineReminderSchedulingHealth: DeadlineReminderSchedulingHealth = DeadlineReminderSchedulingHealth(),
         val deadlinePermissionRequestId: Long? = null,
+        val showTaskCompletionTooltip: Boolean = false,
         val effect: Effect? = null,
         val eventSink: (Event) -> Unit,
     ) : CircuitUiState
@@ -225,6 +226,8 @@ data object HomeScreen : ParcelableScreen, StaticScreen {
         ) : Event
 
         data object ConsumeEffect : Event
+
+        data object DismissTaskCompletionTooltip : Event
 
         data object OpenSettings : Event
 

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/HomeScreen.kt
@@ -178,6 +178,7 @@ internal fun Home(
         bandalartData = state.bandalartData,
         bandalartCellData = state.bandalartCellData,
         isDropDownMenuOpened = state.isDropDownMenuOpened,
+        showTaskCompletionTooltip = state.showTaskCompletionTooltip,
         isBannerCreativeVisible = state.isBannerCreativeVisible(),
         eventSink = state.eventSink,
         homeGraphicsLayer = homeGraphicsLayer,
@@ -317,6 +318,7 @@ internal fun HomeContent(
     bandalartData: BandalartUiModel?,
     bandalartCellData: BandalartCellEntity?,
     isDropDownMenuOpened: Boolean,
+    showTaskCompletionTooltip: Boolean,
     isBannerCreativeVisible: Boolean,
     eventSink: (HomeScreen.Event) -> Unit,
     homeGraphicsLayer: GraphicsLayer,
@@ -363,6 +365,10 @@ internal fun HomeContent(
                             BandalartChart(
                                 bandalartData = bandalartData,
                                 bandalartCellData = bandalartCellData,
+                                showTaskCompletionTooltip = showTaskCompletionTooltip,
+                                onTaskCompletionTooltipDismissed = {
+                                    eventSink(HomeScreen.Event.DismissTaskCompletionTooltip)
+                                },
                                 onHomeUiAction = eventSink,
                                 modifier =
                                     Modifier
@@ -420,6 +426,7 @@ private fun HomeScreenPreview() {
             bandalartData = dummyBandalartData,
             bandalartCellData = dummyBandalartChartData,
             isDropDownMenuOpened = false,
+            showTaskCompletionTooltip = false,
             isBannerCreativeVisible = true,
             eventSink = {},
             homeGraphicsLayer = rememberGraphicsLayer(),

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -127,6 +127,7 @@ class HomePresenter(
         var deadlinePermissionRequestId by remember { mutableStateOf<Long?>(null) }
         var nextDeadlinePermissionRequestId by remember { mutableStateOf(0L) }
         var enableDeadlineReminderAfterSettings by rememberRetained { mutableStateOf(false) }
+        var hasDismissedTaskCompletionTooltip by rememberRetained { mutableStateOf(false) }
         val scope = rememberCoroutineScope()
         val recentEmojiSaveJobs = remember { mutableListOf<kotlinx.coroutines.Job>() }
         val selectionLoadGeneration = remember { longArrayOf(0L) }
@@ -823,6 +824,15 @@ class HomePresenter(
             deadlineNotificationAuthorizationStatus = deadlineNotificationAuthorizationStatus,
             deadlineReminderSchedulingHealth = deadlineReminderSchedulingHealth,
             deadlinePermissionRequestId = deadlinePermissionRequestId,
+            showTaskCompletionTooltip =
+                !hasDismissedTaskCompletionTooltip &&
+                    bandalartData != null &&
+                    bandalartCellData != null &&
+                    bottomSheet == null &&
+                    dialog == null &&
+                    !isDropDownMenuOpened &&
+                    imageRequest == null &&
+                    rewardedAdRequestId == null,
             effect = effect,
         ) { event ->
             when (event) {
@@ -962,6 +972,9 @@ class HomePresenter(
 
                 is HomeScreen.Event.DeleteCell -> scope.launch { deleteCell(event.cellId) }
                 HomeScreen.Event.ConsumeEffect -> consumeEffect()
+                HomeScreen.Event.DismissTaskCompletionTooltip -> {
+                    hasDismissedTaskCompletionTooltip = true
+                }
                 is HomeScreen.Event.SelectThemeMode -> {
                     scope.launch { settingsRepository.setThemeMode(event.themeMode) }
                 }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartCell.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartCell.kt
@@ -30,11 +30,20 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -42,6 +51,7 @@ import bandalart.core.designsystem.generated.resources.Res
 import bandalart.core.designsystem.generated.resources.add_description
 import bandalart.core.designsystem.generated.resources.complete_description
 import bandalart.core.designsystem.generated.resources.home_main_cell
+import bandalart.core.designsystem.generated.resources.home_task_completion_tooltip
 import bandalart.core.designsystem.generated.resources.home_complete_task_long_click
 import bandalart.core.designsystem.generated.resources.home_uncomplete_task_long_click
 import bandalart.core.designsystem.generated.resources.home_sub_cell
@@ -52,6 +62,10 @@ import com.nexters.bandalart.core.domain.entity.BandalartCellEntity
 import com.nexters.bandalart.feature.home.model.BandalartUiModel
 import com.nexters.bandalart.feature.home.model.CellType
 import com.nexters.bandalart.feature.home.HomeScreen
+import com.skydoves.balloon.ArrowPositionRules
+import com.skydoves.balloon.Balloon
+import com.skydoves.balloon.rememberBalloonBuilder
+import com.skydoves.balloon.rememberBalloonState
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.resources.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -85,6 +99,106 @@ fun BandalartCell(
     outerPadding: Dp = 3.dp,
     innerPadding: Dp = 2.dp,
     mainCellPadding: Dp = 1.dp,
+    showTaskCompletionTooltip: Boolean = false,
+    onTaskCompletionTooltipDismissed: () -> Unit = {},
+) {
+    if (showTaskCompletionTooltip) {
+        TaskCompletionTooltip(
+            anchorKey = cellData.id,
+            onDismiss = onTaskCompletionTooltipDismissed,
+            modifier = modifier,
+        ) {
+            BandalartCellAnchor(
+                bandalartData = bandalartData,
+                cellType = cellType,
+                cellData = cellData,
+                onHomeUiAction = onHomeUiAction,
+                cellInfo = cellInfo,
+                outerPadding = outerPadding,
+                innerPadding = innerPadding,
+                mainCellPadding = mainCellPadding,
+            )
+        }
+    } else {
+        BandalartCellAnchor(
+            bandalartData = bandalartData,
+            cellType = cellType,
+            cellData = cellData,
+            onHomeUiAction = onHomeUiAction,
+            modifier = modifier,
+            cellInfo = cellInfo,
+            outerPadding = outerPadding,
+            innerPadding = innerPadding,
+            mainCellPadding = mainCellPadding,
+        )
+    }
+}
+
+@Composable
+private fun TaskCompletionTooltip(
+    anchorKey: Long,
+    onDismiss: () -> Unit,
+    modifier: Modifier,
+    content: @Composable () -> Unit,
+) {
+    val backgroundColor = MaterialTheme.colorScheme.inverseSurface
+    val contentColor = MaterialTheme.colorScheme.inverseOnSurface
+    val style =
+        rememberBalloonBuilder(key = backgroundColor) {
+            setArrowSize(10.dp)
+            setArrowPositionRules(ArrowPositionRules.ALIGN_ANCHOR)
+            setBackgroundColor(backgroundColor)
+            setCornerRadius(8.dp)
+            setPadding(start = 12.dp, top = 10.dp, end = 12.dp, bottom = 10.dp)
+            setMargin(8.dp)
+            setMaxWidth(280.dp)
+            setDismissWhenClicked(true)
+            setDismissWhenTouchOutside(true)
+            setDismissWhenBackPressed(true)
+            setAutoDismissDuration(0L)
+        }
+    val balloonState = rememberBalloonState(style = style, key = anchorKey)
+    val currentOnDismiss by rememberUpdatedState(onDismiss)
+
+    DisposableEffect(balloonState) {
+        balloonState.onDismiss = { currentOnDismiss() }
+        onDispose {
+            balloonState.dismiss()
+            balloonState.onDismiss = null
+        }
+    }
+    LaunchedEffect(balloonState) {
+        withFrameNanos { }
+        balloonState.showAlignTop()
+    }
+
+    Balloon(
+        state = balloonState,
+        modifier = modifier,
+        key = anchorKey,
+        balloonContent = {
+            Text(
+                text = stringResource(Res.string.home_task_completion_tooltip),
+                color = contentColor,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite },
+            )
+        },
+        content = content,
+    )
+}
+
+@Composable
+private fun BandalartCellAnchor(
+    bandalartData: BandalartUiModel,
+    cellType: CellType,
+    cellData: BandalartCellEntity,
+    onHomeUiAction: (HomeScreen.Event) -> Unit,
+    modifier: Modifier = Modifier,
+    cellInfo: CellInfo,
+    outerPadding: Dp,
+    innerPadding: Dp,
+    mainCellPadding: Dp,
 ) {
     val onLongClick =
         if (

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartCellGrid.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartCellGrid.kt
@@ -38,6 +38,8 @@ fun BandalartCellGrid(
     subCell: SubCell,
     rows: Int,
     cols: Int,
+    tooltipTaskCellId: Long? = null,
+    onTaskCompletionTooltipDismissed: () -> Unit = {},
     onHomeUiAction: (HomeScreen.Event) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -55,6 +57,12 @@ fun BandalartCellGrid(
             ) {
                 repeat(cols) { colIndex ->
                     val isSubCell = rowIndex == subCell.subCellRowIndex && colIndex == subCell.subCellColIndex
+                    val cellData =
+                        if (isSubCell) {
+                            subCell.subCellData!!
+                        } else {
+                            subCell.subCellData!!.children[taskIndex++]
+                        }
                     BandalartCell(
                         modifier = Modifier.weight(1f),
                         bandalartData = bandalartData,
@@ -67,7 +75,9 @@ fun BandalartCellGrid(
                                 colCnt = cols,
                                 rowCnt = rows,
                             ),
-                        cellData = if (isSubCell) subCell.subCellData!! else subCell.subCellData!!.children[taskIndex++],
+                        cellData = cellData,
+                        showTaskCompletionTooltip = cellData.id == tooltipTaskCellId,
+                        onTaskCompletionTooltipDismissed = onTaskCompletionTooltipDismissed,
                         onHomeUiAction = onHomeUiAction,
                     )
                 }

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartChart.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartChart.kt
@@ -48,11 +48,21 @@ import androidx.compose.ui.tooling.preview.Preview
 fun BandalartChart(
     bandalartData: BandalartUiModel,
     bandalartCellData: BandalartCellEntity,
+    showTaskCompletionTooltip: Boolean = false,
+    onTaskCompletionTooltipDismissed: () -> Unit = {},
     onHomeUiAction: (HomeScreen.Event) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     BoxWithConstraints {
         val paddedMaxWidth = remember(maxWidth) { maxWidth - (15.dp * 2) }
+        val tooltipTaskCellId =
+            remember(bandalartCellData, showTaskCompletionTooltip) {
+                if (showTaskCompletionTooltip) {
+                    bandalartCellData.firstIncompleteTaskCellId()
+                } else {
+                    null
+                }
+            }
 
         val subCellList =
             persistentListOf(
@@ -81,6 +91,8 @@ fun BandalartChart(
                             subCell = subCellList[index],
                             rows = subCellList[index].rowCnt,
                             cols = subCellList[index].colCnt,
+                            tooltipTaskCellId = tooltipTaskCellId,
+                            onTaskCompletionTooltipDismissed = onTaskCompletionTooltipDismissed,
                             onHomeUiAction = onHomeUiAction,
                         )
                     }
@@ -133,6 +145,14 @@ fun BandalartChart(
         }
     }
 }
+
+internal fun BandalartCellEntity.firstIncompleteTaskCellId(): Long? =
+    children
+        .asSequence()
+        .flatMap { subCell -> subCell.children.asSequence() }
+        .firstOrNull { taskCell ->
+            !taskCell.title.isNullOrBlank() && !taskCell.isCompleted
+        }?.id
 
 // @ComponentPreview
 @Preview

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ supabase = "3.2.0"
 # Compose & UI
 compose-multiplatform = "1.10.3"
 compose-material-icons = "1.7.3"
+balloon = "2.0.0"
 androidx-core = "1.16.0"
 androidx-datastore = "1.1.4"
 androidx-lifecycle-runtime = "2.9.0-beta01"
@@ -161,6 +162,7 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-util = { group = "androidx.compose.ui", name = "ui-util" }
 androidx-navigation-compose = { group = "org.jetbrains.androidx.navigation", name = "navigation-compose", version.ref = "jetbrains-androidx-navigation" }
 androidx-compose-ui-test = { group = "androidx.compose.ui", name = "ui-test"}
+balloon = { group = "com.github.skydoves", name = "balloon", version.ref = "balloon" }
 
 # Room Database
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "androidx-room" }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #373

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- Balloon 2.0.0을 `feature/home` commonMain에 추가했습니다.
- 처음 확인되는 내용 있는 미완료 태스크 셀에 빠른 완료 툴팁을 연결했습니다.
- 위쪽 배치를 우선하되 공간 부족 시 자동 flip/clamp하고, 화살표는 실제 앵커 셀을 가리키도록 설정했습니다.
- 홈 세션당 한 번만 노출하고 바텀시트·다이얼로그·드롭다운·이미지 처리·보상형 광고와 겹치지 않도록 했습니다.
- 한국어·영어·일본어 문구와 접근성 live region을 추가했습니다.
- Balloon Apache-2.0 제3자 고지를 반영했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `./gradlew :feature:home:testAndroidHostTest`
- `./gradlew :feature:home:compileKotlinIosSimulatorArm64`
- `./gradlew :feature:home:spotlessCheck`

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

- Android/iOS 기기 수동 확인 후 첨부가 필요합니다.

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- 이번 PR은 #373의 1차 권장 대상만 적용하므로 이슈를 닫지 않습니다.
- 노출 정책은 영구 저장 없이 홈 화면 세션당 1회로 제한했습니다.
- 실제 기기에서 화면 가장자리 flip, 다크 모드, TalkBack/VoiceOver 확인이 필요합니다.
