### PR TITLE
fix: 네이티브 광고 미디어 등록 시점 수정

### DIFF
--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/NativeAdViewContainer.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/NativeAdViewContainer.kt
@@ -105,8 +105,26 @@ internal fun NativeAdViewContainer(
     )
 
     val currentNativeAd by rememberUpdatedState(nativeAd)
+    val currentNativeAdView = nativeAdViewRef.value
+    val currentMediaView = mediaView
     SideEffect {
-        nativeAdViewRef.value?.registerNativeAd(currentNativeAd, mediaView)
+        registerNativeAdWhenReady(
+            nativeAdView = currentNativeAdView,
+            nativeAd = currentNativeAd,
+            mediaView = currentMediaView,
+            register = NativeAdView::registerNativeAd,
+        )
+    }
+}
+
+internal inline fun <AdView, Ad, Media> registerNativeAdWhenReady(
+    nativeAdView: AdView?,
+    nativeAd: Ad,
+    mediaView: Media?,
+    register: (AdView, Ad, Media) -> Unit,
+) {
+    if (nativeAdView != null && mediaView != null) {
+        register(nativeAdView, nativeAd, mediaView)
     }
 }
 

--- a/androidApp/src/test/kotlin/com/nexters/bandalart/ads/nativead/NativeAdRegistrationTest.kt
+++ b/androidApp/src/test/kotlin/com/nexters/bandalart/ads/nativead/NativeAdRegistrationTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 easyhooon
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nexters.bandalart.ads.nativead
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class NativeAdRegistrationTest {
+    @Test
+    fun nativeAdIsRegisteredOnlyAfterItsMediaViewIsReady() {
+        val registrations = mutableListOf<Triple<String, String, String>>()
+
+        registerNativeAdWhenReady(
+            nativeAdView = "ad-view",
+            nativeAd = "ad",
+            mediaView = null,
+            register = { adView, ad, media -> registrations += Triple(adView, ad, media) },
+        )
+        registerNativeAdWhenReady(
+            nativeAdView = "ad-view",
+            nativeAd = "ad",
+            mediaView = "media-view",
+            register = { adView, ad, media -> registrations += Triple(adView, ad, media) },
+        )
+
+        assertEquals(
+            listOf(Triple("ad-view", "ad", "media-view")),
+            registrations,
+        )
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->

- Close #387

## 📙 작업 설명

<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- NativeAdView와 MediaView가 모두 준비된 뒤 네이티브 광고를 등록하도록 수정했습니다.
- MediaView 준비 전에는 광고 등록을 보류하는 회귀 테스트를 추가했습니다.

## 🧪 테스트 내역 (선택)

- [x] 주요 기능 정상 동작 확인
- [x] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

- `./gradlew :androidApp:testDebugUnitTest` — 42/42 통과
- `:androidApp:spotlessCheck`, `detekt` 통과
- 전체 `spotlessCheck`는 origin/main의 기존 `core/common/.../ObserveEvent.kt` 포맷 위반으로 실패

## 📸 스크린샷 또는 시연 영상 (선택)

<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->

|  기능   |             미리보기             |  기능   |             미리보기             |
|:-----:|:----------------------------:|:-----:|:----------------------------:|
| 변경 전 | MediaView 회색 빈 영역 재현 | 변경 후 | MediaView 준비 후 광고 등록 |

## 💬 추가 설명 or 리뷰 포인트 (선택)

<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- YeoBee Android의 동일 Compose 상태 추적 패턴을 참고했습니다.
- 광고가 늦게 도착한 경우 현재 팝업에 삽입하지 않는 기존 정책은 유지합니다.