### PR TITLE
test: Maestro QA 회귀 검증 및 보고서 추가

### DIFF
--- a/.maestro/android/completion-screen.yaml
+++ b/.maestro/android/completion-screen.yaml
@@ -1,0 +1,32 @@
+appId: com.nexters.bandalart.dev
+name: Android completion screen
+---
+- pressKey: HOME
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- runFlow:
+    when:
+      visible: "달성률 100%"
+    commands:
+      - longPressOn: "last task"
+      - waitForAnimationToEnd
+- stopApp
+- pressKey: HOME
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- extendedWaitUntil:
+    visible: "달성률 88%"
+    timeout: 15000
+- assertVisible: "last task"
+- longPressOn: "last task"
+- waitForAnimationToEnd
+- assertVisible: "반다라트의 모든 목표를 달성했어요.\\n정말 대단해요!"
+- assertVisible: "달성 완료 반다라트"
+- assertVisible: "완료 화면 테스트"
+- assertVisible: "저장하기"
+- assertVisible: "공유하기"
+- tapOn: "뒤로 가기"
+- waitForAnimationToEnd
+- assertVisible: "완료 화면 테스트"

--- a/.maestro/android/notification-settings.yaml
+++ b/.maestro/android/notification-settings.yaml
@@ -1,0 +1,29 @@
+appId: com.nexters.bandalart.dev
+name: Android deadline reminder settings
+---
+- pressKey: HOME
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- tapOn: "설정 아이콘"
+- waitForAnimationToEnd
+- assertVisible: "마감일 알림"
+- tapOn: "마감일 알림"
+- assertVisible: "마감일 알림을 켤까요?"
+- assertVisible: "알림 켜기"
+- tapOn: "알림 켜기"
+- waitForAnimationToEnd
+- tapOn: "시트 닫기"
+- stopApp
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- tapOn: "설정 아이콘"
+- waitForAnimationToEnd
+- tapOn: "마감일 알림"
+- assertNotVisible: "마감일 알림을 켤까요?"
+- tapOn: "마감일 알림"
+- assertVisible: "마감일 알림을 켤까요?"
+- tapOn: "취소"
+- tapOn: "시트 닫기"
+- assertVisible: "완료 화면 테스트"

--- a/.maestro/ios/completion-screen.yaml
+++ b/.maestro/ios/completion-screen.yaml
@@ -1,0 +1,11 @@
+appId: com.nexters.bandalart.iosApp
+name: iOS completion screen content
+---
+- assertVisible: "반다라트의 모든 목표를 달성했어요.\\n정말 대단해요!"
+- assertVisible: "달성 완료 반다라트"
+- assertVisible: "완료 화면 테스트"
+- assertVisible: "저장하기"
+- assertVisible: "공유하기"
+- tapOn: "뒤로 가기"
+- waitForAnimationToEnd
+- assertVisible: "완료 화면 테스트"

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,11 @@
 - [Coordinator 패턴과 현재 적용 위치](architecture/coordinator/COORDINATOR_PATTERN_GUIDE.md)
 - [Compose Multiplatform 마이그레이션 문제 해결](architecture/kmp/COMPOSE_MULTIPLATFORM_MIGRATION_TROUBLESHOOTING.md)
 - [KMP 테스트 소스셋과 Circuit Presenter 테스트 가이드](architecture/kmp/KMP_TESTING_GUIDE.md)
+- [Maestro UI 테스트 가이드](testing/MAESTRO_UI_TEST_GUIDE.md)
+
+## Testing
+
+- [Maestro UI 테스트 가이드](testing/MAESTRO_UI_TEST_GUIDE.md)
 
 ## Architecture
 

--- a/docs/testing/MAESTRO_UI_TEST_GUIDE.md
+++ b/docs/testing/MAESTRO_UI_TEST_GUIDE.md
@@ -25,6 +25,105 @@ iPhone이 Xcode에 연결되어 있어도 Maestro 또는 Maestro MCP의 실행 �
 
 두 플랫폼의 공통 화면은 Android 실기기와 iOS Simulator에서 같은 Maestro flow 또는 같은 검증 항목으로 비교한다. iOS 실기기 결과를 Maestro 자동화 결과로 기록하지 않는다.
 
