### PR TITLE
feat: Android 종료 다이얼로그에 네이티브 광고 추가

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -59,6 +59,7 @@ android {
             resValue("string", "admob_rewarded_bandalart_creation_ad_unit_id", "ca-app-pub-3940256099942544/5224354917")
             resValue("string", "admob_rewarded_cloud_backup_ad_unit_id", "ca-app-pub-3940256099942544/5224354917")
             resValue("string", "admob_banner_ad_unit_id", "ca-app-pub-3940256099942544/6300978111")
+            resValue("string", "admob_exit_dialog_native_ad_unit_id", "ca-app-pub-3940256099942544/2247696110")
             manifestPlaceholders +=
                 mapOf(
                     "appName" to "@string/app_name_dev",
@@ -74,6 +75,11 @@ android {
             resValue("string", "admob_rewarded_bandalart_creation_ad_unit_id", "ca-app-pub-5570932833347277/6659503579")
             resValue("string", "admob_rewarded_cloud_backup_ad_unit_id", "ca-app-pub-5570932833347277/7686378276")
             resValue("string", "admob_banner_ad_unit_id", "ca-app-pub-5570932833347277/1215605203")
+            resValue(
+                "string",
+                "admob_exit_dialog_native_ad_unit_id",
+                "ca-app-pub-5570932833347277/1778455797",
+            )
             manifestPlaceholders +=
                 mapOf(
                     "appName" to "@string/app_name",
@@ -108,11 +114,13 @@ dependencies {
     implementation(projects.core.data)
     implementation(projects.core.designsystem)
     implementation(projects.core.domain)
+    implementation(projects.feature.home)
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.fragment)
     implementation(libs.androidx.glance.appwidget)
     implementation(libs.androidx.lifecycle.process)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.splash)
     implementation(libs.androidx.profileinstaller)
@@ -122,6 +130,7 @@ dependencies {
     implementation(libs.google.mobile.ads.next.gen)
 
     implementation(libs.cmptoast)
+    implementation(libs.compose.components.resources)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.napier)
     implementation(platform(libs.firebase.bom))

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/BandalartApplication.kt
@@ -24,6 +24,7 @@ import com.google.firebase.Firebase
 import com.google.firebase.initialize
 import com.nexters.bandalart.ads.AdsInitializer
 import com.nexters.bandalart.ads.AndroidBannerAdHost
+import com.nexters.bandalart.ads.AndroidExitDialogHost
 import com.nexters.bandalart.ads.AndroidRewardedAdGateway
 import com.nexters.bandalart.ads.DelegatingRewardedAdGateway
 import com.nexters.bandalart.core.data.backup.BackupApiConfig
@@ -64,10 +65,12 @@ class BandalartApplication : Application() {
 
         val rewardedAdGateway = DelegatingRewardedAdGateway()
         val bannerAdHost = AndroidBannerAdHost(adsInitializer::awaitInitialized)
+        val exitDialogHost = AndroidExitDialogHost(adsInitializer::awaitInitialized)
         appGraph =
             createAndroidAppGraph(
                 application = this,
                 bannerAdHost = bannerAdHost,
+                exitDialogHost = exitDialogHost,
                 rewardedAdGateway = rewardedAdGateway,
                 backupApiConfig =
                     BackupApiConfig(

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidExitDialogHost.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidExitDialogHost.kt
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.ads
+
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalActivity
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.nexters.bandalart.R
+import com.nexters.bandalart.ads.nativead.NativeAdBodyView
+import com.nexters.bandalart.ads.nativead.NativeAdCallToActionView
+import com.nexters.bandalart.ads.nativead.NativeAdChoicesView
+import com.nexters.bandalart.ads.nativead.NativeAdHeadlineView
+import com.nexters.bandalart.ads.nativead.NativeAdMediaView
+import com.nexters.bandalart.ads.nativead.NativeAdViewContainer
+import com.nexters.bandalart.ads.nativead.rememberNativeAdPreloader
+import com.nexters.bandalart.core.common.ExitDialogHost
+import com.nexters.bandalart.core.designsystem.theme.pretendardFontFamily
+import com.nexters.bandalart.feature.home.ui.bandalart.BandalartActionAlertDialog
+
+class AndroidExitDialogHost(
+    private val awaitAdsInitialized: suspend () -> Boolean,
+) : ExitDialogHost {
+    @Composable
+    override fun Content(enabled: Boolean) {
+        val activity = LocalActivity.current ?: return
+        var showDialog by remember { mutableStateOf(false) }
+        var hasEnteredHome by remember { mutableStateOf(false) }
+
+        LaunchedEffect(enabled) {
+            if (enabled) {
+                hasEnteredHome = true
+            } else {
+                showDialog = false
+            }
+        }
+
+        val adPreloader =
+            rememberNativeAdPreloader(
+                adUnitId = activity.getString(R.string.admob_exit_dialog_native_ad_unit_id),
+                awaitAdsInitialized = awaitAdsInitialized,
+                preload = hasEnteredHome,
+            )
+
+        BackHandler(enabled = enabled) {
+            adPreloader.loadIfNeeded()
+            showDialog = true
+        }
+
+        if (enabled && showDialog) {
+            BandalartActionAlertDialog(
+                icon = null,
+                iconContentDescription = null,
+                title = activity.getString(R.string.exit_dialog_title),
+                message = null,
+                confirmLabel = activity.getString(R.string.exit_dialog_confirm),
+                cancelLabel = activity.getString(R.string.exit_dialog_cancel),
+                onConfirmClick = activity::finish,
+                onCancelClick = {
+                    showDialog = false
+                    if (adPreloader.ad != null) adPreloader.recycle()
+                },
+                content =
+                    adPreloader.ad?.let { nativeAd ->
+                        {
+                            NativeAdViewContainer(
+                                nativeAd = nativeAd,
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                ExitDialogNativeAdContent(
+                                    headline = nativeAd.headline.orEmpty(),
+                                    body = nativeAd.body,
+                                    callToAction = nativeAd.callToAction,
+                                    mediaContent = nativeAd.mediaContent,
+                                )
+                            }
+                        }
+                    },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExitDialogNativeAdContent(
+    headline: String,
+    body: String?,
+    callToAction: String?,
+    mediaContent: com.google.android.libraries.ads.mobile.sdk.nativead.MediaContent?,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        NativeAdChoicesView(
+            modifier =
+                Modifier
+                    .align(Alignment.End)
+                    .size(16.dp),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        NativeAdMediaView(
+            mediaContent = mediaContent,
+            modifier =
+                Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .size(192.dp)
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text =
+                    androidx.compose.ui.res
+                        .stringResource(R.string.exit_dialog_ad_label),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontSize = 10.sp,
+                fontFamily = pretendardFontFamily(),
+                fontWeight = FontWeight.W600,
+                modifier =
+                    Modifier
+                        .background(
+                            color = MaterialTheme.colorScheme.surfaceVariant,
+                            shape = RoundedCornerShape(4.dp),
+                        ).padding(horizontal = 6.dp, vertical = 2.dp),
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            NativeAdHeadlineView(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = headline,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    fontSize = 14.sp,
+                    fontFamily = pretendardFontFamily(),
+                    fontWeight = FontWeight.W700,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        if (!body.isNullOrBlank()) {
+            Spacer(modifier = Modifier.height(4.dp))
+            NativeAdBodyView(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = body,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    fontSize = 12.sp,
+                    fontFamily = pretendardFontFamily(),
+                )
+            }
+        }
+        if (!callToAction.isNullOrBlank()) {
+            Spacer(modifier = Modifier.height(12.dp))
+            NativeAdCallToActionView(
+                rippleColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+                cornerRadius = 12.dp,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(44.dp)
+                            .border(
+                                width = 1.dp,
+                                color = MaterialTheme.colorScheme.outlineVariant,
+                                shape = RoundedCornerShape(12.dp),
+                            ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = callToAction,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontSize = 14.sp,
+                        fontFamily = pretendardFontFamily(),
+                        fontWeight = FontWeight.W600,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/NativeAdPreloader.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/NativeAdPreloader.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.ads.nativead
+
+import androidx.compose.runtime.Stable
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
+
+@Stable
+internal class NativeAdPreloader(
+    private val state: NativeAdState,
+    private val requestAd: (NativeAdLoaderCallback) -> Unit,
+    private val dispatchCallback: (() -> Unit) -> Unit,
+    private val onAdFailedToLoad: (LoadAdError) -> Unit,
+) {
+    private var destroyed = false
+    private var loadingEnabled = false
+    private var loading = false
+    private var generation = 0L
+
+    val ad: NativeAd?
+        get() = state.ad
+
+    fun enableLoading() {
+        if (destroyed) return
+        loadingEnabled = true
+        loadIfNeeded()
+    }
+
+    fun loadIfNeeded() {
+        if (destroyed || !loadingEnabled || loading) return
+        if (state.isExpired()) state.clear()
+        if (state.ad != null) return
+
+        loading = true
+        val requestGeneration = ++generation
+        requestAd(
+            object : NativeAdLoaderCallback {
+                private var completed = false
+                private var returnedAd: NativeAd? = null
+
+                override fun onNativeAdLoaded(nativeAd: NativeAd) {
+                    dispatchCallback {
+                        if (returnedAd === nativeAd) return@dispatchCallback
+                        returnedAd = nativeAd
+                        if (completed || destroyed || requestGeneration != generation) {
+                            nativeAd.destroy()
+                            return@dispatchCallback
+                        }
+                        completed = true
+                        loading = false
+                        state.store(nativeAd)
+                    }
+                }
+
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    dispatchCallback {
+                        if (completed || destroyed || requestGeneration != generation) return@dispatchCallback
+                        completed = true
+                        loading = false
+                        onAdFailedToLoad(adError)
+                    }
+                }
+            },
+        )
+    }
+
+    fun recycle() {
+        if (destroyed) return
+        state.clear()
+        loadIfNeeded()
+    }
+
+    fun destroy() {
+        if (destroyed) return
+        destroyed = true
+        generation++
+        state.clear()
+    }
+}

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/NativeAdState.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/NativeAdState.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.ads.nativead
+
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+
+@Stable
+internal class NativeAdState(
+    ttlMillis: Long,
+    elapsedRealtime: () -> Long,
+) {
+    private var loadedAtMillis: Long = 0
+
+    var ad: NativeAd? by mutableStateOf(null)
+        private set
+
+    private val ttlMillis = ttlMillis
+    private val elapsedRealtime = elapsedRealtime
+
+    fun store(newAd: NativeAd) {
+        ad?.destroy()
+        ad = newAd
+        loadedAtMillis = elapsedRealtime()
+    }
+
+    fun clear() {
+        ad?.destroy()
+        ad = null
+    }
+
+    fun remainingMillis(): Long {
+        if (ad == null) return 0
+        return (loadedAtMillis + ttlMillis - elapsedRealtime()).coerceAtLeast(0)
+    }
+
+    fun isExpired(): Boolean = ad != null && remainingMillis() == 0L
+}

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/NativeAdViewContainer.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/NativeAdViewContainer.kt
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.ads.nativead
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.RippleDrawable
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.ImageView
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCompositionContext
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.libraries.ads.mobile.sdk.common.AdChoicesView
+import com.google.android.libraries.ads.mobile.sdk.nativead.MediaContent
+import com.google.android.libraries.ads.mobile.sdk.nativead.MediaView
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView
+
+private class NativeAdScope(
+    val nativeAdView: NativeAdView,
+    val onMediaViewCreated: (MediaView) -> Unit,
+)
+
+private val LocalNativeAdScope = staticCompositionLocalOf<NativeAdScope?> { null }
+
+@Composable
+internal fun NativeAdViewContainer(
+    nativeAd: NativeAd,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val nativeAdViewRef = remember { mutableStateOf<NativeAdView?>(null) }
+    var mediaView by remember { mutableStateOf<MediaView?>(null) }
+    val parentCompositionContext = rememberCompositionContext()
+    val currentContent by rememberUpdatedState(content)
+
+    AndroidView(
+        factory = { context ->
+            val composeView =
+                ComposeView(context).apply {
+                    layoutParams =
+                        ViewGroup.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.WRAP_CONTENT,
+                        )
+                }
+            NativeAdView(context).apply {
+                layoutParams =
+                    ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                    )
+                addView(composeView)
+                nativeAdViewRef.value = this
+            }
+        },
+        modifier = modifier,
+        update = { nativeAdView ->
+            val composeView = nativeAdView.getChildAt(0) as? ComposeView ?: return@AndroidView
+            composeView.setParentCompositionContext(parentCompositionContext)
+            composeView.setContent {
+                val scope =
+                    remember(nativeAdView) {
+                        NativeAdScope(nativeAdView) { view -> mediaView = view }
+                    }
+                CompositionLocalProvider(LocalNativeAdScope provides scope) {
+                    currentContent()
+                }
+            }
+        },
+    )
+
+    val currentNativeAd by rememberUpdatedState(nativeAd)
+    SideEffect {
+        nativeAdViewRef.value?.registerNativeAd(currentNativeAd, mediaView)
+    }
+}
+
+@Composable
+internal fun NativeAdHeadlineView(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    NativeAdAssetView(modifier, content) { adView, view -> adView.headlineView = view }
+}
+
+@Composable
+internal fun NativeAdBodyView(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    NativeAdAssetView(modifier, content) { adView, view -> adView.bodyView = view }
+}
+
+@Composable
+internal fun NativeAdCallToActionView(
+    rippleColor: Color,
+    cornerRadius: Dp,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    if (LocalInspectionMode.current) {
+        Box(modifier) { content() }
+        return
+    }
+    val scope = requireNativeAdScope()
+    NativeAdRippleAssetView(
+        rippleColor = rippleColor,
+        cornerRadius = cornerRadius,
+        register = { view -> scope.nativeAdView.callToActionView = view },
+        modifier = modifier,
+        content = content,
+    )
+}
+
+@Composable
+internal fun NativeAdMediaView(
+    mediaContent: MediaContent?,
+    modifier: Modifier = Modifier,
+) {
+    if (LocalInspectionMode.current) {
+        Box(modifier)
+        return
+    }
+    val scope = requireNativeAdScope()
+    AndroidView(
+        factory = { context ->
+            MediaView(context).apply {
+                imageScaleType = ImageView.ScaleType.FIT_CENTER
+                scope.onMediaViewCreated(this)
+            }
+        },
+        modifier = modifier,
+        update = { view -> mediaContent?.let { view.mediaContent = it } },
+    )
+}
+
+@Composable
+internal fun NativeAdChoicesView(modifier: Modifier = Modifier) {
+    if (LocalInspectionMode.current) {
+        Box(modifier)
+        return
+    }
+    val scope = requireNativeAdScope()
+    AndroidView(
+        factory = { context -> AdChoicesView(context) },
+        modifier = modifier,
+        update = { view -> scope.nativeAdView.adChoicesView = view },
+    )
+}
+
+@Composable
+private fun NativeAdAssetView(
+    modifier: Modifier,
+    content: @Composable () -> Unit,
+    register: (NativeAdView, ComposeView) -> Unit,
+) {
+    if (LocalInspectionMode.current) {
+        Box(modifier) { content() }
+        return
+    }
+    val scope = requireNativeAdScope()
+    val parentCompositionContext = rememberCompositionContext()
+    val currentContent by rememberUpdatedState(content)
+    AndroidView(
+        factory = { context -> ComposeView(context) },
+        modifier = modifier,
+        update = { view ->
+            register(scope.nativeAdView, view)
+            view.setParentCompositionContext(parentCompositionContext)
+            view.setContent { currentContent() }
+        },
+    )
+}
+
+@Composable
+private fun NativeAdRippleAssetView(
+    rippleColor: Color,
+    cornerRadius: Dp,
+    register: (View) -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val parentCompositionContext = rememberCompositionContext()
+    val currentContent by rememberUpdatedState(content)
+    val radiusPx = with(LocalDensity.current) { cornerRadius.toPx() }
+    val ripple =
+        remember(rippleColor, radiusPx) {
+            RippleDrawable(
+                ColorStateList.valueOf(rippleColor.toArgb()),
+                null,
+                GradientDrawable().apply {
+                    setColor(Color.White.toArgb())
+                    this.cornerRadius = radiusPx
+                },
+            )
+        }
+    AndroidView(
+        factory = { context ->
+            NativeAdRippleLayout(context).apply {
+                addView(
+                    ComposeView(context),
+                    FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ),
+                )
+            }
+        },
+        modifier = modifier,
+        update = { view ->
+            view.foreground = ripple
+            register(view)
+            val composeView = view.getChildAt(0) as ComposeView
+            composeView.setParentCompositionContext(parentCompositionContext)
+            composeView.setContent { currentContent() }
+        },
+    )
+}
+
+private class NativeAdRippleLayout(
+    context: Context
+) : FrameLayout(context) {
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                foreground?.setHotspot(event.x, event.y)
+                isPressed = true
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                if (event.x < 0 || event.x >= width || event.y < 0 || event.y >= height) {
+                    isPressed = false
+                }
+            }
+
+            MotionEvent.ACTION_UP,
+            MotionEvent.ACTION_CANCEL,
+            -> isPressed = false
+        }
+        return super.dispatchTouchEvent(event)
+    }
+}
+
+@Composable
+private fun requireNativeAdScope(): NativeAdScope =
+    checkNotNull(LocalNativeAdScope.current) {
+        "Native ad assets must be placed inside NativeAdViewContainer."
+    }

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/RememberNativeAdPreloader.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/RememberNativeAdPreloader.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.ads.nativead
+
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
+import com.nexters.bandalart.ads.nonPersonalizedAdExtras
+import io.github.aakira.napier.Napier
+import kotlin.time.Duration.Companion.hours
+
+@Composable
+internal fun rememberNativeAdPreloader(
+    adUnitId: String,
+    awaitAdsInitialized: suspend () -> Boolean,
+    preload: Boolean,
+): NativeAdPreloader {
+    val state =
+        remember(adUnitId) {
+            NativeAdState(
+                ttlMillis = 1.hours.inWholeMilliseconds,
+                elapsedRealtime = SystemClock::elapsedRealtime,
+            )
+        }
+    val previewPreloader =
+        remember(state) {
+            NativeAdPreloader(
+                state = state,
+                requestAd = {},
+                dispatchCallback = {},
+                onAdFailedToLoad = {},
+            )
+        }
+    if (LocalInspectionMode.current) return previewPreloader
+
+    var isAdsInitialized by remember(adUnitId) { mutableStateOf(false) }
+    LaunchedEffect(adUnitId, preload) {
+        if (preload && adUnitId.isNotBlank() && !isAdsInitialized) {
+            isAdsInitialized = awaitAdsInitialized()
+        }
+    }
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val preloader =
+        remember(state, lifecycleOwner, adUnitId) {
+            val handler = Handler(Looper.getMainLooper())
+            NativeAdPreloader(
+                state = state,
+                requestAd = { callback ->
+                    NativeAdLoader.load(
+                        NativeAdRequest
+                            .Builder(adUnitId, listOf(NativeAd.NativeAdType.NATIVE))
+                            .setGoogleExtrasBundle(nonPersonalizedAdExtras())
+                            .build(),
+                        callback,
+                    )
+                },
+                dispatchCallback = { callback -> handler.post(callback) },
+                onAdFailedToLoad = { error ->
+                    Napier.w(
+                        "Exit dialog native ad failed to load: $error",
+                        tag = "NativeAd",
+                    )
+                },
+            )
+        }
+
+    LifecycleResumeEffect(preloader, preload, isAdsInitialized) {
+        if (isAdsInitialized && preload) preloader.enableLoading()
+        onPauseOrDispose {}
+    }
+
+    DisposableEffect(preloader, lifecycleOwner) {
+        val observer =
+            LifecycleEventObserver { _, event ->
+                if (event == Lifecycle.Event.ON_DESTROY) preloader.destroy()
+            }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+            preloader.destroy()
+        }
+    }
+
+    return preloader
+}

--- a/androidApp/src/main/res/values-en/strings.xml
+++ b/androidApp/src/main/res/values-en/strings.xml
@@ -23,4 +23,8 @@
     <string name="bandalart_widget_config_unnamed_subgoal">Untitled sub-goal</string>
     <string name="bandalart_widget_config_saving">Saving…</string>
     <string name="bandalart_widget_config_save">Show in widget</string>
+    <string name="exit_dialog_title">Exit the app?</string>
+    <string name="exit_dialog_confirm">Exit</string>
+    <string name="exit_dialog_cancel">Cancel</string>
+    <string name="exit_dialog_ad_label">Ad</string>
 </resources>

--- a/androidApp/src/main/res/values-ja/strings.xml
+++ b/androidApp/src/main/res/values-ja/strings.xml
@@ -23,4 +23,8 @@
     <string name="bandalart_widget_config_unnamed_subgoal">名前のないサブ目標</string>
     <string name="bandalart_widget_config_saving">保存中…</string>
     <string name="bandalart_widget_config_save">ウィジェットに表示</string>
+    <string name="exit_dialog_title">アプリを終了しますか？</string>
+    <string name="exit_dialog_confirm">終了</string>
+    <string name="exit_dialog_cancel">キャンセル</string>
+    <string name="exit_dialog_ad_label">広告</string>
 </resources>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -24,4 +24,8 @@
     <string name="bandalart_widget_config_unnamed_subgoal">이름 없는 세부 목표</string>
     <string name="bandalart_widget_config_saving">저장 중…</string>
     <string name="bandalart_widget_config_save">위젯에 표시</string>
+    <string name="exit_dialog_title">앱을 종료하시겠어요?</string>
+    <string name="exit_dialog_confirm">종료</string>
+    <string name="exit_dialog_cancel">취소</string>
+    <string name="exit_dialog_ad_label">광고</string>
 </resources>

--- a/androidApp/src/test/kotlin/com/nexters/bandalart/ads/nativead/NativeAdPreloaderTest.kt
+++ b/androidApp/src/test/kotlin/com/nexters/bandalart/ads/nativead/NativeAdPreloaderTest.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.ads.nativead
+
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class NativeAdPreloaderTest {
+    private class Fixture(
+        private val dispatch: (() -> Unit) -> Unit = { it() },
+    ) {
+        var elapsedRealtime = 0L
+        val requests = mutableListOf<NativeAdLoaderCallback>()
+        val state = NativeAdState(ttlMillis = 3_600_000L) { elapsedRealtime }
+        val preloader =
+            NativeAdPreloader(
+                state = state,
+                requestAd = requests::add,
+                dispatchCallback = dispatch,
+                onAdFailedToLoad = {},
+            )
+
+        fun succeed(ad: NativeAd = mockk(relaxed = true)): NativeAd {
+            requests.last().onNativeAdLoaded(ad)
+            return ad
+        }
+    }
+
+    @Test
+    fun repeatedPreloadKeepsOnlyOneRequestAndCachedAd() {
+        val fixture = Fixture()
+
+        fixture.preloader.enableLoading()
+        fixture.preloader.loadIfNeeded()
+        val ad = fixture.succeed()
+        fixture.preloader.enableLoading()
+
+        assertEquals(1, fixture.requests.size)
+        assertSame(ad, fixture.preloader.ad)
+    }
+
+    @Test
+    fun recyclingDisplayedAdDestroysItAndPreloadsTheNextOne() {
+        val fixture = Fixture()
+        fixture.preloader.enableLoading()
+        val ad = fixture.succeed()
+
+        fixture.preloader.recycle()
+
+        verify(exactly = 1) { ad.destroy() }
+        assertNull(fixture.preloader.ad)
+        assertEquals(2, fixture.requests.size)
+    }
+
+    @Test
+    fun expiredCachedAdIsReplacedWhenItIsNextNeeded() {
+        val fixture = Fixture()
+        fixture.preloader.enableLoading()
+        val ad = fixture.succeed()
+        fixture.elapsedRealtime = 3_600_000L
+
+        fixture.preloader.loadIfNeeded()
+
+        verify(exactly = 1) { ad.destroy() }
+        assertNull(fixture.preloader.ad)
+        assertEquals(2, fixture.requests.size)
+    }
+
+    @Test
+    fun delayedAdAfterDestroyIsReleasedInsteadOfStored() {
+        val pendingCallbacks = mutableListOf<() -> Unit>()
+        val fixture = Fixture(dispatch = pendingCallbacks::add)
+        val ad = mockk<NativeAd>(relaxed = true)
+        fixture.preloader.enableLoading()
+        fixture.requests.single().onNativeAdLoaded(ad)
+
+        fixture.preloader.destroy()
+        pendingCallbacks.single().invoke()
+
+        assertNull(fixture.preloader.ad)
+        verify(exactly = 1) { ad.destroy() }
+    }
+}

--- a/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/di/metro/AppGraphTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/nexters/bandalart/di/metro/AppGraphTest.kt
@@ -19,6 +19,7 @@ package com.nexters.bandalart.di.metro
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.nexters.bandalart.core.common.NoOpBannerAdHost
+import com.nexters.bandalart.core.common.NoOpExitDialogHost
 import com.nexters.bandalart.core.common.NoOpRewardedAdGateway
 import com.nexters.bandalart.feature.complete.CompleteScreen
 import com.nexters.bandalart.core.navigation.CloudBackupScreen
@@ -45,7 +46,13 @@ class AppGraphTest {
     @BeforeEach
     fun setUp() {
         val application = ApplicationProvider.getApplicationContext<Application>()
-        appGraph = createAndroidAppGraph(application, NoOpBannerAdHost, NoOpRewardedAdGateway)
+        appGraph =
+            createAndroidAppGraph(
+                application,
+                NoOpBannerAdHost,
+                NoOpExitDialogHost,
+                NoOpRewardedAdGateway,
+            )
     }
 
     @AfterEach
@@ -61,6 +68,7 @@ class AppGraphTest {
         assertSame(appGraph.inAppUpdateDataStore, appGraph.inAppUpdateDataStore)
         assertSame(appGraph.appVersionProvider, appGraph.appVersionProvider)
         assertSame(NoOpBannerAdHost, appGraph.bannerAdHost)
+        assertSame(NoOpExitDialogHost, appGraph.exitDialogHost)
         assertSame(appGraph.imageHandlerProvider, appGraph.imageHandlerProvider)
         assertSame(appGraph.supportMailLauncher, appGraph.supportMailLauncher)
         assertSame(appGraph.rewardedAdGateway, appGraph.rewardedAdGateway)

--- a/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
+++ b/composeApp/src/androidMain/kotlin/com/nexters/bandalart/di/metro/AndroidAppGraph.kt
@@ -22,6 +22,7 @@ import com.nexters.bandalart.backup.AndroidDeviceBackupKeyProvider
 import com.nexters.bandalart.core.common.AndroidSupportMailLauncher
 import com.nexters.bandalart.core.common.AppVersionProvider
 import com.nexters.bandalart.core.common.BannerAdHost
+import com.nexters.bandalart.core.common.ExitDialogHost
 import com.nexters.bandalart.core.common.ImageHandlerProvider
 import com.nexters.bandalart.core.common.RewardedAdGateway
 import com.nexters.bandalart.core.database.BandalartDatabaseFactory
@@ -46,6 +47,7 @@ data class AndroidWidgetRecentSelection(
 private class AndroidPlatformBindings(
     application: Application,
     override val bannerAdHost: BannerAdHost,
+    override val exitDialogHost: ExitDialogHost,
     override val rewardedAdGateway: RewardedAdGateway,
     override val backupApiConfig: BackupApiConfig,
 ) : PlatformBindings {
@@ -63,9 +65,19 @@ private class AndroidPlatformBindings(
 fun createAndroidAppGraph(
     application: Application,
     bannerAdHost: BannerAdHost,
+    exitDialogHost: ExitDialogHost,
     rewardedAdGateway: RewardedAdGateway,
     backupApiConfig: BackupApiConfig = BackupApiConfig(url = "", publishableKey = ""),
-): AppGraph = createAppGraph(AndroidPlatformBindings(application, bannerAdHost, rewardedAdGateway, backupApiConfig))
+): AppGraph =
+    createAppGraph(
+        AndroidPlatformBindings(
+            application,
+            bannerAdHost,
+            exitDialogHost,
+            rewardedAdGateway,
+            backupApiConfig,
+        ),
+    )
 
 fun installAndroidDeadlineReminderInfrastructure(
     appGraph: AppGraph,

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/BandalartApp.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/BandalartApp.kt
@@ -41,6 +41,7 @@ import com.nexters.bandalart.core.domain.entity.ThemeMode
 import com.nexters.bandalart.core.ui.LocalShowSnackbar
 import com.nexters.bandalart.di.metro.AppGraph
 import com.nexters.bandalart.feature.splash.SplashScreen
+import com.nexters.bandalart.feature.home.HomeScreen
 import com.nexters.bandalart.ui.BandalartSnackbar
 import io.github.compose.jindong.JindongProvider
 import com.slack.circuit.backstack.rememberSaveableBackStack
@@ -62,6 +63,7 @@ fun BandalartApp(appGraph: AppGraph) {
                 val pendingWidgetLaunchId by
                     appGraph.bandalartWidgetLaunchTarget.pendingBandalartId.collectAsState()
                 val currentScreen = backStack.topRecord?.screen ?: SplashScreen
+                appGraph.exitDialogHost.Content(enabled = currentScreen is HomeScreen)
                 LaunchedEffect(pendingWidgetLaunchId, currentScreen) {
                     widgetLaunchDestination(currentScreen, pendingWidgetLaunchId)?.let { destination ->
                         navigator.resetRoot(destination)

--- a/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/AppGraph.kt
+++ b/composeApp/src/commonMain/kotlin/com/nexters/bandalart/di/metro/AppGraph.kt
@@ -18,6 +18,7 @@ package com.nexters.bandalart.di.metro
 
 import com.nexters.bandalart.core.common.AppVersionProvider
 import com.nexters.bandalart.core.common.BannerAdHost
+import com.nexters.bandalart.core.common.ExitDialogHost
 import com.nexters.bandalart.core.common.ImageHandlerProvider
 import com.nexters.bandalart.core.common.RewardedAdGateway
 import com.nexters.bandalart.core.common.SupportMailLauncher
@@ -54,6 +55,7 @@ interface PlatformBindings {
     val dataStoreFactory: BandalartDataStoreFactory
     val appVersionProvider: AppVersionProvider
     val bannerAdHost: BannerAdHost
+    val exitDialogHost: ExitDialogHost
     val imageHandlerProvider: ImageHandlerProvider
     val supportMailLauncher: SupportMailLauncher
     val rewardedAdGateway: RewardedAdGateway
@@ -78,6 +80,7 @@ interface AppGraph {
     val inAppUpdateDataStore: InAppUpdateDataStore
     val appVersionProvider: AppVersionProvider
     val bannerAdHost: BannerAdHost
+    val exitDialogHost: ExitDialogHost
     val imageHandlerProvider: ImageHandlerProvider
     val supportMailLauncher: SupportMailLauncher
     val rewardedAdGateway: RewardedAdGateway

--- a/composeApp/src/iosMain/kotlin/com/nexters/bandalart/di/metro/IosAppGraph.kt
+++ b/composeApp/src/iosMain/kotlin/com/nexters/bandalart/di/metro/IosAppGraph.kt
@@ -23,6 +23,7 @@ import com.nexters.bandalart.backup.BackupBuildConfig
 import com.nexters.bandalart.backup.IosDeviceBackupKeyBridge
 import com.nexters.bandalart.core.common.AppVersionProvider
 import com.nexters.bandalart.core.common.ImageHandlerProvider
+import com.nexters.bandalart.core.common.NoOpExitDialogHost
 import com.nexters.bandalart.core.common.IosSupportMailLauncher
 import com.nexters.bandalart.core.data.backup.BackupApiConfig
 import com.nexters.bandalart.core.database.BandalartDatabaseFactory
@@ -39,6 +40,7 @@ private class IosPlatformBindings(
     override val dataStoreFactory = BandalartDataStoreFactory()
     override val appVersionProvider = AppVersionProvider()
     override val bannerAdHost = IosBannerAdHost(adsBridge)
+    override val exitDialogHost = NoOpExitDialogHost
     override val imageHandlerProvider = ImageHandlerProvider()
     override val supportMailLauncher = IosSupportMailLauncher()
     override val rewardedAdGateway = IosRewardedAdGateway(adsBridge)

--- a/core/common/src/commonMain/kotlin/com/nexters/bandalart/core/common/ExitDialogHost.kt
+++ b/core/common/src/commonMain/kotlin/com/nexters/bandalart/core/common/ExitDialogHost.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.core.common
+
+import androidx.compose.runtime.Composable
+
+interface ExitDialogHost {
+    @Composable
+    fun Content(enabled: Boolean)
+}
+
+object NoOpExitDialogHost : ExitDialogHost {
+    @Composable
+    override fun Content(enabled: Boolean) = Unit
+}

--- a/docs/features/ads/ADMOB_AD_ID_POLICY_GUIDE.md
+++ b/docs/features/ads/ADMOB_AD_ID_POLICY_GUIDE.md
@@ -30,7 +30,7 @@ Android와 iOS 빌드에 Google 테스트 광고 단위 ID와 BandalArt 운영 �
 
 | 플랫폼 | 기준 파일 | 보장하는 계약 |
 | --- | --- | --- |
-| Android | `androidApp/build.gradle.kts` | Debug의 Google 테스트 App·광고 단위 ID와 release의 BandalArt 운영 App·광고 단위 ID를 정의한다. |
+| Android | `androidApp/build.gradle.kts` | Debug의 Google 테스트 App·광고 단위 ID와 release의 BandalArt 운영 App·광고 단위 ID를 정의한다. 종료 다이얼로그 Native ID도 별도 지면으로 분리한다. |
 | Android | `scripts/validate_play_aab.py` | Play에 올릴 AAB에서 프로젝트가 현재 사용하는 Google 테스트 Fixed Banner·Rewarded ID를 거부하고 운영 홈 배너·반다라트 생성 Rewarded·클라우드 백업 Rewarded ID를 모두 요구한다. |
 | iOS | `iosApp/iosApp/IosAdsBridgeImpl.swift` | `DEBUG` 또는 `BANDALART_TEST_ADS` 조건에 따라 Banner와 목적별 Rewarded 광고 단위 ID를 선택한다. |
 | iOS | `fastlane/lib/ios_ads_mode.rb` | `ios_ads_mode=test`일 때만 `BANDALART_TEST_ADS` 조건을 Release archive에 추가한다. |
@@ -74,7 +74,7 @@ Google은 게시자가 자신의 실제 광고를 클릭해 만든 클릭이나 
 ### 스토어 운영 후보 검증
 
 1. 버전과 build 번호를 기록하고 의도한 release/production 빌드인지 확인한다.
-2. Android는 AAB validator로 현재 정의된 운영 광고 단위 ID 3개가 있고 프로젝트가 사용하는 Google 테스트 Fixed Banner·Rewarded ID가 없는지 검사한다.
+2. Android는 AAB validator로 현재 정의된 운영 광고 단위 ID 4개가 있고 프로젝트가 사용하는 Google 테스트 Fixed Banner·Rewarded·Native ID가 없는지 검사한다.
 3. 개발자·테스터 실기기는 AdMob 테스트 기기로 등록한 상태에서 요청과 UI만 확인한다. 운영 ID가 들어 있어도 이 기기에는 테스트 모드 광고가 표시되는 것이 정상이다.
 4. 실제 운영 광고 게재와 수익은 개발자 기기에서 인위적으로 만들지 않고, 배포 뒤 자연 사용자 트래픽과 AdMob 보고서 반영으로 확인한다.
 

--- a/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartActionAlertDialog.kt
+++ b/feature/home/src/commonMain/kotlin/com/nexters/bandalart/feature/home/ui/bandalart/BandalartActionAlertDialog.kt
@@ -17,6 +17,7 @@
 package com.nexters.bandalart.feature.home.ui.bandalart
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -25,7 +26,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.Icon
@@ -46,16 +49,19 @@ import org.jetbrains.compose.resources.vectorResource
 
 @Composable
 fun BandalartActionAlertDialog(
-    icon: DrawableResource,
+    icon: DrawableResource?,
     iconContentDescription: String?,
     title: String,
-    message: String,
+    message: String?,
     confirmLabel: String,
     cancelLabel: String,
     onConfirmClick: () -> Unit,
     onCancelClick: () -> Unit,
     modifier: Modifier = Modifier,
+    content: (@Composable () -> Unit)? = null,
 ) {
+    val scrollState = rememberScrollState()
+
     Dialog(onDismissRequest = onCancelClick) {
         Surface(
             shape = RoundedCornerShape(16.dp),
@@ -65,18 +71,26 @@ fun BandalartActionAlertDialog(
                 modifier =
                     modifier
                         .fillMaxWidth()
-                        .padding(top = 24.dp),
+                        .then(
+                            if (content == null) {
+                                Modifier
+                            } else {
+                                Modifier.verticalScroll(scrollState)
+                            },
+                        ).padding(top = 24.dp),
             ) {
-                Icon(
-                    imageVector = vectorResource(icon),
-                    contentDescription = iconContentDescription,
-                    modifier =
-                        Modifier
-                            .size(28.dp)
-                            .align(Alignment.CenterHorizontally),
-                    tint = MaterialTheme.colorScheme.primary,
-                )
-                Spacer(modifier = Modifier.height(18.dp))
+                if (icon != null) {
+                    Icon(
+                        imageVector = vectorResource(icon),
+                        contentDescription = iconContentDescription,
+                        modifier =
+                            Modifier
+                                .size(28.dp)
+                                .align(Alignment.CenterHorizontally),
+                        tint = MaterialTheme.colorScheme.primary,
+                    )
+                    Spacer(modifier = Modifier.height(18.dp))
+                }
                 Text(
                     text = title,
                     color = MaterialTheme.colorScheme.onSurface,
@@ -91,21 +105,29 @@ fun BandalartActionAlertDialog(
                     lineHeight = 30.sp,
                     letterSpacing = (-0.4).sp,
                 )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    text = message,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontSize = 14.sp,
-                    fontFamily = pretendardFontFamily(),
-                    fontWeight = FontWeight.W500,
-                    modifier =
-                        Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .padding(horizontal = 24.dp),
-                    textAlign = TextAlign.Center,
-                    lineHeight = 21.sp,
-                    letterSpacing = (-0.28).sp,
-                )
+                if (!message.isNullOrBlank()) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = message,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        fontSize = 14.sp,
+                        fontFamily = pretendardFontFamily(),
+                        fontWeight = FontWeight.W500,
+                        modifier =
+                            Modifier
+                                .align(Alignment.CenterHorizontally)
+                                .padding(horizontal = 24.dp),
+                        textAlign = TextAlign.Center,
+                        lineHeight = 21.sp,
+                        letterSpacing = (-0.28).sp,
+                    )
+                }
+                if (content != null) {
+                    Spacer(modifier = Modifier.height(24.dp))
+                    Box(modifier = Modifier.padding(horizontal = 24.dp)) {
+                        content()
+                    }
+                }
                 Spacer(modifier = Modifier.height(30.dp))
                 Row(
                     modifier =

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -141,6 +141,7 @@ app-update-ktx = { group = "com.google.android.play", name = "app-update-ktx", v
 # Compose
 compose-material-iconsCore = { group = "org.jetbrains.compose.material", name = "material-icons-core", version.ref = "compose-material-icons" }
 compose-ui-toolingPreview = { group = "org.jetbrains.compose.ui", name = "ui-tooling-preview", version.ref = "compose-multiplatform" }
+compose-components-resources = { group = "org.jetbrains.compose.components", name = "components-resources", version.ref = "compose-multiplatform" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activity-compose" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "androidx-work" }
 androidx-work-testing = { group = "androidx.work", name = "work-testing", version.ref = "androidx-work" }

--- a/scripts/tests/test_play_release_scripts.py
+++ b/scripts/tests/test_play_release_scripts.py
@@ -95,13 +95,17 @@ class ValidateAabTest(unittest.TestCase):
         self.assertEqual(fixed_size_banner_id.encode(), validate_play_aab.TEST_BANNER_ID)
         self.assertIn(validate_play_aab.TEST_REWARDED_ID.decode(), debug_config)
         self.assertIn(fixed_size_banner_id, debug_config)
+        self.assertIn(validate_play_aab.TEST_NATIVE_ID.decode(), debug_config)
         for production_rewarded_id in validate_play_aab.PRODUCTION_REWARDED_IDS:
             self.assertNotIn(production_rewarded_id.decode(), debug_config)
         self.assertNotIn(validate_play_aab.PRODUCTION_BANNER_ID.decode(), debug_config)
+        self.assertNotIn(validate_play_aab.PRODUCTION_NATIVE_ID.decode(), debug_config)
         for production_rewarded_id in validate_play_aab.PRODUCTION_REWARDED_IDS:
             self.assertIn(production_rewarded_id.decode(), release_and_later)
         self.assertIn(validate_play_aab.PRODUCTION_BANNER_ID.decode(), release_and_later)
+        self.assertIn(validate_play_aab.PRODUCTION_NATIVE_ID.decode(), release_and_later)
         self.assertNotIn(validate_play_aab.TEST_REWARDED_ID.decode(), release_and_later)
+        self.assertNotIn(validate_play_aab.TEST_NATIVE_ID.decode(), release_and_later)
         self.assertNotIn(fixed_size_banner_id, release_and_later)
         self.assertNotIn("bandalart.useTestAds", build_gradle)
         self.assertNotIn("bandalart.useTestAds", fastfile)
@@ -145,6 +149,8 @@ class ValidateAabTest(unittest.TestCase):
                     + b"\0"
                     + validate_play_aab.PRODUCTION_BANNER_ID
                     + b"\0"
+                    + validate_play_aab.PRODUCTION_NATIVE_ID
+                    + b"\0"
                     + validate_play_aab.REQUIRED_NAMESPACE[0],
                 )
 
@@ -160,6 +166,7 @@ class ValidateAabTest(unittest.TestCase):
                     validate_play_aab.TEST_REWARDED_ID
                     + b"\0".join(validate_play_aab.PRODUCTION_REWARDED_IDS)
                     + validate_play_aab.PRODUCTION_BANNER_ID
+                    + validate_play_aab.PRODUCTION_NATIVE_ID
                     + validate_play_aab.REQUIRED_NAMESPACE[0],
                 )
 
@@ -176,10 +183,28 @@ class ValidateAabTest(unittest.TestCase):
                     b"\0".join(validate_play_aab.PRODUCTION_REWARDED_IDS)
                     + validate_play_aab.TEST_BANNER_ID
                     + validate_play_aab.PRODUCTION_BANNER_ID
+                    + validate_play_aab.PRODUCTION_NATIVE_ID
                     + validate_play_aab.REQUIRED_NAMESPACE[0],
                 )
 
             with self.assertRaisesRegex(ValueError, "test banner ad ID"):
+                validate_play_aab.verify_archive(aab)
+
+    def test_rejects_test_native_id(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            aab = Path(directory) / "app.aab"
+            with zipfile.ZipFile(aab, "w") as archive:
+                archive.writestr("base/manifest/AndroidManifest.xml", b"manifest")
+                archive.writestr(
+                    "base/resources.pb",
+                    b"\0".join(validate_play_aab.PRODUCTION_REWARDED_IDS)
+                    + validate_play_aab.PRODUCTION_BANNER_ID
+                    + validate_play_aab.TEST_NATIVE_ID
+                    + validate_play_aab.PRODUCTION_NATIVE_ID
+                    + validate_play_aab.REQUIRED_NAMESPACE[0],
+                )
+
+            with self.assertRaisesRegex(ValueError, "test native ad ID"):
                 validate_play_aab.verify_archive(aab)
 
     def test_requires_each_production_rewarded_id(self) -> None:
@@ -204,6 +229,7 @@ class ValidateAabTest(unittest.TestCase):
                     "base/resources.pb",
                     b"\0".join(present_rewarded_ids)
                     + validate_play_aab.PRODUCTION_BANNER_ID
+                    + validate_play_aab.PRODUCTION_NATIVE_ID
                     + validate_play_aab.REQUIRED_NAMESPACE[0],
                 )
 
@@ -218,10 +244,26 @@ class ValidateAabTest(unittest.TestCase):
                 archive.writestr(
                     "base/resources.pb",
                     b"\0".join(validate_play_aab.PRODUCTION_REWARDED_IDS)
+                    + validate_play_aab.PRODUCTION_NATIVE_ID
                     + validate_play_aab.REQUIRED_NAMESPACE[0],
                 )
 
             with self.assertRaisesRegex(ValueError, "production banner ad ID"):
+                validate_play_aab.verify_archive(aab)
+
+    def test_requires_production_native_id(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            aab = Path(directory) / "app.aab"
+            with zipfile.ZipFile(aab, "w") as archive:
+                archive.writestr("base/manifest/AndroidManifest.xml", b"manifest")
+                archive.writestr(
+                    "base/resources.pb",
+                    b"\0".join(validate_play_aab.PRODUCTION_REWARDED_IDS)
+                    + validate_play_aab.PRODUCTION_BANNER_ID
+                    + validate_play_aab.REQUIRED_NAMESPACE[0],
+                )
+
+            with self.assertRaisesRegex(ValueError, "production native ad ID"):
                 validate_play_aab.verify_archive(aab)
 
 

--- a/scripts/validate_play_aab.py
+++ b/scripts/validate_play_aab.py
@@ -19,6 +19,8 @@ PRODUCTION_REWARDED_IDS = (
 )
 TEST_BANNER_ID = b"ca-app-pub-3940256099942544/6300978111"
 PRODUCTION_BANNER_ID = b"ca-app-pub-5570932833347277/1215605203"
+TEST_NATIVE_ID = b"ca-app-pub-3940256099942544/2247696110"
+PRODUCTION_NATIVE_ID = b"ca-app-pub-5570932833347277/1778455797"
 ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
 REQUIRED_NAMESPACE = (
     b"bandalart.core.designsystem.generated.resources",
@@ -71,6 +73,8 @@ def verify_archive(path: Path) -> None:
         production_rewarded_ids_found: set[bytes] = set()
         test_banner_id_found = False
         production_banner_id_found = False
+        test_native_id_found = False
+        production_native_id_found = False
         required_namespace_found = False
         removed_namespace_found = False
         for info in archive.infolist():
@@ -83,6 +87,8 @@ def verify_archive(path: Path) -> None:
             )
             test_banner_id_found = test_banner_id_found or TEST_BANNER_ID in content
             production_banner_id_found = production_banner_id_found or PRODUCTION_BANNER_ID in content
+            test_native_id_found = test_native_id_found or TEST_NATIVE_ID in content
+            production_native_id_found = production_native_id_found or PRODUCTION_NATIVE_ID in content
             required_namespace_found = required_namespace_found or any(
                 value in content for value in REQUIRED_NAMESPACE
             )
@@ -98,6 +104,10 @@ def verify_archive(path: Path) -> None:
             fail("official Google test banner ad ID is present")
         if not production_banner_id_found:
             fail("production banner ad ID is missing")
+        if test_native_id_found:
+            fail("official Google test native ad ID is present")
+        if not production_native_id_found:
+            fail("production native ad ID is missing")
         if not required_namespace_found:
             fail("expected Compose resource namespace is missing")
         if removed_namespace_found:


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #380

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- Android Home 루트에서 시스템 백 버튼을 누르면 기존 `BandalartActionAlertDialog` 스타일의 종료 확인 팝업을 표시합니다.
- 종료 팝업에 AdMob NativeAd의 미디어, 광고 배지, AdChoices, 제목, 본문과 CTA를 등록해 표시합니다.
- Home 최초 진입 시 광고를 한 번 사전 로드하고, 팝업 취소 후 다음 광고를 준비하는 단발 로드 방식을 적용했습니다.
- 중복 요청을 방지하고 광고 교체·화면 종료·늦게 도착한 콜백에서 `NativeAd.destroy()`를 호출합니다.
- Debug에는 Google 테스트 Native ID, Release에는 BandalArt 운영 Native ID를 사용하며 AAB 검증에도 반영했습니다.
- iOS에는 No-op host를 주입해 기존 동작을 유지합니다.

## 🧪 테스트 내역 (선택)

- [ ] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `./gradlew :androidApp:testDebugUnitTest` — 39개 통과
- `./gradlew :composeApp:testAndroidHostTest` — 통과
- `./gradlew :androidApp:spotlessCheck :composeApp:spotlessCheck detekt` — 통과
- `/usr/bin/python3 -m unittest scripts.tests.test_play_release_scripts` — 14개 통과

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

| 기능 | 미리보기 | 기능 | 미리보기 |
|:---:|:---:|:---:|:---:|
| Android 종료 다이얼로그 | 미첨부 | - | - |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- YeoBee PR #519의 NativeAd UI 등록 방식을 참고했습니다.
- YeoBee PR #522의 주기 갱신·지수 백오프·Remote Config 구조는 종료 팝업 단일 지면에는 과하다고 판단해 제외했습니다.
- 전체 `spotlessCheck`는 이번 변경과 무관한 기존 `ObserveEvent.kt`, `CellText.kt` 포맷 위반 때문에 실행되지 않으며, 변경된 Android/Compose 모듈은 별도로 통과했습니다.