### PR TITLE
fix: 종료 다이얼로그 광고 교체 주기 정리

### DIFF
--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidExitDialogHost.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/AndroidExitDialogHost.kt
@@ -64,27 +64,27 @@ class AndroidExitDialogHost(
     override fun Content(enabled: Boolean) {
         val activity = LocalActivity.current ?: return
         var showDialog by remember { mutableStateOf(false) }
-        var hasEnteredHome by remember { mutableStateOf(false) }
         val adSession = remember { ExitDialogAdSession<NativeAd>() }
-
-        LaunchedEffect(enabled) {
-            if (enabled) {
-                hasEnteredHome = true
-            } else {
-                showDialog = false
-            }
-        }
 
         val adPreloader =
             rememberNativeAdPreloader(
                 adUnitId = activity.getString(R.string.admob_exit_dialog_native_ad_unit_id),
                 awaitAdsInitialized = awaitAdsInitialized,
-                preload = hasEnteredHome,
+                preload = enabled,
             )
+
+        LaunchedEffect(enabled, adPreloader) {
+            if (!enabled) {
+                val wasAdDisplayed = adSession.closeAndWasAdDisplayed()
+                showDialog = false
+                adPreloader.disableLoading()
+                if (wasAdDisplayed) adPreloader.discard()
+            }
+        }
 
         BackHandler(enabled = enabled) {
             adPreloader.loadIfNeeded()
-            adSession.open(adPreloader.ad)
+            adSession.open(adPreloader.adSnapshotForDisplay())
             showDialog = true
         }
 
@@ -98,9 +98,9 @@ class AndroidExitDialogHost(
                 cancelLabel = activity.getString(R.string.exit_dialog_cancel),
                 onConfirmClick = activity::finish,
                 onCancelClick = {
-                    val shouldRecycle = adSession.closeAndShouldRecycle()
+                    val wasAdDisplayed = adSession.closeAndWasAdDisplayed()
                     showDialog = false
-                    if (shouldRecycle) adPreloader.recycle()
+                    if (wasAdDisplayed) adPreloader.recycleIfEligible()
                 },
                 content =
                     adSession.ad?.let { nativeAd ->

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/ExitDialogAdSession.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/ExitDialogAdSession.kt
@@ -24,9 +24,9 @@ internal class ExitDialogAdSession<T> {
         ad = availableAd
     }
 
-    fun closeAndShouldRecycle(): Boolean {
-        val shouldRecycle = ad != null
+    fun closeAndWasAdDisplayed(): Boolean {
+        val wasAdDisplayed = ad != null
         ad = null
-        return shouldRecycle
+        return wasAdDisplayed
     }
 }

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/NativeAdPreloader.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/NativeAdPreloader.kt
@@ -27,14 +27,20 @@ internal class NativeAdPreloader(
     private val requestAd: (NativeAdLoaderCallback) -> Unit,
     private val dispatchCallback: (() -> Unit) -> Unit,
     private val onAdFailedToLoad: (LoadAdError) -> Unit,
+    private val elapsedRealtime: () -> Long,
+    private val minimumRequestIntervalMillis: Long,
+    private val debugLog: (String) -> Unit = {},
 ) {
     private var destroyed = false
     private var loadingEnabled = false
     private var loading = false
     private var generation = 0L
+    private var lastRequestAtMillis: Long? = null
 
     val ad: NativeAd?
         get() = state.ad
+
+    fun adSnapshotForDisplay(): NativeAd? = state.ad?.also { debugLog("display instance=${it.identity()}") }
 
     fun enableLoading() {
         if (destroyed) return
@@ -44,11 +50,20 @@ internal class NativeAdPreloader(
 
     fun loadIfNeeded() {
         if (destroyed || !loadingEnabled || loading) return
-        if (state.isExpired()) state.clear()
+        if (state.isExpired()) {
+            state.ad?.let { debugLog("expire instance=${it.identity()}") }
+            state.clear()
+        }
         if (state.ad != null) return
+
+        val now = elapsedRealtime()
+        val lastRequestAt = lastRequestAtMillis
+        if (lastRequestAt != null && now - lastRequestAt < minimumRequestIntervalMillis) return
 
         loading = true
         val requestGeneration = ++generation
+        lastRequestAtMillis = now
+        debugLog("request generation=$requestGeneration")
         requestAd(
             object : NativeAdLoaderCallback {
                 private var completed = false
@@ -59,12 +74,16 @@ internal class NativeAdPreloader(
                         if (returnedAd === nativeAd) return@dispatchCallback
                         returnedAd = nativeAd
                         if (completed || destroyed || requestGeneration != generation) {
+                            debugLog(
+                                "discard late generation=$requestGeneration instance=${nativeAd.identity()}",
+                            )
                             nativeAd.destroy()
                             return@dispatchCallback
                         }
                         completed = true
                         loading = false
                         state.store(nativeAd)
+                        debugLog("loaded generation=$requestGeneration instance=${nativeAd.identity()}")
                     }
                 }
 
@@ -73,6 +92,7 @@ internal class NativeAdPreloader(
                         if (completed || destroyed || requestGeneration != generation) return@dispatchCallback
                         completed = true
                         loading = false
+                        debugLog("failed generation=$requestGeneration")
                         onAdFailedToLoad(adError)
                     }
                 }
@@ -80,16 +100,37 @@ internal class NativeAdPreloader(
         )
     }
 
-    fun recycle() {
+    fun disableLoading() {
         if (destroyed) return
+        loadingEnabled = false
+    }
+
+    fun recycleIfEligible() {
+        val nativeAd = state.ad ?: return
+        val lastRequestAt = lastRequestAtMillis ?: return
+        val requestAgeMillis = (elapsedRealtime() - lastRequestAt).coerceAtLeast(0)
+        if (destroyed || requestAgeMillis < minimumRequestIntervalMillis) {
+            debugLog("retain ageMs=$requestAgeMillis instance=${nativeAd.identity()}")
+            return
+        }
+        debugLog("recycle ageMs=$requestAgeMillis instance=${nativeAd.identity()}")
         state.clear()
         loadIfNeeded()
+    }
+
+    fun discard() {
+        if (destroyed) return
+        state.ad?.let { debugLog("discard instance=${it.identity()}") }
+        state.clear()
     }
 
     fun destroy() {
         if (destroyed) return
         destroyed = true
         generation++
+        state.ad?.let { debugLog("destroy instance=${it.identity()}") }
         state.clear()
     }
+
+    private fun NativeAd.identity(): Int = System.identityHashCode(this)
 }

--- a/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/RememberNativeAdPreloader.kt
+++ b/androidApp/src/main/kotlin/com/nexters/bandalart/ads/nativead/RememberNativeAdPreloader.kt
@@ -37,6 +37,7 @@ import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
 import com.nexters.bandalart.ads.nonPersonalizedAdExtras
 import io.github.aakira.napier.Napier
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
 
 @Composable
 internal fun rememberNativeAdPreloader(
@@ -44,11 +45,12 @@ internal fun rememberNativeAdPreloader(
     awaitAdsInitialized: suspend () -> Boolean,
     preload: Boolean,
 ): NativeAdPreloader {
+    val elapsedRealtime = SystemClock::elapsedRealtime
     val state =
         remember(adUnitId) {
             NativeAdState(
                 ttlMillis = 1.hours.inWholeMilliseconds,
-                elapsedRealtime = SystemClock::elapsedRealtime,
+                elapsedRealtime = elapsedRealtime,
             )
         }
     val previewPreloader =
@@ -58,6 +60,8 @@ internal fun rememberNativeAdPreloader(
                 requestAd = {},
                 dispatchCallback = {},
                 onAdFailedToLoad = {},
+                elapsedRealtime = elapsedRealtime,
+                minimumRequestIntervalMillis = 60.seconds.inWholeMilliseconds,
             )
         }
     if (LocalInspectionMode.current) return previewPreloader
@@ -91,8 +95,15 @@ internal fun rememberNativeAdPreloader(
                         tag = "NativeAd",
                     )
                 },
+                elapsedRealtime = elapsedRealtime,
+                minimumRequestIntervalMillis = 60.seconds.inWholeMilliseconds,
+                debugLog = { message -> Napier.d(message, tag = "NativeAd") },
             )
         }
+
+    LaunchedEffect(preloader, preload) {
+        if (!preload) preloader.disableLoading()
+    }
 
     LifecycleResumeEffect(preloader, preload, isAdsInitialized) {
         if (isAdsInitialized && preload) preloader.enableLoading()

--- a/androidApp/src/test/kotlin/com/nexters/bandalart/ads/ExitDialogAdSessionTest.kt
+++ b/androidApp/src/test/kotlin/com/nexters/bandalart/ads/ExitDialogAdSessionTest.kt
@@ -32,7 +32,7 @@ class ExitDialogAdSessionTest {
         availableAd = "next ad"
         assertNull(session.ad)
 
-        session.closeAndShouldRecycle()
+        session.closeAndWasAdDisplayed()
         session.open(availableAd)
         assertEquals("next ad", session.ad)
     }
@@ -42,10 +42,10 @@ class ExitDialogAdSessionTest {
         val session = ExitDialogAdSession<String>()
 
         session.open(availableAd = null)
-        assertFalse(session.closeAndShouldRecycle())
+        assertFalse(session.closeAndWasAdDisplayed())
 
         session.open(availableAd = "displayed ad")
-        assertTrue(session.closeAndShouldRecycle())
+        assertTrue(session.closeAndWasAdDisplayed())
         assertNull(session.ad)
     }
 }

--- a/androidApp/src/test/kotlin/com/nexters/bandalart/ads/nativead/NativeAdPreloaderTest.kt
+++ b/androidApp/src/test/kotlin/com/nexters/bandalart/ads/nativead/NativeAdPreloaderTest.kt
@@ -38,6 +38,8 @@ class NativeAdPreloaderTest {
                 requestAd = requests::add,
                 dispatchCallback = dispatch,
                 onAdFailedToLoad = {},
+                elapsedRealtime = { elapsedRealtime },
+                minimumRequestIntervalMillis = 60_000L,
             )
 
         fun succeed(ad: NativeAd = mockk(relaxed = true)): NativeAd {
@@ -60,15 +62,73 @@ class NativeAdPreloaderTest {
     }
 
     @Test
-    fun recyclingDisplayedAdDestroysItAndPreloadsTheNextOne() {
+    fun displayedAdIsKeptUntilMinimumRefreshInterval() {
+        val fixture = Fixture()
+        fixture.preloader.enableLoading()
+        val ad = fixture.succeed()
+        fixture.elapsedRealtime = 59_999L
+
+        fixture.preloader.recycleIfEligible()
+
+        verify(exactly = 0) { ad.destroy() }
+        assertSame(ad, fixture.preloader.ad)
+        assertEquals(1, fixture.requests.size)
+    }
+
+    @Test
+    fun displayedAdIsRecycledAfterMinimumRefreshInterval() {
+        val fixture = Fixture()
+        fixture.preloader.enableLoading()
+        val ad = fixture.succeed()
+        fixture.elapsedRealtime = 60_000L
+
+        fixture.preloader.recycleIfEligible()
+
+        verify(exactly = 1) { ad.destroy() }
+        assertNull(fixture.preloader.ad)
+        assertEquals(2, fixture.requests.size)
+    }
+
+    @Test
+    fun failedRequestIsNotRetriedBeforeMinimumRefreshInterval() {
+        val fixture = Fixture()
+        fixture.preloader.enableLoading()
+        fixture.requests.single().onAdFailedToLoad(mockk(relaxed = true))
+
+        fixture.elapsedRealtime = 59_999L
+        fixture.preloader.loadIfNeeded()
+        assertEquals(1, fixture.requests.size)
+
+        fixture.elapsedRealtime = 60_000L
+        fixture.preloader.loadIfNeeded()
+        assertEquals(2, fixture.requests.size)
+    }
+
+    @Test
+    fun discardDestroysAdWithoutPreloadingOffScreen() {
         val fixture = Fixture()
         fixture.preloader.enableLoading()
         val ad = fixture.succeed()
 
-        fixture.preloader.recycle()
+        fixture.preloader.discard()
 
         verify(exactly = 1) { ad.destroy() }
         assertNull(fixture.preloader.ad)
+        assertEquals(1, fixture.requests.size)
+    }
+
+    @Test
+    fun disabledLoadingWaitsForTheNextEnableBeforeRequesting() {
+        val fixture = Fixture()
+        fixture.preloader.enableLoading()
+        fixture.requests.single().onAdFailedToLoad(mockk(relaxed = true))
+        fixture.elapsedRealtime = 60_000L
+
+        fixture.preloader.disableLoading()
+        fixture.preloader.loadIfNeeded()
+        assertEquals(1, fixture.requests.size)
+
+        fixture.preloader.enableLoading()
         assertEquals(2, fixture.requests.size)
     }
 


### PR DESCRIPTION
<!-- PR 제목은 변경 내용을 명확하게 요약해주세요 -->
<!-- 예: `feat: 사용자 인증 기능 추가` -->

## 🔗 관련 이슈

<!-- 관련 이슈 번호를 작성해주세요 -->
<!-- 예: Close #123, Fix #456 -->

- Close #390

## 📝 작업 내용

<!-- 주요 변경 사항을 작성해주세요 -->

- 네이티브 광고 요청 간 최소 60초 간격 적용
- 60초 전 표시 광고 유지, 이후 닫을 때 교체 요청
- Home 이탈 시 표시 세션 정리 및 화면 밖 신규 요청 차단
- 요청 세대와 `NativeAd` 객체 identity 진단 로그 추가

## 🧪 테스트

<!-- 테스트 방법과 결과를 작성해주세요 -->

- [ ] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기별 테스트 완료
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음 확인

### 검증 결과

- `./gradlew :androidApp:testDebugUnitTest`: 46개 통과
- `./gradlew :androidApp:spotlessKotlinCheck :androidApp:spotlessKotlinGradleCheck`: 통과
- 루트 `spotlessCheck`: 기존 `core/common/.../ObserveEvent.kt` 포맷 위반

## 📸 스크린샷

<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->

| Before | After |
|--------|-------|
| 해당 없음 | 해당 없음 |

## 📋 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

- Remote Config와 반복 갱신 타이머 미도입
- Android 전용 변경, iOS 변경 없음