+완료 화면 검사는 다음 flow를 사용한다:
+
+- Android: `.maestro/android/completion-screen.yaml`
+- iOS: `.maestro/ios/completion-screen.yaml`
+- Android 알림 설정: `.maestro/android/notification-settings.yaml`
+
+Android flow는 제목이 `완료 화면 테스트`이고 `last task`를 제외한 실행 목표가 모두 완료된 반다라트를 전제로 한다. 실행 전 `HOME` 키로 알림창 같은 시스템 오버레이를 닫고 앱을 시작한다. 달성률이 이미 100%이면 `last task`를 먼저 미완료로 되돌리고 앱을 재실행한다. 마지막 실행 목표와 상위 서브목표·메인목표가 함께 미완료로 집계되므로 이때 달성률은 `88%`다. flow는 이 값을 확인해 fixture 오류를 완료 문구 assertion 실패와 구분한 뒤, 마지막 목표를 길게 눌러 완료 화면으로 이동하고 내용을 검사한다. Android Maestro 입력은 한글 조합을 지원하지 않으므로 fixture 이름은 영문으로 유지한다.
+
+iOS flow는 완료 화면에 수동 진입한 상태에서 내용과 뒤로가기만 자동 검사한다. 현재 Maestro의 iOS `longPressOn`은 Compose Multiplatform의 `combinedClickable` 셀에서 길게 누르기 대신 일반 탭으로 처리되어 수정 시트를 열기 때문에 완료 화면 진입 단계에는 사용하지 않는다. 이 제한은 텍스트가 Maestro Viewer에서 생략되어 보이는 현상과 무관하다.
+
+접근성 문구는 화면 텍스트처럼 조회하며 `id` 선택자로 조회하지 않는다. 완료 화면의 뒤로가기는 `tapOn: "뒤로 가기"`로 선택한다.
+
+Android 알림 설정 flow는 실기기에서 활성화 확인창, 앱 재실행 후 설정 유지와 비활성 상태 복원을 검사한다. 설정 화면의 테스트 알림 UI는 제품에서 숨긴 상태이므로 시스템 알림 수신 자체는 마감일이 있는 fixture와 실기기 수동 검사로 보완한다.
+
+## 결과 내보내기와 알림
+
+Maestro MCP Viewer의 누적 목록은 테스트를 탐색하고 실패 지점을 확인하는 용도로 사용한다. 현재 MCP `run` 호출은 성공 여부와 실행 명령 수를 반환하지만, 보고서 출력 경로를 받지 않는다. Viewer 목록을 공식 QA 증빙으로 직접 내보낼 수는 없다.
+
+### 실행 방식별 결과물
+
+실행 목적에 따라 다음 방식을 선택한다:
+
+| 실행 방식 | 용도 | 저장 결과 | 완료 알림 |
+| --- | --- | --- | --- |
+| Maestro MCP Viewer | 로컬 탐색과 flow 수정 | Viewer 세션 기록 | 없음 |
+| Maestro CLI | 로컬 회귀 검사 | HTML, JUnit, 스크린샷, 명령 기록, 디버그 로그 | 프로세스 종료 코드 |
+| GitHub Actions | 반복 실행과 결과 보관 | workflow 로그와 artifact | GitHub 상태 알림, 외부 webhook |
+| Maestro Cloud | 원격 기기 실행 | Console 결과, flow 상태, 영상과 로그 | Cloud Action 출력값, 외부 webhook |
+
+### 로컬 결과 생성
+
+아래 명령은 상세 HTML 보고서, 실패 스크린샷, 명령 기록과 디버그 로그를 한 디렉터리 아래에 생성한다:
+
+```bash
+mkdir -p build/reports/maestro
+maestro test \
+  --format html-detailed \
+  --output build/reports/maestro/report.html \
+  --test-output-dir build/reports/maestro/artifacts \
+  --debug-output build/reports/maestro/debug \
+  .maestro/android/completion-screen.yaml
+```
+
+CI가 읽을 JUnit 보고서가 필요하면 출력 형식과 파일명만 바꾼다:
+
+```bash
+maestro test \
+  --format junit \
+  --output build/reports/maestro/report.xml \
+  --test-output-dir build/reports/maestro/artifacts \
+  --debug-output build/reports/maestro/debug \
+  .maestro/android/completion-screen.yaml
+```
+
+각 옵션은 다음 결과를 저장한다:
+
+- `--output`: 사람이 읽는 HTML 또는 CI가 읽는 JUnit 보고서
+- `--test-output-dir`: 실행 스크린샷과 `commands-*.json` 명령 기록
+- `--debug-output`: `maestro.log` 디버그 로그
+
+옵션을 생략하면 Maestro는 기본 실행 산출물을 macOS와 Linux의 `~/.maestro/tests` 아래에 저장한다. 보고서와 산출물의 차이는 [Maestro 테스트 보고서와 산출물](https://docs.maestro.dev/troubleshooting/debug-output)에서 확인한다.
+
+PR에 QA 증빙을 남길 때는 통과한 HTML 또는 JUnit과 요약만 `reports/maestro/YYYY-MM-DD/`에 저장한다. 알림 내용이나 개인정보가 포함될 수 있는 원본 스크린샷, 기기 로그와 전체 명령 artifact는 프로젝트에 커밋하지 않는다.
+
+### GitHub Actions 보관과 알림
+
+GitHub Actions는 Maestro CLI의 종료 코드를 workflow 성공 여부로 사용한다. 테스트 단계의 성공 여부와 무관하게 결과를 남기려면 artifact 업로드 단계에 `if: always()`를 적용하고 `build/reports/maestro`를 업로드한다.
+
+완료 알림은 다음 정보를 포함한다:
+
+- workflow 이름과 commit SHA
+- 성공, 실패 또는 취소 상태
+- HTML 또는 JUnit artifact 링크
+- 실패한 flow 이름
+
+GitHub 알림만 사용할 때는 별도 secret이 필요 없다. Slack이나 다른 webhook을 연결할 때는 URL을 `SLACK_WEBHOOK_URL` 같은 GitHub Actions secret에 저장한다. 알림 단계에도 `if: always()`를 적용해야 실패 결과를 전송할 수 있다.
+
+GitHub-hosted runner는 로컬 USB Android 실기기에 접근할 수 없다. 실기기 검사가 필요하면 기기가 연결된 self-hosted runner를 사용한다. 그렇지 않으면 Android 에뮬레이터, iOS Simulator 또는 Maestro Cloud에서 flow를 실행한다.
+
+### Maestro Cloud 결과 알림
+
+Maestro Cloud 공식 GitHub Action은 완료 후 다음 출력값을 제공한다:
+
+- `MAESTRO_CLOUD_UPLOAD_STATUS`: 전체 실행 상태
+- `MAESTRO_CLOUD_FLOW_RESULTS`: flow별 상태와 오류
+- `MAESTRO_CLOUD_CONSOLE_URL`: 영상과 로그를 확인할 Console URL
+
+동기 실행에서만 완료 상태와 flow 결과를 바로 사용할 수 있다. `async: true`는 workflow가 테스트 완료를 기다리지 않으므로 완료 알림 용도로 사용하지 않는다. Cloud 실행에는 Maestro Cloud Plan과 API key가 필요하다. 자세한 출력 형식은 [Maestro Cloud Action 출력값과 trigger](https://docs.maestro.dev/maestro-cloud/ci-cd-integration/github-actions/outputs-and-triggers)에서 확인한다.
+
+### QA 완료 기준
+
+QA 자동화 완료 기록에는 다음 항목을 남긴다:
+
+1. 실행한 commit SHA와 앱 버전
+2. 대상 플랫폼과 기기 또는 Simulator 버전
+3. flow별 성공, 실패 상태
+4. HTML 또는 JUnit 보고서와 실패 산출물
+5. iOS 실기기처럼 자동화하지 못한 수동 검사 결과
+
 ## 실행 전 확인 사항
 
 1. 테스트할 최신 빌드를 대상 기기에 설치한다.

--- a/docs/testing/MAESTRO_UI_TEST_GUIDE.md
+++ b/docs/testing/MAESTRO_UI_TEST_GUIDE.md
@@ -1,0 +1,34 @@
+# Maestro UI 테스트 가이드
+
+이 문서는 BandalArt의 Maestro 기반 UI 테스트 범위와 기기 선택 기준을 정한다. Maestro 자동화가 지원하지 않는 환경은 별도 수동 검증으로 보완한다.
+
+## 플랫폼별 지원 범위
+
+Maestro는 Android 실기기와 에뮬레이터, iOS Simulator에서 로컬 UI 테스트를 지원한다. iOS 실기기 실행은 아직 지원하지 않는다.
+
+| 플랫폼 | 에뮬레이터·Simulator | 실기기 |
+| --- | --- | --- |
+| Android | 지원 | 지원 |
+| iOS | 지원 | 미지원 |
+
+iPhone이 Xcode에 연결되어 있어도 Maestro 또는 Maestro MCP의 실행 대상으로 사용할 수 없다. iOS 실기기에서 앱을 빌드하고 실행하는 작업은 Xcode로 진행한다.
+
+지원 범위가 바뀔 수 있으므로 도구를 업데이트할 때 [Maestro 지원 플랫폼](https://docs.maestro.dev/getting-started/build-and-install-your-app)과 [iOS 제약 사항](https://docs.maestro.dev/platform-support/ios-uikit)을 다시 확인한다.
+
+## 프로젝트의 테스트 조합
+
+일반 UI 회귀 검사는 다음 조합을 사용한다:
+
+- **Android 실기기**: 제조사별 화면, 시스템 권한, 알림, 위젯을 포함한 동작 검사
+- **iOS Simulator**: 화면 진입, 텍스트 노출, 입력, 내비게이션, 앱 재실행 검사
+- **iOS 실기기 수동 검사**: 서명, TestFlight 설치, 알림, 위젯과 실기기에서만 확인할 수 있는 동작 검사
+
+두 플랫폼의 공통 화면은 Android 실기기와 iOS Simulator에서 같은 Maestro flow 또는 같은 검증 항목으로 비교한다. iOS 실기기 결과를 Maestro 자동화 결과로 기록하지 않는다.
+
+## 실행 전 확인 사항
+
+1. 테스트할 최신 빌드를 대상 기기에 설치한다.
+2. Android 실기기의 잠금을 해제하거나 iOS Simulator를 부팅한다.
+3. Maestro 기기 목록에서 대상이 연결 상태인지 확인한다.
+4. 기존 데이터를 유지할 테스트는 `clearState: false`로 실행한다.
+5. 알림과 위젯처럼 앱 밖에서 발생하는 동작은 해당 플랫폼의 실기기에서 별도로 확인한다.

--- a/feature/complete/src/commonMain/kotlin/com/nexters/bandalart/feature/complete/ui/CompleteTopBar.kt
+++ b/feature/complete/src/commonMain/kotlin/com/nexters/bandalart/feature/complete/ui/CompleteTopBar.kt
@@ -28,12 +28,12 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import bandalart.core.designsystem.generated.resources.Res
-import bandalart.core.designsystem.generated.resources.arrow_forward_description
+import bandalart.core.designsystem.generated.resources.back_description
 import com.nexters.bandalart.core.designsystem.theme.BandalartTheme
 import org.jetbrains.compose.resources.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 
 @Composable
 fun CompleteTopBar(
@@ -55,7 +55,7 @@ fun CompleteTopBar(
         ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                contentDescription = stringResource(Res.string.arrow_forward_description),
+                contentDescription = stringResource(Res.string.back_description),
                 tint = MaterialTheme.colorScheme.onBackground,
             )
         }

--- a/reports/maestro/2026-09-07/README.md
+++ b/reports/maestro/2026-09-07/README.md
@@ -54,8 +54,18 @@ flow는 마감일 알림 활성화 확인창을 거쳐 설정을 켜고, 앱을 
 | 크기 | 2×2 |
 | 시스템 등록 | App widget ID 15 등록 확인 |
 | 마지막 조회 반영 | `완료 화면 테스트`, 100% 표시 성공 |
+| cold-start 전환 | A↔B 10/10 성공 |
+| active-session 전환 | A↔B 6/6 성공 |
+| stale 재현 | 0/16 |
 
-위젯 추가 직후에는 설정 과정에서 선택한 ID 1이 앱의 `recent_bandalart_id`에도 저장되어 `이름 없는 목표`, 0%가 표시됐다. 앱 목록에서 `완료 화면 테스트`를 선택한 뒤 `recent_bandalart_id=3` 저장과 위젯의 `완료 화면 테스트`, 100% 갱신을 확인했다. 따라서 마지막으로 조회한 반다라트를 따라가는 동작은 정상이다.
+위젯 추가 직후에는 설정 과정에서 선택한 ID 1이 앱의 `recent_bandalart_id`에도 저장되어 `이름 없는 목표`, 0%가 표시됐다. 이는 이전 반다라트가 남은 것이 아니라 메인 목표가 비어 있는 ID 1의 정상 fallback 표시다.
+
+마지막 조회 동기화는 ID 1과 ID 3을 교대로 선택해 검증했다. 각 회차에서 앱 목록의 선택 완료, DataStore protobuf의 `recent_bandalart_id`, 홈 이동 3초 후 위젯의 OCR 제목을 차례로 비교했다. ID 1은 `recent_bandalart_id=1`과 `이름 없는 목표`, ID 3은 `recent_bandalart_id=3`과 `완료 화면 테스트`가 일치했다.
+
+- 앱을 매번 종료하고 다시 시작하는 cold-start 경로: 10회 모두 성공
+- 앱 프로세스와 Glance composition을 유지하는 active-session 경로: 6회 모두 성공
+
+현재 브랜치에는 갱신 요청을 직렬화하는 `c888d15b`와 활성 Glance 세션이 최근 선택 Flow를 구독하도록 한 `fe5e615c`가 모두 포함되어 있다. Samsung One UI 실기기에서 16회 동안 이전 대상이 유지되는 현상은 재현되지 않았으므로, 이 동기화 문제를 위한 추가 코드 패치나 긴급 앱 업데이트는 필요하지 않다고 판단한다.
 
 Samsung 런처의 Glance 위젯은 UI hierarchy에 내부 텍스트를 노출하지 않아 Maestro text assertion을 사용할 수 없었다. 화면 OCR로 기대 제목을 판정했으며, 홈 화면의 다른 정보가 포함된 원본 스크린샷은 저장 범위에서 제외했다.
 

--- a/reports/maestro/2026-09-07/README.md
+++ b/reports/maestro/2026-09-07/README.md
@@ -1,0 +1,90 @@
+# Maestro QA 결과: 2026-09-07
+
+이 보고서는 `docs/maestro-ui-test-guide` 브랜치의 UI 자동화 결과를 기록한다. 테스트 작업 트리는 `25a90a2a5874`를 기준으로 완료 화면 접근성 수정과 Maestro flow 변경을 포함했다.
+
+## Android 완료 화면
+
+| 항목 | 결과 |
+| --- | --- |
+| 앱 | `com.nexters.bandalart.dev` 2.4.9 debug |
+| 기기 | Samsung SM-S936N (`R3CY70P3F4H`) |
+| flow | `.maestro/android/completion-screen.yaml` |
+| HTML 실행 | 성공, 32초 |
+| JUnit 반복 실행 | 성공, 36초 |
+
+결과 파일:
+
+- [상세 HTML 보고서](android-completion/report.html)
+- [JUnit 보고서](android-completion/report.xml)
+
+flow는 알림창 같은 시스템 오버레이를 닫고 앱을 시작한다. 달성률이 100%이면 `last task`를 미완료로 되돌린 뒤 앱을 재실행한다. 마지막 실행 목표와 상위 목표가 미완료로 집계된 `달성률 88%`를 확인하고 완료 화면의 제목, 저장, 공유와 뒤로가기를 검사한다.
+
+## Android 알림 설정
+
+| 항목 | 결과 |
+| --- | --- |
+| 기기 | Samsung SM-S936N (`R3CY70P3F4H`) |
+| flow | `.maestro/android/notification-settings.yaml` |
+| HTML 실행 | 성공, 43초 |
+| 시스템 권한 | `POST_NOTIFICATIONS` 허용 확인 |
+
+- [상세 HTML 보고서](android-notification-settings/report.html)
+
+flow는 마감일 알림 활성화 확인창을 거쳐 설정을 켜고, 앱을 재실행해 활성 상태가 유지되는지 확인한 다음 원래 비활성 상태로 복원한다. 설정 화면의 테스트 알림 버튼은 `4fe34232`에서 의도적으로 숨겼으므로 공개 UI 검증 범위에 넣지 않았다.
+
+알림 계획·예약·전송과 위젯 갱신 로직은 다음 Android host test와 함께 검증했다.
+
+| Gradle task | 결과 |
+| --- | --- |
+| `:androidApp:testDebugUnitTest` | 성공 |
+| `:composeApp:testAndroidHostTest` | 성공 |
+| `:core:data:testAndroidHostTest` | 성공 |
+| `:core:domain:testAndroidHostTest` | 성공 |
+| `:feature:complete:testAndroidHostTest` | 성공 |
+| `:feature:home:testAndroidHostTest` | 성공 |
+
+총 53개 suite, 213개 test가 실행됐고 실패·오류·건너뜀은 모두 0개다. 이 중 Android 위젯 전용 test는 22개다.
+
+## Android 위젯
+
+| 항목 | 결과 |
+| --- | --- |
+| 기기 | Samsung SM-S936N (`R3CY70P3F4H`) |
+| 런처 | Samsung One UI |
+| 크기 | 2×2 |
+| 시스템 등록 | App widget ID 15 등록 확인 |
+| 마지막 조회 반영 | `완료 화면 테스트`, 100% 표시 성공 |
+
+위젯 추가 직후에는 설정 과정에서 선택한 ID 1이 앱의 `recent_bandalart_id`에도 저장되어 `이름 없는 목표`, 0%가 표시됐다. 앱 목록에서 `완료 화면 테스트`를 선택한 뒤 `recent_bandalart_id=3` 저장과 위젯의 `완료 화면 테스트`, 100% 갱신을 확인했다. 따라서 마지막으로 조회한 반다라트를 따라가는 동작은 정상이다.
+
+Samsung 런처의 Glance 위젯은 UI hierarchy에 내부 텍스트를 노출하지 않아 Maestro text assertion을 사용할 수 없었다. 화면 OCR로 기대 제목을 판정했으며, 홈 화면의 다른 정보가 포함된 원본 스크린샷은 저장 범위에서 제외했다.
+
+## iOS 완료 화면
+
+| 항목 | 결과 |
+| --- | --- |
+| 앱 | `com.nexters.bandalart.iosApp` debug |
+| 기기 | iPhone 17 Pro Simulator, iOS 26.2 |
+| flow | `.maestro/ios/completion-screen.yaml` |
+| HTML 실행 | 성공, 8초 |
+
+- [상세 HTML 보고서](ios-completion/report.html)
+
+Compose Multiplatform 셀의 iOS `longPressOn`은 일반 탭으로 처리되므로 사용자가 완료 화면에 한 번 수동 진입했다. 진입 후 완료 문구, 제목, 저장, 공유와 뒤로가기는 Maestro로 자동 검사했다.
+
+## 실행 중 수정한 테스트 오류
+
+- `달성률 96%` 기대값을 `88%`로 수정했다. 마지막 실행 목표와 상위 서브목표·메인목표가 함께 달성률에 반영된다.
+- Samsung 알림창이 앱 위에 남는 환경을 처리하도록 `HOME` 키 이후 앱을 시작한다.
+- 완료 화면 뒤로가기는 접근성 문구 `뒤로 가기`로 선택한다.
+
+위 항목은 테스트 flow와 접근성 문구 수정이다. 기능 크래시, 데이터 손상 또는 완료 화면 렌더링 회귀는 발견하지 못했다.
+
+## 저장 범위
+
+PR에는 HTML, JUnit과 이 요약만 포함한다. 실기기 알림 내용이 포함될 수 있는 원본 스크린샷, 기기 로그와 전체 명령 artifact는 커밋하지 않는다.
+
+## 남은 수동 검증
+
+- Android 실기기에서 마감일이 있는 실제 목표의 오전 9시 알림 수신 확인
+- iOS 실기기의 알림 예약·수신과 위젯 표시·갱신 확인

--- a/reports/maestro/2026-09-07/android-completion/report.html
+++ b/reports/maestro/2026-09-07/android-completion/report.html
@@ -1,0 +1,128 @@
+<html>
+  <head>
+    <title>Maestro Test Report</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body>
+    <div class="card mb-4">
+      <div class="card-body">
+        <h1 class="mt-5 text-center">Flow Execution Summary</h1>
+<br>Test Result: PASSED<br>Duration: 32.276s<br>Start Time: <time datetime="2026-09-07T13:20:51.206+09:00">Sep 7, 2026, 13:20:51 KST</time><br><br>
+        <div class="card-group mb-4">
+          <div class="card">
+            <div class="card-body">
+              <h5 class="card-title text-center">Total number of Flows</h5>
+              <h3 class="card-text text-center">1</h3>
+            </div>
+          </div>
+          <div class="card text-white bg-danger">
+            <div class="card-body">
+              <h5 class="card-title text-center">Failed Flows</h5>
+              <h3 class="card-text text-center">0</h3>
+            </div>
+          </div>
+          <div class="card text-white bg-success">
+            <div class="card-body">
+              <h5 class="card-title text-center">Successful Flows</h5>
+              <h3 class="card-text text-center">1</h3>
+            </div>
+          </div>
+        </div>
+        <div class="card mb-4">
+          <div class="card-header">
+            <h5 class="mb-0"><button class="btn btn-success" type="button" data-bs-toggle="collapse" data-bs-target="#flow-0-Android-completion-screen" aria-expanded="false" aria-controls="flow-0-Android-completion-screen">Android completion screen : SUCCESS</button></h5>
+          </div>
+          <div class="collapse" id="flow-0-Android-completion-screen">
+            <div class="card-body">
+              <p class="card-text">Status: SUCCESS<br>Duration: 32.261s<br>Start Time: <time datetime="2026-09-07T13:20:51.215+09:00">Sep 7, 2026, 13:20:51 KST</time><br>File Name: completion-screen<br></p>
+              <h6 class="mt-3 mb-3">Test Steps (22)</h6>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">1. Define variables</span></span><span class="badge bg-light text-dark">4ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">2. Apply configuration</span></span><span class="badge bg-light text-dark">0ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">3. Press Home key</span></span><span class="badge bg-light text-dark">1.9s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">4. Launch app &quot;com.nexters.bandalart.dev&quot;</span></span><span class="badge bg-light text-dark">2.7s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">5. Wait for animation to end</span></span><span class="badge bg-light text-dark">2.0s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>⏭️ <span class="step-name">6. Run flow when &quot;달성률 100%&quot; is visible</span></span><span class="badge bg-light text-dark">7.3s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">7. Stop com.nexters.bandalart.dev</span></span><span class="badge bg-light text-dark">70ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">8. Press Home key</span></span><span class="badge bg-light text-dark">1.2s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">9. Launch app &quot;com.nexters.bandalart.dev&quot;</span></span><span class="badge bg-light text-dark">2.5s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">10. Wait for animation to end</span></span><span class="badge bg-light text-dark">3.1s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">11. Assert that &quot;달성률 88%&quot; is visible</span></span><span class="badge bg-light text-dark">134ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">12. Assert that &quot;last task&quot; is visible</span></span><span class="badge bg-light text-dark">137ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">13. Long press on &quot;last task&quot;</span></span><span class="badge bg-light text-dark">4.8s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">14. Wait for animation to end</span></span><span class="badge bg-light text-dark">585ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">15. Assert that &quot;반다라트의 모든 목표를 달성했어요.\n정말 대단해요!&quot; is visible</span></span><span class="badge bg-light text-dark">93ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">16. Assert that &quot;달성 완료 반다라트&quot; is visible</span></span><span class="badge bg-light text-dark">86ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">17. Assert that &quot;완료 화면 테스트&quot; is visible</span></span><span class="badge bg-light text-dark">91ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">18. Assert that &quot;저장하기&quot; is visible</span></span><span class="badge bg-light text-dark">86ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">19. Assert that &quot;공유하기&quot; is visible</span></span><span class="badge bg-light text-dark">96ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">20. Tap on &quot;뒤로 가기&quot;</span></span><span class="badge bg-light text-dark">3.7s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">21. Wait for animation to end</span></span><span class="badge bg-light text-dark">595ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">22. Assert that &quot;완료 화면 테스트&quot; is visible</span></span><span class="badge bg-light text-dark">219ms</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <style>.step-item {
+    border-left: 3px solid #dee2e6;
+    padding-left: 12px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+}
+
+.step-header {
+    font-family: monospace;
+    font-size: 14px;
+}
+
+.step-name {
+    font-weight: 500;
+}
+</style>
+      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js"></script>
+    </div>
+  </body>
+</html>

--- a/reports/maestro/2026-09-07/android-completion/report.xml
+++ b/reports/maestro/2026-09-07/android-completion/report.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<testsuites>
+  <testsuite name="Test Suite" device="R3CY70P3F4H" tests="1" failures="0" time="35.621" timestamp="2026-09-07T13:21:48">
+    <testcase id="Android completion screen" name="Android completion screen" classname="Android completion screen" file=".maestro/android/completion-screen.yaml" time="35.607" timestamp="2026-09-07T13:21:48" status="SUCCESS"/>
+  </testsuite>
+</testsuites>

--- a/reports/maestro/2026-09-07/android-notification-settings/report.html
+++ b/reports/maestro/2026-09-07/android-notification-settings/report.html
@@ -1,0 +1,140 @@
+<html>
+  <head>
+    <title>Maestro Test Report</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body>
+    <div class="card mb-4">
+      <div class="card-body">
+        <h1 class="mt-5 text-center">Flow Execution Summary</h1>
+<br>Test Result: PASSED<br>Duration: 42.721s<br>Start Time: <time datetime="2026-09-07T13:32:39.209+09:00">Sep 7, 2026, 13:32:39 KST</time><br><br>
+        <div class="card-group mb-4">
+          <div class="card">
+            <div class="card-body">
+              <h5 class="card-title text-center">Total number of Flows</h5>
+              <h3 class="card-text text-center">1</h3>
+            </div>
+          </div>
+          <div class="card text-white bg-danger">
+            <div class="card-body">
+              <h5 class="card-title text-center">Failed Flows</h5>
+              <h3 class="card-text text-center">0</h3>
+            </div>
+          </div>
+          <div class="card text-white bg-success">
+            <div class="card-body">
+              <h5 class="card-title text-center">Successful Flows</h5>
+              <h3 class="card-text text-center">1</h3>
+            </div>
+          </div>
+        </div>
+        <div class="card mb-4">
+          <div class="card-header">
+            <h5 class="mb-0"><button class="btn btn-success" type="button" data-bs-toggle="collapse" data-bs-target="#flow-0-Android-deadline-reminder-settings" aria-expanded="false" aria-controls="flow-0-Android-deadline-reminder-settings">Android deadline reminder settings : SUCCESS</button></h5>
+          </div>
+          <div class="collapse" id="flow-0-Android-deadline-reminder-settings">
+            <div class="card-body">
+              <p class="card-text">Status: SUCCESS<br>Duration: 42.705s<br>Start Time: <time datetime="2026-09-07T13:32:39.218+09:00">Sep 7, 2026, 13:32:39 KST</time><br>File Name: notification-settings<br></p>
+              <h6 class="mt-3 mb-3">Test Steps (26)</h6>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">1. Define variables</span></span><span class="badge bg-light text-dark">2ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">2. Apply configuration</span></span><span class="badge bg-light text-dark">0ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">3. Press Home key</span></span><span class="badge bg-light text-dark">1.6s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">4. Launch app &quot;com.nexters.bandalart.dev&quot;</span></span><span class="badge bg-light text-dark">2.5s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">5. Wait for animation to end</span></span><span class="badge bg-light text-dark">2.0s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">6. Tap on &quot;설정 아이콘&quot;</span></span><span class="badge bg-light text-dark">4.4s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">7. Wait for animation to end</span></span><span class="badge bg-light text-dark">584ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">8. Assert that &quot;마감일 알림&quot; is visible</span></span><span class="badge bg-light text-dark">112ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">9. Tap on &quot;마감일 알림&quot;</span></span><span class="badge bg-light text-dark">3.0s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">10. Assert that &quot;마감일 알림을 켤까요?&quot; is visible</span></span><span class="badge bg-light text-dark">69ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">11. Assert that &quot;알림 켜기&quot; is visible</span></span><span class="badge bg-light text-dark">67ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">12. Tap on &quot;알림 켜기&quot;</span></span><span class="badge bg-light text-dark">2.0s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">13. Wait for animation to end</span></span><span class="badge bg-light text-dark">575ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">14. Tap on &quot;시트 닫기&quot;</span></span><span class="badge bg-light text-dark">2.9s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">15. Stop com.nexters.bandalart.dev</span></span><span class="badge bg-light text-dark">91ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">16. Launch app &quot;com.nexters.bandalart.dev&quot;</span></span><span class="badge bg-light text-dark">2.5s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">17. Wait for animation to end</span></span><span class="badge bg-light text-dark">1.3s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">18. Tap on &quot;설정 아이콘&quot;</span></span><span class="badge bg-light text-dark">4.5s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">19. Wait for animation to end</span></span><span class="badge bg-light text-dark">600ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">20. Tap on &quot;마감일 알림&quot;</span></span><span class="badge bg-light text-dark">2.2s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">21. Assert that &quot;마감일 알림을 켤까요?&quot; is not visible</span></span><span class="badge bg-light text-dark">640ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">22. Tap on &quot;마감일 알림&quot;</span></span><span class="badge bg-light text-dark">3.1s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">23. Assert that &quot;마감일 알림을 켤까요?&quot; is visible</span></span><span class="badge bg-light text-dark">101ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">24. Tap on &quot;취소&quot;</span></span><span class="badge bg-light text-dark">2.2s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">25. Tap on &quot;시트 닫기&quot;</span></span><span class="badge bg-light text-dark">4.6s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">26. Assert that &quot;완료 화면 테스트&quot; is visible</span></span><span class="badge bg-light text-dark">69ms</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <style>.step-item {
+    border-left: 3px solid #dee2e6;
+    padding-left: 12px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+}
+
+.step-header {
+    font-family: monospace;
+    font-size: 14px;
+}
+
+.step-name {
+    font-weight: 500;
+}
+</style>
+      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js"></script>
+    </div>
+  </body>
+</html>

--- a/reports/maestro/2026-09-07/ios-completion/report.html
+++ b/reports/maestro/2026-09-07/ios-completion/report.html
@@ -1,0 +1,92 @@
+<html>
+  <head>
+    <title>Maestro Test Report</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  </head>
+  <body>
+    <div class="card mb-4">
+      <div class="card-body">
+        <h1 class="mt-5 text-center">Flow Execution Summary</h1>
+<br>Test Result: PASSED<br>Duration: 7.578s<br>Start Time: <time datetime="2026-09-07T13:26:33.937+09:00">Sep 7, 2026, 13:26:33 KST</time><br><br>
+        <div class="card-group mb-4">
+          <div class="card">
+            <div class="card-body">
+              <h5 class="card-title text-center">Total number of Flows</h5>
+              <h3 class="card-text text-center">1</h3>
+            </div>
+          </div>
+          <div class="card text-white bg-danger">
+            <div class="card-body">
+              <h5 class="card-title text-center">Failed Flows</h5>
+              <h3 class="card-text text-center">0</h3>
+            </div>
+          </div>
+          <div class="card text-white bg-success">
+            <div class="card-body">
+              <h5 class="card-title text-center">Successful Flows</h5>
+              <h3 class="card-text text-center">1</h3>
+            </div>
+          </div>
+        </div>
+        <div class="card mb-4">
+          <div class="card-header">
+            <h5 class="mb-0"><button class="btn btn-success" type="button" data-bs-toggle="collapse" data-bs-target="#flow-0-iOS-completion-screen-content" aria-expanded="false" aria-controls="flow-0-iOS-completion-screen-content">iOS completion screen content : SUCCESS</button></h5>
+          </div>
+          <div class="collapse" id="flow-0-iOS-completion-screen-content">
+            <div class="card-body">
+              <p class="card-text">Status: SUCCESS<br>Duration: 7.538s<br>Start Time: <time datetime="2026-09-07T13:26:33.956+09:00">Sep 7, 2026, 13:26:33 KST</time><br>File Name: completion-screen<br></p>
+              <h6 class="mt-3 mb-3">Test Steps (10)</h6>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">1. Define variables</span></span><span class="badge bg-light text-dark">3ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">2. Apply configuration</span></span><span class="badge bg-light text-dark">0ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">3. Assert that &quot;반다라트의 모든 목표를 달성했어요.\n정말 대단해요!&quot; is visible</span></span><span class="badge bg-light text-dark">371ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">4. Assert that &quot;달성 완료 반다라트&quot; is visible</span></span><span class="badge bg-light text-dark">173ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">5. Assert that &quot;완료 화면 테스트&quot; is visible</span></span><span class="badge bg-light text-dark">155ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">6. Assert that &quot;저장하기&quot; is visible</span></span><span class="badge bg-light text-dark">154ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">7. Assert that &quot;공유하기&quot; is visible</span></span><span class="badge bg-light text-dark">168ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">8. Tap on &quot;뒤로 가기&quot;</span></span><span class="badge bg-light text-dark">5.1s</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">9. Wait for animation to end</span></span><span class="badge bg-light text-dark">546ms</span></div>
+              </div>
+              <div class="step-item mb-2">
+                <div class="step-header d-flex justify-content-between align-items-center"><span>✅ <span class="step-name">10. Assert that &quot;완료 화면 테스트&quot; is visible</span></span><span class="badge bg-light text-dark">229ms</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <style>.step-item {
+    border-left: 3px solid #dee2e6;
+    padding-left: 12px;
+    padding-top: 8px;
+    padding-bottom: 8px;
+}
+
+.step-header {
+    font-family: monospace;
+    font-size: 14px;
+}
+
+.step-name {
+    font-weight: 500;
+}
+</style>
+      <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js"></script>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- 관련 이슈 없음

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->

- Android 실기기용 완료 화면·알림 설정 Maestro 회귀 flow를 추가했습니다.
- iOS Simulator 완료 화면 검증 flow와 플랫폼별 자동화 제한을 문서화했습니다.
- 완료 화면 뒤로가기 아이콘의 접근성 문구를 올바른 `뒤로 가기` 리소스로 수정했습니다.
- 실행 결과를 [`reports/maestro/2026-09-07`](https://github.com/Nexters/BandalArt-KMP/tree/docs/maestro-ui-test-guide/reports/maestro/2026-09-07)에 보관했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- Android 완료 화면: Samsung SM-S936N 실기기, HTML/JUnit 반복 성공
- Android 알림 설정: Samsung SM-S936N 실기기, 설정 유지·복원 성공
- Android 위젯: One UI 2×2 위젯에서 cold-start 10회와 active-session 6회 전환 모두 성공, stale 0/16
- iOS 완료 화면: iPhone 17 Pro Simulator(iOS 26.2), 화면 진입 후 자동 검증 성공
- Gradle: 6개 task, 총 53 suites / 213 tests, 실패·오류·건너뜀 0

상세 결과: [Maestro QA 요약](https://github.com/Nexters/BandalArt-KMP/blob/docs/maestro-ui-test-guide/reports/maestro/2026-09-07/README.md)

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

| 기능 | 미리보기 | 기능 | 미리보기 |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| Android 완료 화면 | [HTML 보고서](https://github.com/Nexters/BandalArt-KMP/blob/docs/maestro-ui-test-guide/reports/maestro/2026-09-07/android-completion/report.html) | iOS 완료 화면 | [HTML 보고서](https://github.com/Nexters/BandalArt-KMP/blob/docs/maestro-ui-test-guide/reports/maestro/2026-09-07/ios-completion/report.html) |
| Android 알림 설정 | [HTML 보고서](https://github.com/Nexters/BandalArt-KMP/blob/docs/maestro-ui-test-guide/reports/maestro/2026-09-07/android-notification-settings/report.html) | Android 완료 화면 JUnit | [XML 보고서](https://github.com/Nexters/BandalArt-KMP/blob/docs/maestro-ui-test-guide/reports/maestro/2026-09-07/android-completion/report.xml) |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->

- iOS의 Compose `combinedClickable` long press는 Maestro가 일반 탭으로 처리해 완료 화면 진입만 수동으로 수행했습니다. 진입 후 검증은 자동입니다.
- 위젯의 `이름 없는 목표` 표시는 이전 값이 아니라 메인 목표가 비어 있는 반다라트의 정상 fallback이며, 각 회차에서 DataStore 최근 ID와 OCR 제목이 일치했습니다.
- Android 오전 9시 실제 예약 알림 수신과 iOS 실기기 알림·위젯 검증은 수동 검증 항목으로 남겼습니다.
- 이번 QA에서는 긴급 패치가 필요한 기능 오류를 발견하지 않았습니다. 접근성 문구 수정은 다음 일반 배포에 포함하면 됩니다.
