### PR TITLE
fix: 종료 팝업 광고 지연 렌더링 방지

### DIFF
--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidExitDialogHost.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidExitDialogHost.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
 import com.nexters.bandalart.R
 import com.nexters.bandalart.ads.nativead.NativeAdBodyView
 import com.nexters.bandalart.ads.nativead.NativeAdCallToActionView
@@ -64,6 +65,7 @@ class AndroidExitDialogHost(
         val activity = LocalActivity.current ?: return
         var showDialog by remember { mutableStateOf(false) }
         var hasEnteredHome by remember { mutableStateOf(false) }
+        val adSession = remember { ExitDialogAdSession<NativeAd>() }
 
         LaunchedEffect(enabled) {
             if (enabled) {
@@ -82,6 +84,7 @@ class AndroidExitDialogHost(
 
         BackHandler(enabled = enabled) {
             adPreloader.loadIfNeeded()
+            adSession.open(adPreloader.ad)
             showDialog = true
         }
 
@@ -95,11 +98,12 @@ class AndroidExitDialogHost(
                 cancelLabel = activity.getString(R.string.exit_dialog_cancel),
                 onConfirmClick = activity::finish,
                 onCancelClick = {
+                    val shouldRecycle = adSession.closeAndShouldRecycle()
                     showDialog = false
-                    if (adPreloader.ad != null) adPreloader.recycle()
+                    if (shouldRecycle) adPreloader.recycle()
                 },
                 content =
-                    adPreloader.ad?.let { nativeAd ->
+                    adSession.ad?.let { nativeAd ->
                         {
                             NativeAdViewContainer(
                                 nativeAd = nativeAd,

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/ExitDialogAdSession.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/ExitDialogAdSession.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.ads
+
+internal class ExitDialogAdSession<T> {
+    var ad: T? = null
+        private set
+
+    fun open(availableAd: T?) {
+        ad = availableAd
+    }
+
+    fun closeAndShouldRecycle(): Boolean {
+        val shouldRecycle = ad != null
+        ad = null
+        return shouldRecycle
+    }
+}

--- a/androidApp/src/test/kotlin/com/nexters/bandalart/ads/ExitDialogAdSessionTest.kt
+++ b/androidApp/src/test/kotlin/com/nexters/bandalart/ads/ExitDialogAdSessionTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.ads
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ExitDialogAdSessionTest {
+    @Test
+    fun adLoadedWhileDialogIsOpenIsDeferredUntilNextDialog() {
+        val session = ExitDialogAdSession<String>()
+        var availableAd: String? = null
+
+        session.open(availableAd)
+        availableAd = "next ad"
+        assertNull(session.ad)
+
+        session.closeAndShouldRecycle()
+        session.open(availableAd)
+        assertEquals("next ad", session.ad)
+    }
+
+    @Test
+    fun onlyDisplayedAdIsRecycledWhenDialogCloses() {
+        val session = ExitDialogAdSession<String>()
+
+        session.open(availableAd = null)
+        assertFalse(session.closeAndShouldRecycle())
+
+        session.open(availableAd = "displayed ad")
+        assertTrue(session.closeAndShouldRecycle())
+        assertNull(session.ad)
+    }
+}


### PR DESCRIPTION
<!--
✅ PR 제목 작성 가이드
형식: <라벨>: <작업 요약>
예: feat: 로그인 페이지 구현, fix: 버튼 클릭 버그 수정
-->

## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #384

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 백버튼을 누른 시점의 네이티브 광고를 종료 팝업 세션에 고정합니다.
- 광고 없이 열린 팝업은 로드가 완료되어도 중간에 확장되지 않도록 수정합니다.
- 실제 광고를 표시한 경우에만 닫을 때 해당 광고를 recycle하고 다음 광고를 준비합니다.
- Android 앱 모듈만 변경하며 iOS 동작은 변경하지 않습니다.

## 🧪 테스트 내역 (선택)

- [x] Android 단위 테스트 41/41 통과
- [x] `:androidApp:spotlessCheck` 통과
- [x] `:androidApp:detekt` 통과
- [x] 광고 지연 로드 및 표시 여부별 recycle 회귀 테스트 추가

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

| 기능 | 미리보기 | 기능 | 미리보기 |
|:---:|:---:|:---:|:---:|
| 수정 전 지연 렌더링 | 사용자 제공 녹화로 재현 | 수정 후 | 내부 테스트에서 확인 예정 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 팝업이 열린 상태에서 `adPreloader.ad`를 직접 관찰하던 것이 레이아웃 변경의 원인이었습니다.
- 미디어 이미지 자체의 비동기 표시는 고정된 광고 영역 안에서 발생할 수 있지만 팝업 전체 높이는 변경되지 않습니다.