### PR TITLE
fix: 태스크 완료 툴팁 문구와 영속 노출 정책 보완

### DIFF
--- a/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/notification/DefaultDeadlineReminderReconcilerTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/notification/DefaultDeadlineReminderReconcilerTest.kt
@@ -150,6 +150,7 @@ class DefaultDeadlineReminderReconcilerTest {
         override val themeMode: Flow<ThemeMode> = MutableStateFlow(ThemeMode.SYSTEM)
         override val recentEmojis: Flow<List<String>> = MutableStateFlow(emptyList())
         override val deadlineReminderEnabled = MutableStateFlow(false)
+        override val taskCompletionTooltipDismissed: Flow<Boolean> = MutableStateFlow(false)
 
         override suspend fun setThemeMode(themeMode: ThemeMode) = Unit
 
@@ -158,5 +159,7 @@ class DefaultDeadlineReminderReconcilerTest {
         override suspend fun setDeadlineReminderEnabled(enabled: Boolean) {
             deadlineReminderEnabled.value = enabled
         }
+
+        override suspend fun dismissTaskCompletionTooltip() = Unit
     }
 }

--- a/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/repository/SettingsRepositoryTest.kt
+++ b/core/data/src/androidHostTest/kotlin/com/nexters/bandalart/core/data/repository/SettingsRepositoryTest.kt
@@ -37,6 +37,7 @@ class SettingsRepositoryTest {
             every { dataStore.themeMode } returns flowOf("unexpected")
             every { dataStore.recentEmojis } returns flowOf(emptyList())
             every { dataStore.deadlineReminderEnabled } returns flowOf(false)
+            every { dataStore.taskCompletionTooltipDismissed } returns flowOf(false)
 
             val repository = DefaultSettingsRepository(dataStore)
 
@@ -49,6 +50,7 @@ class SettingsRepositoryTest {
             every { dataStore.themeMode } returns flowOf(null)
             every { dataStore.recentEmojis } returns flowOf(emptyList())
             every { dataStore.deadlineReminderEnabled } returns flowOf(false)
+            every { dataStore.taskCompletionTooltipDismissed } returns flowOf(false)
             coEvery { dataStore.setThemeMode(any()) } returns Unit
             val repository = DefaultSettingsRepository(dataStore)
 
@@ -63,6 +65,7 @@ class SettingsRepositoryTest {
             every { dataStore.themeMode } returns flowOf(null)
             every { dataStore.recentEmojis } returns flowOf(listOf("🎯", "🚀"))
             every { dataStore.deadlineReminderEnabled } returns flowOf(false)
+            every { dataStore.taskCompletionTooltipDismissed } returns flowOf(false)
             coEvery { dataStore.addRecentEmoji(any()) } returns Unit
             val repository = DefaultSettingsRepository(dataStore)
 
@@ -78,6 +81,7 @@ class SettingsRepositoryTest {
             every { dataStore.themeMode } returns flowOf(null)
             every { dataStore.recentEmojis } returns flowOf(emptyList())
             every { dataStore.deadlineReminderEnabled } returns flowOf(true)
+            every { dataStore.taskCompletionTooltipDismissed } returns flowOf(false)
             coEvery { dataStore.setDeadlineReminderEnabled(any()) } returns Unit
             val repository = DefaultSettingsRepository(dataStore)
 
@@ -85,5 +89,21 @@ class SettingsRepositoryTest {
             repository.setDeadlineReminderEnabled(false)
 
             coVerify(exactly = 1) { dataStore.setDeadlineReminderEnabled(false) }
+        }
+
+    @Test
+    fun taskCompletionTooltipDismissalIsExposedAndStored() =
+        runTest {
+            every { dataStore.themeMode } returns flowOf(null)
+            every { dataStore.recentEmojis } returns flowOf(emptyList())
+            every { dataStore.deadlineReminderEnabled } returns flowOf(false)
+            every { dataStore.taskCompletionTooltipDismissed } returns flowOf(true)
+            coEvery { dataStore.dismissTaskCompletionTooltip() } returns Unit
+            val repository = DefaultSettingsRepository(dataStore)
+
+            assertEquals(true, repository.taskCompletionTooltipDismissed.first())
+            repository.dismissTaskCompletionTooltip()
+
+            coVerify(exactly = 1) { dataStore.dismissTaskCompletionTooltip() }
         }
 }

--- a/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/repository/DefaultSettingsRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/nexters/bandalart/core/data/repository/DefaultSettingsRepository.kt
@@ -29,6 +29,8 @@ class DefaultSettingsRepository(
         bandalartDataStore.themeMode.map(ThemeMode::fromStorageValue)
     override val recentEmojis: Flow<List<String>> = bandalartDataStore.recentEmojis
     override val deadlineReminderEnabled: Flow<Boolean> = bandalartDataStore.deadlineReminderEnabled
+    override val taskCompletionTooltipDismissed: Flow<Boolean> =
+        bandalartDataStore.taskCompletionTooltipDismissed
 
     override suspend fun setThemeMode(themeMode: ThemeMode) {
         bandalartDataStore.setThemeMode(themeMode.storageValue)
@@ -40,5 +42,9 @@ class DefaultSettingsRepository(
 
     override suspend fun setDeadlineReminderEnabled(enabled: Boolean) {
         bandalartDataStore.setDeadlineReminderEnabled(enabled)
+    }
+
+    override suspend fun dismissTaskCompletionTooltip() {
+        bandalartDataStore.dismissTaskCompletionTooltip()
     }
 }

--- a/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreTest.kt
+++ b/core/datastore/src/androidHostTest/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStoreTest.kt
@@ -108,6 +108,27 @@ class BandalartDataStoreTest {
     }
 
     @Nested
+    @DisplayName("태스크 완료 툴팁 설정 테스트")
+    inner class TaskCompletionTooltipPreferenceTest {
+        @Test
+        @DisplayName("최초에는 툴팁을 노출할 수 있어야 한다")
+        fun taskCompletionTooltipIsNotDismissedByDefault() =
+            runTest {
+                assertFalse(bandalartDataStore.taskCompletionTooltipDismissed.first())
+            }
+
+        @Test
+        @DisplayName("툴팁 비활성화 상태는 DataStore에 영구 저장되어야 한다")
+        fun taskCompletionTooltipDismissalIsStored() =
+            runTest {
+                bandalartDataStore.dismissTaskCompletionTooltip()
+
+                val recreatedDataStore = BandalartDataStore(dataStore)
+                assertTrue(recreatedDataStore.taskCompletionTooltipDismissed.first())
+            }
+    }
+
+    @Nested
     @DisplayName("최근 반다라트 ID 관련 테스트")
     inner class RecentBandalartIdTest {
         @Test

--- a/core/datastore/src/commonMain/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStore.kt
+++ b/core/datastore/src/commonMain/kotlin/com/nexters/bandalart/core/datastore/BandalartDataStore.kt
@@ -42,6 +42,7 @@ class BandalartDataStore(
         private const val THEME_MODE = "theme_mode"
         private const val RECENT_EMOJIS = "recent_emojis"
         private const val DEADLINE_REMINDER_ENABLED = "deadline_reminder_enabled"
+        private const val TASK_COMPLETION_TOOLTIP_DISMISSED_V1 = "task_completion_tooltip_dismissed_v1"
         private const val MAX_BANDALART_SLOTS = "max_bandalart_slots"
         private const val PENDING_REWARDED_REQUEST_ID = "pending_rewarded_request_id"
         private const val PENDING_REWARDED_TARGET_SLOTS = "pending_rewarded_target_slots"
@@ -56,6 +57,8 @@ class BandalartDataStore(
     private val themeModeKey = stringPreferencesKey(THEME_MODE)
     private val recentEmojisKey = stringPreferencesKey(RECENT_EMOJIS)
     private val deadlineReminderEnabledKey = booleanPreferencesKey(DEADLINE_REMINDER_ENABLED)
+    private val taskCompletionTooltipDismissedKey =
+        booleanPreferencesKey(TASK_COMPLETION_TOOLTIP_DISMISSED_V1)
     private val maxBandalartSlotsKey = intPreferencesKey(MAX_BANDALART_SLOTS)
     private val pendingRewardedRequestIdKey = longPreferencesKey(PENDING_REWARDED_REQUEST_ID)
     private val pendingRewardedTargetSlotsKey = intPreferencesKey(PENDING_REWARDED_TARGET_SLOTS)
@@ -216,6 +219,15 @@ class BandalartDataStore(
                 else
                     throw exception
             }.map { preferences -> preferences[deadlineReminderEnabledKey] ?: false }
+
+    val taskCompletionTooltipDismissed =
+        dataStore.data
+            .catch { exception ->
+                if (exception is IOException)
+                    emit(emptyPreferences())
+                else
+                    throw exception
+            }.map { preferences -> preferences[taskCompletionTooltipDismissedKey] ?: false }
 
     val recentBandalartId =
         dataStore.data
@@ -383,6 +395,12 @@ class BandalartDataStore(
     suspend fun setDeadlineReminderEnabled(enabled: Boolean) {
         dataStore.edit { preferences ->
             preferences[deadlineReminderEnabledKey] = enabled
+        }
+    }
+
+    suspend fun dismissTaskCompletionTooltip() {
+        dataStore.edit { preferences ->
+            preferences[taskCompletionTooltipDismissedKey] = true
         }
     }
 

--- a/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-en/strings.xml
@@ -35,7 +35,7 @@
     <string name="home_sub_cell">Sub Goal</string>
     <string name="home_complete_task_long_click">Complete goal</string>
     <string name="home_uncomplete_task_long_click">Mark goal incomplete</string>
-    <string name="home_task_completion_tooltip">Press and hold a task to complete it instantly.</string>
+    <string name="home_task_completion_tooltip">Press and hold a task\nto complete it instantly.</string>
     <string name="please_input_main_goal">Please enter the main goal first.</string>
     <string name="please_input_sub_goal">Please enter the sub goal first.</string>
 

--- a/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values-ja/strings.xml
@@ -35,7 +35,7 @@
     <string name="home_sub_cell">サブ目標</string>
     <string name="home_complete_task_long_click">目標を完了</string>
     <string name="home_uncomplete_task_long_click">目標を未完了に戻す</string>
-    <string name="home_task_completion_tooltip">タスクを長押しすると、すぐに完了できます。</string>
+    <string name="home_task_completion_tooltip">タスクを長押しすると、\nすぐに完了できます。</string>
     <string name="please_input_main_goal">先にメイン目標を入力してください。</string>
     <string name="please_input_sub_goal">先にサブ目標を入力してください。</string>
 

--- a/core/designsystem/src/commonMain/composeResources/values/strings.xml
+++ b/core/designsystem/src/commonMain/composeResources/values/strings.xml
@@ -35,7 +35,7 @@
     <string name="home_sub_cell">서브목표</string>
     <string name="home_complete_task_long_click">목표 완료</string>
     <string name="home_uncomplete_task_long_click">목표 완료 취소</string>
-    <string name="home_task_completion_tooltip">태스크를 길게 누르면 바로 완료할 수 있어요.</string>
+    <string name="home_task_completion_tooltip">태스크를 길게 누르면\n바로 완료할 수 있어요.</string>
     <string name="please_input_main_goal">메인 목표를 먼저 입력해주세요.</string>
     <string name="please_input_sub_goal">서브 목표를 먼저 입력해주세요.</string>
 

--- a/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/repository/SettingsRepository.kt
+++ b/core/domain/src/commonMain/kotlin/com/nexters/bandalart/core/domain/repository/SettingsRepository.kt
@@ -23,10 +23,13 @@ interface SettingsRepository {
     val themeMode: Flow<ThemeMode>
     val recentEmojis: Flow<List<String>>
     val deadlineReminderEnabled: Flow<Boolean>
+    val taskCompletionTooltipDismissed: Flow<Boolean>
 
     suspend fun setThemeMode(themeMode: ThemeMode)
 
     suspend fun addRecentEmoji(emoji: String)
 
     suspend fun setDeadlineReminderEnabled(enabled: Boolean)
+
+    suspend fun dismissTaskCompletionTooltip()
 }

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeSettingsRepository.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/FakeSettingsRepository.kt
@@ -24,18 +24,24 @@ import kotlinx.coroutines.flow.asStateFlow
 class FakeSettingsRepository(
     initialThemeMode: ThemeMode = ThemeMode.SYSTEM,
     initialDeadlineReminderEnabled: Boolean = false,
+    initialTaskCompletionTooltipDismissed: Boolean = false,
     private val beforeRecentEmojiSave: suspend (String) -> Unit = {},
 ) : SettingsRepository {
     private val themeModeState = MutableStateFlow(initialThemeMode)
     private val recentEmojisState = MutableStateFlow<List<String>>(emptyList())
     private val deadlineReminderEnabledState = MutableStateFlow(initialDeadlineReminderEnabled)
+    private val taskCompletionTooltipDismissedState =
+        MutableStateFlow(initialTaskCompletionTooltipDismissed)
 
     override val themeMode = themeModeState.asStateFlow()
     override val recentEmojis = recentEmojisState.asStateFlow()
     override val deadlineReminderEnabled = deadlineReminderEnabledState.asStateFlow()
+    override val taskCompletionTooltipDismissed = taskCompletionTooltipDismissedState.asStateFlow()
 
     val savedThemeModes = mutableListOf<ThemeMode>()
     val savedRecentEmojis = mutableListOf<String>()
+    var taskCompletionTooltipDismissals = 0
+        private set
 
     override suspend fun setThemeMode(themeMode: ThemeMode) {
         savedThemeModes += themeMode
@@ -52,5 +58,10 @@ class FakeSettingsRepository(
 
     override suspend fun setDeadlineReminderEnabled(enabled: Boolean) {
         deadlineReminderEnabledState.value = enabled
+    }
+
+    override suspend fun dismissTaskCompletionTooltip() {
+        taskCompletionTooltipDismissals += 1
+        taskCompletionTooltipDismissedState.value = true
     }
 }

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterQuickCompletionTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterQuickCompletionTest.kt
@@ -36,6 +36,28 @@ import org.junit.jupiter.api.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class HomePresenterQuickCompletionTest {
     @Test
+    fun validLongPressPermanentlyDismissesTooltip() =
+        runTest {
+            val taskCell = cell(id = 12L, title = "매일 걷기")
+            val repository = repositoryWithTasks(taskCell)
+            val settingsRepository = FakeSettingsRepository()
+
+            presenter(repository, settingsRepository).test {
+                var state = awaitLoadedBandalart()
+                while (!state.showTaskCompletionTooltip) state = awaitItem()
+
+                state.eventSink(HomeScreen.Event.ToggleTaskCompletion(taskCell))
+                do {
+                    state = awaitItem()
+                } while (state.effect !is HomeScreen.Effect.PlayTaskCompletionHaptic)
+
+                assertFalse(state.showTaskCompletionTooltip)
+                assertEquals(1, settingsRepository.taskCompletionTooltipDismissals)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun validTaskIsCompletedWithPreservedContentAndOneShotEffect() =
         runTest {
             val taskCell =
@@ -430,14 +452,17 @@ class HomePresenterQuickCompletionTest {
         )
     }
 
-    private fun presenter(repository: FakeBandalartRepository) =
-        HomePresenter(
-            navigator = FakeNavigator(HomeScreen),
-            bandalartRepository = repository,
-            bandalartSlotRepository = FakeBandalartSlotRepository(),
-            inAppUpdateRepository = FakeInAppUpdateRepository(),
-            settingsRepository = FakeSettingsRepository(),
-        )
+    private fun presenter(
+        repository: FakeBandalartRepository,
+        settingsRepository: FakeSettingsRepository =
+            FakeSettingsRepository(initialTaskCompletionTooltipDismissed = true),
+    ) = HomePresenter(
+        navigator = FakeNavigator(HomeScreen),
+        bandalartRepository = repository,
+        bandalartSlotRepository = FakeBandalartSlotRepository(),
+        inAppUpdateRepository = FakeInAppUpdateRepository(),
+        settingsRepository = settingsRepository,
+    )
 
     private suspend fun ReceiveTurbine<HomeScreen.State>.awaitLoadedBandalart(bandalartId: Long = 1L,): HomeScreen.State {
         var state = awaitItem()

--- a/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenterTest.kt
@@ -356,15 +356,16 @@ class HomePresenterTest {
         }
 
     @Test
-    fun taskCompletionTooltipIsShownOnlyUntilDismissedInTheHomeSession() =
+    fun taskCompletionTooltipIsShownOnlyUntilPermanentlyDismissed() =
         runTest {
             val repository =
                 FakeBandalartRepository(
                     initialBandalarts = listOf(bandalart(1L)),
                     recentBandalartId = 1L,
                 )
+            val settingsRepository = FakeSettingsRepository()
 
-            presenter(repository).test {
+            presenter(repository, settingsRepository = settingsRepository).test {
                 var state = awaitItem()
                 while (state.bandalartData?.id != 1L) state = awaitItem()
 
@@ -374,6 +375,15 @@ class HomePresenterTest {
                 do {
                     state = awaitItem()
                 } while (state.showTaskCompletionTooltip)
+
+                assertFalse(state.showTaskCompletionTooltip)
+                assertEquals(1, settingsRepository.taskCompletionTooltipDismissals)
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            presenter(repository, settingsRepository = settingsRepository).test {
+                var state = awaitItem()
+                while (state.bandalartData?.id != 1L) state = awaitItem()
 
                 assertFalse(state.showTaskCompletionTooltip)
                 cancelAndIgnoreRemainingEvents()
@@ -398,12 +408,13 @@ class HomePresenterTest {
     private fun presenter(
         repository: FakeBandalartRepository,
         widgetLaunchTarget: BandalartWidgetLaunchTarget = BufferedBandalartWidgetLaunchTarget(),
+        settingsRepository: FakeSettingsRepository = FakeSettingsRepository(),
     ) = HomePresenter(
         navigator = FakeNavigator(HomeScreen),
         bandalartRepository = repository,
         bandalartSlotRepository = FakeBandalartSlotRepository(),
         inAppUpdateRepository = FakeInAppUpdateRepository(),
-        settingsRepository = FakeSettingsRepository(),
+        settingsRepository = settingsRepository,
         bandalartWidgetLaunchTarget = widgetLaunchTarget,
     )
 

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/presenter/HomePresenter.kt
@@ -118,6 +118,8 @@ class HomePresenter(
         val themeMode by settingsRepository.themeMode.collectAsState(initial = ThemeMode.SYSTEM)
         val recentEmojis by settingsRepository.recentEmojis.collectAsState(initial = emptyList())
         val deadlineReminderEnabled by settingsRepository.deadlineReminderEnabled.collectAsState(initial = false)
+        val taskCompletionTooltipDismissed by
+            settingsRepository.taskCompletionTooltipDismissed.collectAsState(initial = true)
         val deadlineReminderSchedulingHealth by deadlineReminderReconciler.schedulingHealth.collectAsState()
         val pendingDeadlineLaunchId by deadlineNotificationLaunchTarget.pendingBandalartId.collectAsState()
         val pendingWidgetLaunchId by bandalartWidgetLaunchTarget.pendingBandalartId.collectAsState()
@@ -127,7 +129,7 @@ class HomePresenter(
         var deadlinePermissionRequestId by remember { mutableStateOf<Long?>(null) }
         var nextDeadlinePermissionRequestId by remember { mutableStateOf(0L) }
         var enableDeadlineReminderAfterSettings by rememberRetained { mutableStateOf(false) }
-        var hasDismissedTaskCompletionTooltip by rememberRetained { mutableStateOf(false) }
+        var isTaskCompletionTooltipDismissalRequested by remember { mutableStateOf(false) }
         val scope = rememberCoroutineScope()
         val recentEmojiSaveJobs = remember { mutableListOf<kotlinx.coroutines.Job>() }
         val selectionLoadGeneration = remember { longArrayOf(0L) }
@@ -141,6 +143,12 @@ class HomePresenter(
                     previousJob?.join()
                     settingsRepository.addRecentEmoji(emoji)
                 }
+        }
+
+        fun dismissTaskCompletionTooltip() {
+            if (taskCompletionTooltipDismissed || isTaskCompletionTooltipDismissalRequested) return
+            isTaskCompletionTooltipDismissalRequested = true
+            scope.launch { settingsRepository.dismissTaskCompletionTooltip() }
         }
 
         fun emitEffect(newEffect: HomeScreen.Effect) {
@@ -564,6 +572,7 @@ class HomePresenter(
             val currentBandalart = bandalartData ?: return
             val currentCell = bandalartCellData?.findTaskCell(requestedCell.id) ?: return
             if (currentCell.title.isNullOrBlank()) return
+            dismissTaskCompletionTooltip()
             if (!togglingTaskCellIds.add(currentCell.id)) return
             val updatedCompletion = !currentCell.isCompleted
 
@@ -825,7 +834,8 @@ class HomePresenter(
             deadlineReminderSchedulingHealth = deadlineReminderSchedulingHealth,
             deadlinePermissionRequestId = deadlinePermissionRequestId,
             showTaskCompletionTooltip =
-                !hasDismissedTaskCompletionTooltip &&
+                !taskCompletionTooltipDismissed &&
+                    !isTaskCompletionTooltipDismissalRequested &&
                     bandalartData != null &&
                     bandalartCellData != null &&
                     bottomSheet == null &&
@@ -973,7 +983,7 @@ class HomePresenter(
                 is HomeScreen.Event.DeleteCell -> scope.launch { deleteCell(event.cellId) }
                 HomeScreen.Event.ConsumeEffect -> consumeEffect()
                 HomeScreen.Event.DismissTaskCompletionTooltip -> {
-                    hasDismissedTaskCompletionTooltip = true
+                    dismissTaskCompletionTooltip()
                 }
                 is HomeScreen.Event.SelectThemeMode -> {
                     scope.launch { settingsRepository.setThemeMode(event.themeMode) }


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- #373

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- 한국어·영어·일본어 툴팁 문구를 의미 단위 두 줄로 통일했습니다.
- 툴팁 닫기 또는 유효한 태스크 길게 누르기 시 비활성화 상태를 DataStore에 저장합니다.
- 반다라트별이 아닌 앱 전체 최초 1회만 노출되며 Android와 iOS 재실행 후에도 유지됩니다.
- 저장값 로딩 전에는 툴팁을 숨겨 기존 사용자에게 순간적으로 다시 표시되지 않도록 했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `./gradlew :core:datastore:testAndroidHostTest :core:data:testAndroidHostTest :feature:home:testAndroidHostTest`
- `./gradlew :core:datastore:compileKotlinIosSimulatorArm64 :core:data:compileKotlinIosSimulatorArm64 :feature:home:compileKotlinIosSimulatorArm64`
- `./gradlew :core:designsystem:spotlessCheck :core:datastore:spotlessCheck :core:data:spotlessCheck`

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

- Android 내부 테스트와 iOS TestFlight 배포 후 실제 기기에서 확인할 예정입니다.

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- 이번 PR도 #373의 1차 권장 대상 보완 작업이므로 이슈를 닫지 않습니다.
- 툴팁 비활성화 값은 로컬 UI 선호 상태로 취급해 클라우드 백업 대상에는 포함하지 않았습니다.
- 전체 `spotlessCheck`는 현재 `main`에 존재하는 `SuspendCatching.kt`, `CellText.kt` 위반으로 별도 확인이 필요합니다.
